### PR TITLE
BGImageProcessor : fixes drawing problem

### DIFF
--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -1,11 +1,12 @@
 package bms.player.beatoraja.play.bga;
 
-import bms.model.TimeLine;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
-
 import java.util.Arrays;
 import java.util.logging.Logger;
+
+import bms.model.TimeLine;
+
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
 
 /**
  * BGIリソース管理用クラス
@@ -42,16 +43,25 @@ public class BGImageProcessor {
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				Pixmap pix = bgamap[bga];
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+						bgamap[bga].getHeight() : bgamap[bga].getWidth();
+				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
+				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
+						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
 					count++;
 				}
 			}
+
 			bga = tl.getLayer();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				Pixmap pix = bgamap[bga];
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+						bgamap[bga].getHeight() : bgamap[bga].getWidth();
+				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
+				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
+						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -73,14 +83,13 @@ public class BGImageProcessor {
 		if (bgacache[cid] != null) {
 			bgacache[cid].dispose();
 		}
-		Pixmap pix = bgamap[id];
-		if (pix != null) {
-			bgacache[cid] = new Texture(pix);
-			bgacacheid[cid] = id;
-			return bgacache[cid];
-		}
-		return null;
-
+		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ? bgamap[id].getHeight() : bgamap[id].getWidth();
+		Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[id].getFormat());
+		pix.drawPixmap(bgamap[id], 0, 0,bgamap[id].getWidth(),bgamap[id].getHeight(),
+				0,0,bgamap[id].getWidth(),bgamap[id].getHeight());
+		bgacache[cid] = new Texture(pix);
+		bgacacheid[cid] = id;
+		return bgacache[cid];
 	}
 
 	/**

--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -43,11 +43,17 @@ public class BGImageProcessor {
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ? 
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
-				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
-						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
+				Pixmap pix;
+				if ( bgasize <=256 ){
+					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
+				} else {
+					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+							bgamap[bga].getFormat());
+				}
+				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+						0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -59,9 +65,14 @@ public class BGImageProcessor {
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
 				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
-				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
-						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
+				Pixmap pix;
+				if ( bgasize <=256 ){
+					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
+				} else {
+					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(), bgamap[bga].getFormat());
+				}
+				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+						0, 0,bgamap[bga].getWidth(), bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -83,10 +94,16 @@ public class BGImageProcessor {
 		if (bgacache[cid] != null) {
 			bgacache[cid].dispose();
 		}
-		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ? bgamap[id].getHeight() : bgamap[id].getWidth();
-		Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[id].getFormat());
-		pix.drawPixmap(bgamap[id], 0, 0,bgamap[id].getWidth(),bgamap[id].getHeight(),
-				0,0,bgamap[id].getWidth(),bgamap[id].getHeight());
+		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ?
+				bgamap[id].getHeight() : bgamap[id].getWidth();
+		Pixmap pix;
+		if ( bgasize <=256 ){
+			pix = new Pixmap(bgasize, bgasize,bgamap[id].getFormat());
+		} else {
+			pix = new Pixmap(bgamap[id].getWidth(), bgamap[id].getHeight(), bgamap[id].getFormat());
+		}
+		pix.drawPixmap(bgamap[id], 0, 0, bgamap[id].getWidth(), bgamap[id].getHeight(),
+				0, 0, bgamap[id].getWidth(), bgamap[id].getHeight());
 		bgacache[cid] = new Texture(pix);
 		bgacacheid[cid] = id;
 		return bgacache[cid];


### PR DESCRIPTION
It enables legacy BGI correctly.(e.g. x-aria,その欺くも美しき紅に) 
The difference between the small image and the large image is the same specification as LR2.
Change the small image to the upper left justified square.