### PR TITLE
Fix compiling without adding duplicate files.

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -18,7 +18,7 @@
 	</target>
 
 	<target name="create_run_jar" depends="compile">
-		<jar destfile="./beatoraja.jar" filesetmanifest="mergewithoutmain" duplicate="fail">
+		<jar destfile="./beatoraja.jar" filesetmanifest="mergewithoutmain" duplicate="preserve">
 			<manifest>
 				<attribute name="Main-Class" value="bms.player.beatoraja.MainLoader" />
 				<attribute name="Bundle-NativeCode" value="jasiohost32.dll;jasiohost64.dll" />


### PR DESCRIPTION
The >300% decrease in size reported was probably due to the ffmpeg libraries not getting added.