### PR TITLE
Correct bit operation and avoid 16bit sound noise

### DIFF
--- a/src/bms/player/beatoraja/audio/PCM.java
+++ b/src/bms/player/beatoraja/audio/PCM.java
@@ -114,7 +114,7 @@ public class PCM {
 //				final long time = System.nanoTime();
 				this.sample = new short[bytes / 2];
 				for (int i = 0; i < sample.length; i++) {
-					this.sample[i] = (short) (pcm[i * 2] + (pcm[i * 2 + 1] << 8));
+					this.sample[i] = (short) ((pcm[i * 2] & 0xff) | (pcm[i * 2 + 1] << 8));
 				}
 				
 //				 ShortBuffer shortbuf =


### PR DESCRIPTION
* There were noises caused by a bug in data conversion of 16bit sound.
* They were usually small, but sometimes very harsh if individual key sounds are loud (e.g. Papyrus / BOF2009, BMS-WAV version).

```java
  pcm[i * 2] = (byte)0x9C = -100;
  pcm[i * 2 + 1] = (byte)0x80 = -128;

  // expected:
  sample[i] = (short)0x809C = -32612;

  // old:
  sample[i] = (short)((int)(-100) + (int)(0x80 << 8)) = (short)((int)0x7F9C) = 32668; // harsh noise!

  // new:
  sample[i] = (short)((int)0x9C | (int)(0x80 << 8)) = (short)((int)0x809C) = -32612;
```