### PR TITLE
BGImageProcessor : fixes drawing problem (fixes #19) BGAProcessor : fixes aspect ratio

### DIFF
--- a/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -8,7 +8,8 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.logging.Logger;
 
 import javax.imageio.ImageIO;
@@ -16,8 +17,8 @@ import javax.imageio.ImageIO;
 import bms.model.BMSModel;
 import bms.model.TimeLine;
 import bms.player.beatoraja.Config;
-
 import bms.player.beatoraja.play.BMSPlayer;
+
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.files.FileHandleStream;
 import com.badlogic.gdx.graphics.Color;
@@ -31,7 +32,7 @@ import com.badlogic.gdx.math.Rectangle;
 
 /**
  * BGAのリソース管理、描画用クラス
- * 
+ *
  * @author exch
  */
 public class BGAProcessor {
@@ -146,14 +147,14 @@ public class BGAProcessor {
 		if (stage != null && stage.length() > 0) {
 			Path p = dpath.resolve(stage);
 			if(Files.exists(p)) {
-				stagefilep = this.loadPicture(p);				
+				stagefilep = this.loadPicture(p);
 			}
 		}
 		String back = model.getBackbmp();
 		if (back != null && back.length() > 0) {
 			Path p = dpath.resolve(back);
 			if(Files.exists(p)) {
-				backbmpp = this.loadPicture(p);				
+				backbmpp = this.loadPicture(p);
 			}
 		}
 
@@ -369,7 +370,7 @@ public class BGAProcessor {
 			// draw backbmp
 			sprite.begin();
 			if (getBackbmpData() != null) {
-				sprite.draw(getBackbmpData(), r.x, r.y, r.width, r.height);
+				drawBGAFixRatio(sprite, r, getBackbmpData().getTexture());
 			}
 			sprite.end();
 		} else if (misslayer != null && misslayertime != 0 && time >= misslayertime && time < misslayertime + 500) {
@@ -378,7 +379,7 @@ public class BGAProcessor {
 			if (miss != null) {
 				miss.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 				sprite.begin();
-				sprite.draw(miss, r.x, r.y, r.width, r.height);
+				drawBGAFixRatio(sprite, r, miss);
 				sprite.end();
 			}
 		} else {
@@ -390,10 +391,10 @@ public class BGAProcessor {
 				if (mpgmap.containsKey(playingbgaid)) {
 					final ShaderProgram shader = mpgmap.get(playingbgaid).getShader();
 					sprite.setShader(shader);
-					sprite.draw(playingbgatex, r.x, r.y, r.width, r.height);
+					drawBGAFixRatio(sprite, r, playingbgatex);
 					sprite.setShader(null);
 				} else {
-					sprite.draw(playingbgatex, r.x, r.y, r.width, r.height);
+					drawBGAFixRatio(sprite, r, playingbgatex);
 				}
 			} else {
 				sprite.draw(blanktex, r.x, r.y, r.width, r.height);
@@ -408,14 +409,14 @@ public class BGAProcessor {
 				if (mpgmap.containsKey(playinglayerid)) {
 					final ShaderProgram shader = mpgmap.get(playinglayerid).getShader();
 					sprite.setShader(shader);
-					sprite.draw(playinglayertex, r.x, r.y, r.width, r.height);
+					drawBGAFixRatio(sprite, r, playinglayertex);
 					sprite.setShader(null);
 				} else if (layershader.isCompiled()) {
 					sprite.setShader(layershader);
-					sprite.draw(playinglayertex, r.x, r.y, r.width, r.height);
+					drawBGAFixRatio(sprite, r, playinglayertex);
 					sprite.setShader(null);
 				} else {
-					sprite.draw(playinglayertex, r.x, r.y, r.width, r.height);
+					drawBGAFixRatio(sprite, r, playinglayertex);
 				}
 				sprite.end();
 			}
@@ -426,8 +427,31 @@ public class BGAProcessor {
 	}
 
 	/**
+	 * Modify the aspect ratio and draw BGA
+	 */
+	private void drawBGAFixRatio(SpriteBatch sprite, Rectangle r, Texture bga){
+		float fixx,fixy,fixheight,fixwidth;
+		float movieaspect = (float)bga.getWidth() / bga.getHeight();
+		float windowaspect = (float)r.width / r.height;
+		float scaleheight = (float)windowaspect / movieaspect;
+		float scalewidth  = (float)1.0f / scaleheight;
+        if(1.0f > scaleheight){
+        	fixx = r.x;
+            fixy = r.y+ (r.height * (1.0f - scaleheight)) / 2.0f;
+            fixheight = r.height * scaleheight;
+            fixwidth = r.width;
+        } else {
+            fixx = r.x+(r.width * (1.0f - scalewidth)) / 2.0f;
+            fixy = r.y;
+            fixheight = r.height;
+            fixwidth = r.width * scalewidth;
+        }
+        sprite.draw(bga, fixx, fixy, fixwidth, fixheight);
+	}
+
+	/**
 	 * ミスレイヤー開始時間を設定する
-	 * 
+	 *
 	 * @param time
 	 *            ミスレイヤー開始時間(ms)
 	 */
@@ -464,11 +488,11 @@ public class BGAProcessor {
 			}
 		}
 		mpgmap.clear();
-		
+
 		try {
 			layershader.dispose();
 		} catch(Throwable e) {
-			
+
 		}
 	}
 

--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -1,11 +1,12 @@
 package bms.player.beatoraja.play.bga;
 
-import bms.model.TimeLine;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
-
 import java.util.Arrays;
 import java.util.logging.Logger;
+
+import bms.model.TimeLine;
+
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
 
 /**
  * BGIリソース管理用クラス
@@ -42,16 +43,25 @@ public class BGImageProcessor {
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				Pixmap pix = bgamap[bga];
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+						bgamap[bga].getHeight() : bgamap[bga].getWidth();
+				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
+				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
+						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
 					count++;
 				}
 			}
+
 			bga = tl.getLayer();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				Pixmap pix = bgamap[bga];
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+						bgamap[bga].getHeight() : bgamap[bga].getWidth();
+				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
+				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
+						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -73,14 +83,13 @@ public class BGImageProcessor {
 		if (bgacache[cid] != null) {
 			bgacache[cid].dispose();
 		}
-		Pixmap pix = bgamap[id];
-		if (pix != null) {
-			bgacache[cid] = new Texture(pix);
-			bgacacheid[cid] = id;
-			return bgacache[cid];
-		}
-		return null;
-
+		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ? bgamap[id].getHeight() : bgamap[id].getWidth();
+		Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[id].getFormat());
+		pix.drawPixmap(bgamap[id], 0, 0,bgamap[id].getWidth(),bgamap[id].getHeight(),
+				0,0,bgamap[id].getWidth(),bgamap[id].getHeight());
+		bgacache[cid] = new Texture(pix);
+		bgacacheid[cid] = id;
+		return bgacache[cid];
 	}
 
 	/**

--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -42,8 +42,8 @@ public class BGImageProcessor {
 		int count = 0;
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ? 
+			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bgamap[bga] != null) {
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
 				Pixmap pix;
 				if ( bgasize <=256 ){
@@ -54,15 +54,13 @@ public class BGImageProcessor {
 				}
 				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
 						0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight());
-				if (pix != null) {
-					bgacache[bga % bgacache.length] = new Texture(pix);
-					bgacacheid[bga % bgacache.length] = bga;
-					count++;
-				}
+				bgacache[bga % bgacache.length] = new Texture(pix);
+				bgacacheid[bga % bgacache.length] = bga;
+				count++;
 			}
 
 			bga = tl.getLayer();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
+			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bgamap[bga] != null) {
 				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
 				Pixmap pix;
@@ -73,11 +71,9 @@ public class BGImageProcessor {
 				}
 				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
 						0, 0,bgamap[bga].getWidth(), bgamap[bga].getHeight());
-				if (pix != null) {
-					bgacache[bga % bgacache.length] = new Texture(pix);
-					bgacacheid[bga % bgacache.length] = bga;
-					count++;
-				}
+				bgacache[bga % bgacache.length] = new Texture(pix);
+				bgacacheid[bga % bgacache.length] = bga;
+				count++;
 			}
 		}
 		Logger.getGlobal().info(

--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -43,11 +43,17 @@ public class BGImageProcessor {
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
-				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
+				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ? 
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
-				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
-						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
+				Pixmap pix;
+				if ( bgasize <=256 ){
+					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
+				} else {
+					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+							bgamap[bga].getFormat());
+				}
+				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+						0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -59,9 +65,14 @@ public class BGImageProcessor {
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null) {
 				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
 						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[bga].getFormat());
-				pix.drawPixmap(bgamap[bga], 0, 0,bgamap[bga].getWidth(),bgamap[bga].getHeight(),
-						0,0,bgamap[bga].getWidth(),bgamap[bga].getHeight());
+				Pixmap pix;
+				if ( bgasize <=256 ){
+					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
+				} else {
+					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(), bgamap[bga].getFormat());
+				}
+				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
+						0, 0,bgamap[bga].getWidth(), bgamap[bga].getHeight());
 				if (pix != null) {
 					bgacache[bga % bgacache.length] = new Texture(pix);
 					bgacacheid[bga % bgacache.length] = bga;
@@ -83,10 +94,16 @@ public class BGImageProcessor {
 		if (bgacache[cid] != null) {
 			bgacache[cid].dispose();
 		}
-		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ? bgamap[id].getHeight() : bgamap[id].getWidth();
-		Pixmap pix = new Pixmap(bgasize,bgasize,bgamap[id].getFormat());
-		pix.drawPixmap(bgamap[id], 0, 0,bgamap[id].getWidth(),bgamap[id].getHeight(),
-				0,0,bgamap[id].getWidth(),bgamap[id].getHeight());
+		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ?
+				bgamap[id].getHeight() : bgamap[id].getWidth();
+		Pixmap pix;
+		if ( bgasize <=256 ){
+			pix = new Pixmap(bgasize, bgasize,bgamap[id].getFormat());
+		} else {
+			pix = new Pixmap(bgamap[id].getWidth(), bgamap[id].getHeight(), bgamap[id].getFormat());
+		}
+		pix.drawPixmap(bgamap[id], 0, 0, bgamap[id].getWidth(), bgamap[id].getHeight(),
+				0, 0, bgamap[id].getWidth(), bgamap[id].getHeight());
 		bgacache[cid] = new Texture(pix);
 		bgacacheid[cid] = id;
 		return bgacache[cid];

--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -43,35 +43,14 @@ public class BGImageProcessor {
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bgamap[bga] != null) {
-				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
-						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix;
-				if ( bgasize <=256 ){
-					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
-				} else {
-					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(),
-							bgamap[bga].getFormat());
-				}
-				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
-						0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight());
-				bgacache[bga % bgacache.length] = new Texture(pix);
+				bgacache[bga % bgacache.length] = new Texture(createPixmap(bga));
 				bgacacheid[bga % bgacache.length] = bga;
 				count++;
 			}
 
 			bga = tl.getLayer();
 			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bgamap[bga] != null) {
-				int bgasize = bgamap[bga].getHeight() > bgamap[bga].getWidth() ?
-						bgamap[bga].getHeight() : bgamap[bga].getWidth();
-				Pixmap pix;
-				if ( bgasize <=256 ){
-					pix = new Pixmap(bgasize, bgasize, bgamap[bga].getFormat());
-				} else {
-					pix = new Pixmap(bgamap[bga].getWidth(), bgamap[bga].getHeight(), bgamap[bga].getFormat());
-				}
-				pix.drawPixmap(bgamap[bga], 0, 0, bgamap[bga].getWidth(), bgamap[bga].getHeight(),
-						0, 0,bgamap[bga].getWidth(), bgamap[bga].getHeight());
-				bgacache[bga % bgacache.length] = new Texture(pix);
+				bgacache[bga % bgacache.length] = new Texture(createPixmap(bga));
 				bgacacheid[bga % bgacache.length] = bga;
 				count++;
 			}
@@ -90,6 +69,19 @@ public class BGImageProcessor {
 		if (bgacache[cid] != null) {
 			bgacache[cid].dispose();
 		}
+		if (bgamap[id] != null){
+			bgacache[cid] = new Texture(createPixmap(id));
+			bgacacheid[cid] = id;
+			return bgacache[cid];
+		}
+		return null;
+	}
+
+
+	/**
+	 * Create a pixmap that is compatible with legacy BMS
+	 */
+	private Pixmap createPixmap(int id){
 		int bgasize = bgamap[id].getHeight() > bgamap[id].getWidth() ?
 				bgamap[id].getHeight() : bgamap[id].getWidth();
 		Pixmap pix;
@@ -100,9 +92,7 @@ public class BGImageProcessor {
 		}
 		pix.drawPixmap(bgamap[id], 0, 0, bgamap[id].getWidth(), bgamap[id].getHeight(),
 				0, 0, bgamap[id].getWidth(), bgamap[id].getHeight());
-		bgacache[cid] = new Texture(pix);
-		bgacacheid[cid] = id;
-		return bgacache[cid];
+		return pix;
 	}
 
 	/**


### PR DESCRIPTION
It enables legacy BGI correctly.(e.g. x-aria,その欺くも美しき紅に)
The difference between the small image and the large image is the same specification as LR2.
Change the small image to the upper left justified square.