### PR TITLE
Specify skin category by SkinType enum

### DIFF
--- a/src/bms/player/beatoraja/Config.java
+++ b/src/bms/player/beatoraja/Config.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
@@ -8,6 +9,7 @@ import bms.player.beatoraja.input.BMControllerInputProcessor.BMKeys;
 import bms.player.beatoraja.play.JudgeManager;
 
 import bms.player.beatoraja.play.TargetProperty;
+import bms.player.beatoraja.skin.SkinType;
 import com.badlogic.gdx.Input.Keys;
 
 /**
@@ -160,7 +162,7 @@ public class Config {
 
 	private String soundpath = "";
 
-	private SkinConfig[] skin = new SkinConfig[16];
+	private SkinConfig[] skin;
 	/**
 	 * BMSルートディレクトリパス
 	 */
@@ -231,15 +233,16 @@ public class Config {
 				"http://dpbmsdelta.web.fc2.com/table/insane.html",
 				"http://flowermaster.web.fc2.com/lrnanido/gla/LN.html",
 				"http://stellawingroad.web.fc2.com/new/pms.html" };
-		skin[0] = new SkinConfig(SkinConfig.DEFAULT_PLAY7);
-		skin[1] = new SkinConfig(SkinConfig.DEFAULT_PLAY5);
-		skin[2] = new SkinConfig(SkinConfig.DEFAULT_PLAY14);
-		skin[3] = new SkinConfig(SkinConfig.DEFAULT_PLAY10);
-		skin[4] = new SkinConfig(SkinConfig.DEFAULT_PLAY9);
-		skin[5] = new SkinConfig(SkinConfig.DEFAULT_SELECT);
-		skin[6] = new SkinConfig(SkinConfig.DEFAULT_DECIDE);
-		skin[7] = new SkinConfig(SkinConfig.DEFAULT_RESULT);
-		skin[15] = new SkinConfig(SkinConfig.DEFAULT_GRADERESULT);
+		int maxSkinType = 0;
+		for (SkinType type : SkinType.values()) {
+			if (type.getId() > maxSkinType) {
+				maxSkinType = type.getId();
+			}
+		}
+		skin = new SkinConfig[maxSkinType + 1];
+		for (Map.Entry<SkinType, String> entry : SkinConfig.defaultSkinPathMap.entrySet()) {
+			skin[entry.getKey().getId()] = new SkinConfig(entry.getValue());
+		}
 	}
 
 	public boolean isFullscreen() {
@@ -672,6 +675,20 @@ public class Config {
 		public static final String DEFAULT_DECIDE = "skin/default/decide.json";
 		public static final String DEFAULT_RESULT = "skin/default/result.json";
 		public static final String DEFAULT_GRADERESULT = "skin/default/graderesult.json";
+
+		public static final Map<SkinType, String> defaultSkinPathMap = new HashMap<SkinType, String>() {
+			{
+				put(SkinType.PLAY_7KEYS, DEFAULT_PLAY7);
+				put(SkinType.PLAY_5KEYS, DEFAULT_PLAY5);
+				put(SkinType.PLAY_14KEYS, DEFAULT_PLAY14);
+				put(SkinType.PLAY_10KEYS, DEFAULT_PLAY10);
+				put(SkinType.PLAY_9KEYS, DEFAULT_PLAY9);
+				put(SkinType.MUSIC_SELECT, DEFAULT_SELECT);
+				put(SkinType.DECIDE, DEFAULT_DECIDE);
+				put(SkinType.RESULT, DEFAULT_RESULT);
+				put(SkinType.COURSE_RESULT, DEFAULT_GRADERESULT);
+			}
+		};
 
 		private String path;
 

--- a/src/bms/player/beatoraja/PlayConfigurationView.java
+++ b/src/bms/player/beatoraja/PlayConfigurationView.java
@@ -10,6 +10,7 @@ import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import bms.player.beatoraja.skin.SkinLoader;
+import bms.player.beatoraja.skin.SkinType;
 import org.apache.commons.dbutils.QueryRunner;
 import org.apache.commons.dbutils.handlers.MapListHandler;
 
@@ -141,7 +142,7 @@ public class PlayConfigurationView implements Initializable {
 
 	private SkinConfigurationView skinview;
 	@FXML
-	private ComboBox<Integer> skincategory;
+	private ComboBox<SkinType> skincategory;
 	@FXML
 	private ComboBox<SkinHeader> skin;
 	@FXML
@@ -184,11 +185,13 @@ public class PlayConfigurationView implements Initializable {
 		initComboBox(playconfig, new String[] { "5/7KEYS", "10/14KEYS", "9KEYS" });
 		initComboBox(lntype, new String[] { "LONG NOTE", "CHARGE NOTE", "HELL CHARGE NOTE" });
 		initComboBox(judgealgorithm, new String[] { arg1.getString("JUDGEALG_LR2"), arg1.getString("JUDGEALG_AC"), arg1.getString("JUDGEALG_BOTTOM_PRIORITY") });
-		initComboBox(skincategory,
-				new String[] { "7KEYS", "5KEYS", "14KEYS", "10KEYS", "9KEYS", "MUSIC SELECT", "DECIDE", "RESULT",
-						"KEY CONFIG", "SKIN SELECT", "SOUND SET", "THEME", "7KEYS BATTLE", "5KEYS BATTLE",
-						"9KEYS BATTLE", "COURSE RESULT" });
-		skincategory.getItems().setAll(0, 1, 2, 3, 4, 5, 6, 7, 15);
+
+		skincategory.setCellFactory(new Callback<ListView<SkinType>, ListCell<SkinType>>() {
+			public ListCell<SkinType> call(ListView<SkinType> param) { return new SkinTypeCell(); }
+		});
+		skincategory.setButtonCell(new SkinTypeCell());
+		skincategory.getItems().addAll(SkinType.values());
+
 		initComboBox(audio, new String[] { "OpenAL (LibGDX Sound)", "OpenAL (LibGDX AudioDevice)", "ASIO" });
 		audio.getItems().setAll(0, 2);
 
@@ -258,7 +261,7 @@ public class PlayConfigurationView implements Initializable {
 		updateAudioDriver();
 		playconfig.setValue(0);
 		updatePlayConfig();
-		skincategory.setValue(0);
+		skincategory.setValue(SkinType.PLAY_7KEYS);
 		updateSkinCategory();
 
 		irname.setValue(config.getIrname());
@@ -475,11 +478,11 @@ public class PlayConfigurationView implements Initializable {
 		}
 
 		skin.getItems().clear();
-		SkinHeader[] headers = skinview.getSkinHeader(skincategory.getValue());
+		SkinHeader[] headers = skinview.getSkinHeader(skincategory.getValue().getId());
 		skin.getItems().addAll(headers);
-		mode = skincategory.getValue();
-		if (config.getSkin()[skincategory.getValue()] != null) {
-			SkinConfig skinconf = config.getSkin()[skincategory.getValue()];
+		mode = skincategory.getValue().getId();
+		if (config.getSkin()[skincategory.getValue().getId()] != null) {
+			SkinConfig skinconf = config.getSkin()[skincategory.getValue().getId()];
 			if (skinconf != null) {
 				for (SkinHeader header : skin.getItems()) {
 					if (header != null && header.getPath().equals(Paths.get(skinconf.getPath()))) {
@@ -647,6 +650,17 @@ public class PlayConfigurationView implements Initializable {
 				setText(arg0.getName() + (arg0.getType() == SkinHeader.TYPE_BEATORJASKIN ? "" : " (LR2 Skin)"));
 			} else {
 				setText("");
+			}
+		}
+	}
+
+	class SkinTypeCell extends ListCell<SkinType> {
+
+		@Override
+		protected void updateItem(SkinType arg0, boolean arg1) {
+			super.updateItem(arg0, arg1);
+			if (arg0 != null) {
+				setText(arg0.getName());
 			}
 		}
 	}

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -165,15 +165,14 @@ public class BMSPlayer extends MainState {
 			}
 		}
 		
-		int skinmode = (model.getUseKeys() == 7 ? 0
-				: (model.getUseKeys() == 5 ? 1 : (model.getUseKeys() == 14 ? 2 : (model.getUseKeys() == 10 ? 3 : 4))));
+		SkinType skinType = getSkinType();
 		final String[] defaultskins = { SkinConfig.DEFAULT_PLAY7, SkinConfig.DEFAULT_PLAY5, SkinConfig.DEFAULT_PLAY14,
 				SkinConfig.DEFAULT_PLAY10, SkinConfig.DEFAULT_PLAY9 };
 		try {
-			SkinConfig sc = resource.getConfig().getSkin()[skinmode];
+			SkinConfig sc = resource.getConfig().getSkin()[skinType.getId()];
 			if (sc.getPath().endsWith(".json")) {
 				SkinLoader sl = new SkinLoader(RESOLUTION[resource.getConfig().getResolution()]);
-				setSkin(sl.loadPlaySkin(Paths.get(sc.getPath()), skinmode, sc.getProperty()));
+				setSkin(sl.loadPlaySkin(Paths.get(sc.getPath()), skinType, sc.getProperty()));
 			} else {
 				LR2SkinHeaderLoader loader = new LR2SkinHeaderLoader();
 				SkinHeader header = loader.loadSkin(Paths.get(sc.getPath()), this, sc.getProperty());
@@ -186,7 +185,7 @@ public class BMSPlayer extends MainState {
 		} catch (Throwable e) {
 			e.printStackTrace();
 			SkinLoader sl = new SkinLoader(RESOLUTION[resource.getConfig().getResolution()]);
-			setSkin(sl.loadPlaySkin(Paths.get(defaultskins[skinmode]), skinmode, new HashMap()));
+			setSkin(sl.loadPlaySkin(Paths.get(SkinConfig.defaultSkinPathMap.get(skinType)), skinType, new HashMap()));
 		}
 
 		judge = new JudgeManager(this, model, autoplay == 1, resource.getConstraint());
@@ -272,6 +271,24 @@ public class BMSPlayer extends MainState {
 		}
 		Logger.getGlobal().info("ゲージ設定完了");
 	}
+
+	private SkinType getSkinType() {
+		switch (model.getUseKeys()) {
+		case 7:
+			return SkinType.PLAY_7KEYS;
+		case 5:
+			return SkinType.PLAY_5KEYS;
+		case 14:
+			return SkinType.PLAY_14KEYS;
+		case 10:
+			return SkinType.PLAY_10KEYS;
+		case 9:
+			return SkinType.PLAY_9KEYS;
+		default:
+			return null;
+		}
+	}
+
 
 	public void create() {
 		final MainController main = getMainController();

--- a/src/bms/player/beatoraja/skin/SkinLoader.java
+++ b/src/bms/player/beatoraja/skin/SkinLoader.java
@@ -50,19 +50,19 @@ public class SkinLoader {
 	}
 
 	public MusicResultSkin loadResultSkin(Path p, Map property) {
-		return (MusicResultSkin) load(p, 7, property);
+		return (MusicResultSkin) load(p, SkinType.RESULT, property);
 	}
 
 	public MusicDecideSkin loadDecideSkin(Path p, Map property) {
-		return (MusicDecideSkin) load(p, 6, property);
+		return (MusicDecideSkin) load(p, SkinType.DECIDE, property);
 	}
 
 	public MusicSelectSkin loadSelectSkin(Path p, Map property) {
-		return (MusicSelectSkin) load(p, 5, property);
+		return (MusicSelectSkin) load(p, SkinType.MUSIC_SELECT, property);
 	}
 
-	public PlaySkin loadPlaySkin(Path p, int skinmode, Map property) {
-		return (PlaySkin) load(p, skinmode, property);
+	public PlaySkin loadPlaySkin(Path p, SkinType type, Map property) {
+		return (PlaySkin) load(p, type, property);
 	}
 
 	public SkinHeader loadHeader(Path p) {
@@ -106,7 +106,7 @@ public class SkinLoader {
 		return header;
 	}
 
-	public Skin load(Path p, int type, Map property) {
+	public Skin load(Path p, SkinType type, Map property) {
 		Skin skin = null;
 		try {
 			Json json = new Json();
@@ -116,18 +116,18 @@ public class SkinLoader {
 
 			texmap = new HashMap();
 
-			if (type >= 0 && type < 5) {
+			if (type.isPlay()) {
 				skin = new PlaySkin(sk.w, sk.h, dstr.width, dstr.height);
 				((PlaySkin) skin).setClose(sk.close);
 				((PlaySkin) skin).setPlaystart(sk.playstart);
 			}
-			if (type == 5) {
+			if (type == SkinType.MUSIC_SELECT) {
 				skin = new MusicSelectSkin(sk.w, sk.h, dstr.width, dstr.height);
 			}
-			if (type == 6) {
+			if (type == SkinType.DECIDE) {
 				skin = new MusicDecideSkin(sk.w, sk.h, dstr.width, dstr.height);
 			}
-			if (type == 7) {
+			if (type == SkinType.RESULT) {
 				skin = new MusicResultSkin(sk.w, sk.h, dstr.width, dstr.height);
 			}
 

--- a/src/bms/player/beatoraja/skin/SkinType.java
+++ b/src/bms/player/beatoraja/skin/SkinType.java
@@ -1,0 +1,62 @@
+package bms.player.beatoraja.skin;
+
+public enum SkinType {
+	PLAY_7KEYS(0, "7KEYS", 7, false),
+	PLAY_5KEYS(1, "5KEYS", 5, false),
+	PLAY_14KEYS(2, "14KEYS", 14, false),
+	PLAY_10KEYS(3, "10KEYS", 10, false),
+	PLAY_9KEYS(4, "9KEYS", 9, false),
+	MUSIC_SELECT(5, "MUSIC SELECT"),
+	DECIDE(6, "DECIDE"),
+	RESULT(7, "RESULT"),
+	KEY_CONFIG(8, "KEY CONFIG"),
+	SKIN_SELECT(9, "SKIN SELECT"),
+	SOUND_SET(10, "SOUND SET"),
+	THEME(11, "THEME"),
+	PLAY_7KEYS_BATTLE(12, "7KEYS BATTLE", 7, true),
+	PLAY_5KEYS_BATTLE(13, "5KEYS BATTLE", 5, true),
+	PLAY_9KEYS_BATTLE(14, "9KEYS BATTLE", 9, true),
+	COURSE_RESULT(15, "COURSE RESULT");
+
+	private final int id;
+	private final String name;
+	private final boolean play;
+	private final int keys;
+	private final boolean battle;
+
+	private SkinType(int id, String name) {
+		this.id = id;
+		this.name = name;
+		this.play = false;
+		this.keys = 0;
+		this.battle = false;
+	}
+
+	private SkinType(int id, String name, int keys, boolean battle) {
+		this.id = id;
+		this.name = name;
+		this.play = true;
+		this.keys = keys;
+		this.battle = battle;
+	}
+
+	public int getId() {
+		return id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public boolean isPlay() {
+		return play;
+	}
+
+	public int getKeys() {
+		return keys;
+	}
+
+	public boolean isBattle() {
+		return battle;
+	}
+}

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -633,7 +633,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader {
 
 		skin = new PlaySkin(srcw, srch, dstw, dsth);
 		playerr = new Rectangle[] { new Rectangle() };
-		if (header.getMode() == 2 || header.getMode() == 3) {
+		if (header.getMode() == SkinType.PLAY_14KEYS.getId() || header.getMode() == SkinType.PLAY_10KEYS.getId()) {
 			note = new SkinSource[16];
 			lnstart = new SkinSource[16];
 			lnend = new SkinSource[16];
@@ -643,7 +643,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader {
 			laner = new Rectangle[16];
 			playerr = new Rectangle[] { new Rectangle(), new Rectangle() };
 		}
-		if (header.getMode() == 4) {
+		if (header.getMode() == SkinType.PLAY_9KEYS.getId()) {
 			note = new SkinSource[9];
 			lnstart = new SkinSource[9];
 			lnend = new SkinSource[9];


### PR DESCRIPTION
* This improves readability and extensibility in skin category distinction.
* SkinType's integral id is used to save config. This is compatible with old skin category number.