### PR TITLE
Extend skin property and refactor JudgeManager and KeyInputProcessor for extension

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -98,7 +98,8 @@ public class MainController extends ApplicationAdapter {
 
 	private ScreenShotThread screenshot;
 
-	private long[] timer = new long[256];
+	public static final int timerCount = 2048;
+	private long[] timer = new long[timerCount];
 
 	public MainController(Path f, Config config, int auto, boolean songUpdated) {
 		this.auto = auto;

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -790,14 +790,8 @@ public class BMSPlayer extends MainState {
 		case VALUE_JUDGE_3P_DURATION:
 			return judge.getRecentJudgeTiming();
 		}
-		if (id >= VALUE_JUDGE_1P_SCRATCH && id < VALUE_JUDGE_1P_SCRATCH + 10) {
-			return judge.getJudge()[id - VALUE_JUDGE_1P_SCRATCH];
-		} else if (id >= VALUE_JUDGE_2P_SCRATCH && id < VALUE_JUDGE_2P_SCRATCH + 10) {
-			return judge.getJudge()[id - VALUE_JUDGE_2P_SCRATCH + 10];
-		} else if (id >= VALUE_JUDGE_1P_KEY10 && id <= VALUE_JUDGE_1P_KEY99) {
-			// TODO: get value
-		} else if (id >= VALUE_JUDGE_2P_KEY10 && id <= VALUE_JUDGE_2P_KEY99) {
-			// TODO: get value
+		if (SkinPropertyMapper.isKeyJudgeValueId(id)) {
+			return judge.getJudge(id);
 		}
 		return super.getNumberValue(id);
 	}

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -31,6 +31,7 @@ public class BMSPlayer extends MainState {
 	private BMSModel model;
 
 	private LaneRenderer lanerender;
+	private LaneProperty laneProperty;
 	private JudgeManager judge;
 
 	private BGAProcessor bga;
@@ -231,6 +232,7 @@ public class BMSPlayer extends MainState {
 	public void create() {
 		final MainController main = getMainController();
 		final PlayerResource resource = main.getPlayerResource();
+		laneProperty = new LaneProperty(model.getMode());
 		judge = new JudgeManager(this);
 		control = new ControlInputProcessor(this, autoplay);
 		keyinput = new KeyInputProccessor(this, model.getMode());
@@ -534,6 +536,10 @@ public class BMSPlayer extends MainState {
 
 	public LaneRenderer getLanerender() {
 		return lanerender;
+	}
+
+	public LaneProperty getLaneProperty() {
+		return laneProperty;
 	}
 
 	private void saveConfig() {

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -793,6 +793,9 @@ public class BMSPlayer extends MainState {
 		if (id >= VALUE_JUDGE_1P_SCRATCH && id < VALUE_JUDGE_1P_SCRATCH + 20) {
 			return judge.getJudge()[id - VALUE_JUDGE_1P_SCRATCH];
 		}
+		if (id >= VALUE_JUDGE_1P_KEY20 && id <= VALUE_JUDGE_1P_KEY_MAX) {
+			return judge.getJudge()[id - VALUE_JUDGE_1P_KEY20 + 20];
+		}
 		return super.getNumberValue(id);
 	}
 

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -794,9 +794,9 @@ public class BMSPlayer extends MainState {
 			return judge.getJudge()[id - VALUE_JUDGE_1P_SCRATCH];
 		} else if (id >= VALUE_JUDGE_2P_SCRATCH && id < VALUE_JUDGE_2P_SCRATCH + 10) {
 			return judge.getJudge()[id - VALUE_JUDGE_2P_SCRATCH + 10];
-		} else if (id >= VALUE_JUDGE_1P_KEY10 && id <= VALUE_JUDGE_1P_KEY_MAX) {
+		} else if (id >= VALUE_JUDGE_1P_KEY10 && id <= VALUE_JUDGE_1P_KEY99) {
 			// TODO: get value
-		} else if (id >= VALUE_JUDGE_2P_KEY10 && id <= VALUE_JUDGE_2P_KEY_MAX) {
+		} else if (id >= VALUE_JUDGE_2P_KEY10 && id <= VALUE_JUDGE_2P_KEY99) {
 			// TODO: get value
 		}
 		return super.getNumberValue(id);

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -790,11 +790,14 @@ public class BMSPlayer extends MainState {
 		case VALUE_JUDGE_3P_DURATION:
 			return judge.getRecentJudgeTiming();
 		}
-		if (id >= VALUE_JUDGE_1P_SCRATCH && id < VALUE_JUDGE_1P_SCRATCH + 20) {
+		if (id >= VALUE_JUDGE_1P_SCRATCH && id < VALUE_JUDGE_1P_SCRATCH + 10) {
 			return judge.getJudge()[id - VALUE_JUDGE_1P_SCRATCH];
-		}
-		if (id >= VALUE_JUDGE_1P_KEY20 && id <= VALUE_JUDGE_1P_KEY_MAX) {
-			return judge.getJudge()[id - VALUE_JUDGE_1P_KEY20 + 20];
+		} else if (id >= VALUE_JUDGE_2P_SCRATCH && id < VALUE_JUDGE_2P_SCRATCH + 10) {
+			return judge.getJudge()[id - VALUE_JUDGE_2P_SCRATCH + 10];
+		} else if (id >= VALUE_JUDGE_1P_KEY10 && id <= VALUE_JUDGE_1P_KEY_MAX) {
+			// TODO: get value
+		} else if (id >= VALUE_JUDGE_2P_KEY10 && id <= VALUE_JUDGE_2P_KEY_MAX) {
+			// TODO: get value
 		}
 		return super.getNumberValue(id);
 	}

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -125,41 +125,11 @@ public class JudgeManager {
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(model.getMode()).judge;
 		pmsjudge = rule.pms;
 
-		switch (model.getMode()) {
-		case BEAT_5K:
-			keyassign = new int[] { 0, 1, 2, 3, 4, -1, -1, 5, 5 };
-			break;
-		case BEAT_7K:
-			keyassign = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7 };
-			break;
-		case BEAT_10K:
-			keyassign = new int[] { 0, 1, 2, 3, 4, -1, -1, 5, 5, 6, 7, 8, 9, 10, -1, -1, 11, 11 };
-			break;
-		case BEAT_14K:
-			keyassign = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15 };
-			break;
-		case POPN_9K:
-			keyassign = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
-			break;
-		default:
-			keyassign = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7 };
-			break;
-		}
-		offset = new int[model.getMode().key];
-		player = new int[model.getMode().key];
-		sckeyassign = new int[model.getMode().key];
+		keyassign = main.getLaneProperty().getKeyAssign();
+		offset = main.getLaneProperty().getSkinOffset();
+		player = main.getLaneProperty().getPlayer();
+		sckeyassign = main.getLaneProperty().getScratchAssign();
 		sckey = new int[model.getMode().scratchKey.length];
-		for(int i = 0, sc = 0;i < offset.length;i++) {
-			player[i] = i / (model.getMode().key / model.getMode().player);
-			if(model.getMode().isScratchKey(i)) {
-				sckeyassign[i] = sc;
-				offset[i] = 0;
-				sc++;
-			} else {
-				sckeyassign[i] = -1;
-				offset[i] = i % (model.getMode().key / model.getMode().player) + 1;
-			}
-		}
 
 		judge = new int[model.getMode().player][model.getMode().key / model.getMode().player + 1];
 		processing = new LongNote[sckeyassign.length];

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -125,10 +125,10 @@ public class JudgeManager {
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(model.getMode()).judge;
 		pmsjudge = rule.pms;
 
-		keyassign = main.getLaneProperty().getKeyAssign();
-		offset = main.getLaneProperty().getSkinOffset();
-		player = main.getLaneProperty().getPlayer();
-		sckeyassign = main.getLaneProperty().getScratchAssign();
+		keyassign = main.getLaneProperty().getKeyLaneAssign();
+		offset = main.getLaneProperty().getLaneSkinOffset();
+		player = main.getLaneProperty().getLanePlayer();
+		sckeyassign = main.getLaneProperty().getLaneScratchAssign();
 		sckey = new int[model.getMode().scratchKey.length];
 
 		judge = new int[model.getMode().player][model.getMode().key / model.getMode().player + 1];

--- a/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -21,7 +21,6 @@ import bms.player.beatoraja.skin.SkinPropertyMapper;
 class KeyInputProccessor {
 
 	private final BMSPlayer player;
-	private final boolean ispms;
 
 	private JudgeThread judge;
 
@@ -30,7 +29,6 @@ class KeyInputProccessor {
 
 	public KeyInputProccessor(BMSPlayer player, Mode mode) {
 		this.player = player;
-		ispms = mode == Mode.POPN_5K || mode == Mode.POPN_9K;
 		this.scratch = new int[2];
 	}
 
@@ -46,19 +44,19 @@ class KeyInputProccessor {
 		final JudgeManager judge = player.getJudgeManager();
 		final boolean[] keystate = player.getMainController().getInputProcessor().getKeystate();
 
-		for (int lane = 0; lane < player.getLaneProperty().getSkinOffset().length; lane++) {
+		for (int lane = 0; lane < player.getLaneProperty().getLaneSkinOffset().length; lane++) {
 			// キービームフラグON/OFF
-			final int offset = player.getLaneProperty().getSkinOffset()[lane];
+			final int offset = player.getLaneProperty().getLaneSkinOffset()[lane];
 			boolean pressed = false;
-			for (int i = 0; i < player.getLaneProperty().getLaneAssign()[lane].length; i++) {
-				int key = player.getLaneProperty().getLaneAssign()[lane][i];
+			for (int i = 0; i < player.getLaneProperty().getLaneKeyAssign()[lane].length; i++) {
+				int key = player.getLaneProperty().getLaneKeyAssign()[lane][i];
 				if (key >= 0 && keystate[key]) {
 					pressed = true;
 					break;
 				}
 			}
-			final int timerOn = SkinPropertyMapper.keyOnTimerId(player.getLaneProperty().getPlayer()[lane], offset);
-			final int timerOff = SkinPropertyMapper.keyOffTimerId(player.getLaneProperty().getPlayer()[lane], offset);
+			final int timerOn = SkinPropertyMapper.keyOnTimerId(player.getLaneProperty().getLanePlayer()[lane], offset);
+			final int timerOff = SkinPropertyMapper.keyOffTimerId(player.getLaneProperty().getLanePlayer()[lane], offset);
 			if (pressed) {
 				if (timer[timerOn] == Long.MIN_VALUE) {
 					timer[timerOn] = now;
@@ -76,10 +74,10 @@ class KeyInputProccessor {
 			final int deltatime = now - prevtime;
 			for (int s = 0; s < scratch.length; s++) {
 				scratch[s] += s % 2 == 0 ? 2160 - deltatime : deltatime;
-				if (s < player.getLaneProperty().getScratchToKey().length) {
-					if (keystate[player.getLaneProperty().getScratchToKey()[s][0]]) {
+				if (s < player.getLaneProperty().getScratchKeyAssign().length) {
+					if (keystate[player.getLaneProperty().getScratchKeyAssign()[s][0]]) {
 						scratch[s] += deltatime * 2;
-					} else if (keystate[player.getLaneProperty().getScratchToKey()[s][1]]) {
+					} else if (keystate[player.getLaneProperty().getScratchKeyAssign()[s][1]]) {
 						scratch[s] += 2160 - deltatime * 2;
 					}
 				}

--- a/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -11,6 +11,7 @@ import bms.model.Mode;
 import bms.model.TimeLine;
 import bms.player.beatoraja.input.BMSPlayerInputProcessor;
 import bms.player.beatoraja.input.KeyInputLog;
+import bms.player.beatoraja.skin.SkinPropertyMapper;
 
 /**
  * キー入力処理用スレッド
@@ -22,17 +23,15 @@ class KeyInputProccessor {
 	private final BMSPlayer player;
 	private final boolean ispms;
 
-	private final int[] key_offset = { 1, 2, 3, 4, 5, 6, 7, 0, 11, 12, 13, 14, 15, 16, 17, 10 };
-
 	private JudgeThread judge;
 
 	private int prevtime = -1;
-	private int scratch1;
-	private int scratch2;
+	private int[] scratch;
 
 	public KeyInputProccessor(BMSPlayer player, Mode mode) {
 		this.player = player;
 		ispms = mode == Mode.POPN_5K || mode == Mode.POPN_9K;
+		this.scratch = new int[2];
 	}
 
 	public void startJudge(BMSModel model, List<KeyInputLog> keylog) {
@@ -47,64 +46,51 @@ class KeyInputProccessor {
 		final JudgeManager judge = player.getJudgeManager();
 		final boolean[] keystate = player.getMainController().getInputProcessor().getKeystate();
 
-		for (int lane = 0; lane < 16; lane++) {
+		for (int lane = 0; lane < player.getLaneProperty().getSkinOffset().length; lane++) {
 			// キービームフラグON/OFF
-			if (ispms) {
-				if (keystate[lane]) {
-					if (timer[TIMER_KEYON_1P_KEY1 + lane] == Long.MIN_VALUE) {
-						timer[TIMER_KEYON_1P_KEY1 + lane] = now;
-						timer[TIMER_KEYOFF_1P_KEY1 + lane] = Long.MIN_VALUE;
-					}
-				} else {
-					if (timer[TIMER_KEYOFF_1P_KEY1 + lane] == Long.MIN_VALUE) {
-						timer[TIMER_KEYOFF_1P_KEY1 + lane] = now;
-						timer[TIMER_KEYON_1P_KEY1 + lane] = Long.MIN_VALUE;
-					}
+			final int offset = player.getLaneProperty().getSkinOffset()[lane];
+			boolean pressed = false;
+			for (int i = 0; i < player.getLaneProperty().getLaneAssign()[lane].length; i++) {
+				int key = player.getLaneProperty().getLaneAssign()[lane][i];
+				if (key >= 0 && keystate[key]) {
+					pressed = true;
+					break;
+				}
+			}
+			final int timerOn = SkinPropertyMapper.keyOnTimerId(player.getLaneProperty().getPlayer()[lane], offset);
+			final int timerOff = SkinPropertyMapper.keyOffTimerId(player.getLaneProperty().getPlayer()[lane], offset);
+			if (pressed) {
+				if (timer[timerOn] == Long.MIN_VALUE) {
+					timer[timerOn] = now;
+					timer[timerOff] = Long.MIN_VALUE;
 				}
 			} else {
-				final int key = lane >= 8 ? lane + 1 : lane;
-				final int offset = key_offset[lane];
-				if (keystate[key] || (key == 7 && keystate[8]) || (key == 16 && keystate[17])) {
-					if (timer[TIMER_KEYON_1P_SCRATCH + offset] == Long.MIN_VALUE) {
-						timer[TIMER_KEYON_1P_SCRATCH + offset] = now;
-						timer[TIMER_KEYOFF_1P_SCRATCH + offset] = Long.MIN_VALUE;
-					}
-				} else {
-					if (timer[TIMER_KEYOFF_1P_SCRATCH + offset] == Long.MIN_VALUE) {
-						timer[TIMER_KEYOFF_1P_SCRATCH + offset] = now;
-						timer[TIMER_KEYON_1P_SCRATCH + offset] = Long.MIN_VALUE;
-					}
+				if (timer[timerOff] == Long.MIN_VALUE) {
+					timer[timerOff] = now;
+					timer[timerOn] = Long.MIN_VALUE;
 				}
 			}
 		}
 		
 		if(prevtime >= 0) {
 			final int deltatime = now - prevtime;
-			scratch1 += 2160 - deltatime;
-			scratch2 += deltatime;
-			if (!ispms) {
-				if (keystate[7]) {
-					scratch1 += deltatime * 2;
-				} else if (keystate[8]) {
-					scratch1 += 2160 - deltatime * 2;
+			for (int s = 0; s < scratch.length; s++) {
+				scratch[s] += s % 2 == 0 ? 2160 - deltatime : deltatime;
+				if (s < player.getLaneProperty().getScratchToKey().length) {
+					if (keystate[player.getLaneProperty().getScratchToKey()[s][0]]) {
+						scratch[s] += deltatime * 2;
+					} else if (keystate[player.getLaneProperty().getScratchToKey()[s][1]]) {
+						scratch[s] += 2160 - deltatime * 2;
+					}
 				}
-				if (keystate[16]) {
-					scratch2 += deltatime * 2;
-				} else if (keystate[17]) {
-					scratch2 += 2160 - deltatime * 2;
-				}
+				scratch[s] %= 2160;
 			}
-			scratch1 %= 2160;
-			scratch2 %= 2160;			
 		}
 		prevtime = now;
 	}
 	
 	public int getScratchState(int i) {
-		if(i == 0) {
-			return scratch1 / 6;
-		}
-		return scratch2 / 6;
+		return scratch[i] / 6;
 	}
 
 	public void stopJudge() {

--- a/src/bms/player/beatoraja/play/LaneProperty.java
+++ b/src/bms/player/beatoraja/play/LaneProperty.java
@@ -1,0 +1,88 @@
+package bms.player.beatoraja.play;
+
+import bms.model.Mode;
+
+import java.util.List;
+
+public class LaneProperty {
+
+	private final int[] keyToLane;
+	private final int[][] laneToKey;
+	private final int[] laneToScratch;
+	private final int[] laneToSkinOffset;
+	private final int[] laneToPlayer;
+	private final int[][] scratchToKey;
+
+	public LaneProperty(Mode mode) {
+		switch (mode) {
+		case BEAT_5K:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, -1, -1, 5, 5 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {7,8} };
+			scratchToKey = new int[][] { {7,8} };
+			break;
+		case BEAT_7K:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7,8} };
+			scratchToKey = new int[][] { {7,8} };
+			break;
+		case BEAT_10K:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, -1, -1, 5, 5, 6, 7, 8, 9, 10, -1, -1, 11, 11 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {7,8}, {9}, {10}, {11}, {12}, {13}, {16,17} };
+			scratchToKey = new int[][] { {7,8}, {16,17} };
+			break;
+		case BEAT_14K:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, 9, 10, 11, 12, 13, 14, 15, 15 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7,8}, {9}, {10}, {11}, {12}, {13}, {14}, {15}, {16,17} };
+			scratchToKey = new int[][] { {7,8}, {16,17} };
+			break;
+		case POPN_9K:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7}, {8} };
+			scratchToKey = new int[][] { };
+			break;
+		default:
+			keyToLane = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 7 };
+			laneToKey = new int[][] { {0}, {1}, {2}, {3}, {4}, {5}, {6}, {7,8} };
+			scratchToKey = new int[][] { {7,8} };
+			break;
+		}
+		laneToScratch = new int[mode.key];
+		laneToSkinOffset = new int[mode.key];
+		laneToPlayer = new int[mode.key];
+		for(int i = 0, sc = 0; i < laneToSkinOffset.length; i++) {
+			laneToPlayer[i] = i / (mode.key / mode.player);
+			if(mode.isScratchKey(i)) {
+				laneToSkinOffset[i] = 0;
+				laneToScratch[i] = sc;
+				sc++;
+			} else {
+				laneToSkinOffset[i] = i % (mode.key / mode.player) + 1;
+				laneToScratch[i] = -1;
+			}
+		}
+	}
+
+	public int[] getKeyAssign() {
+		return keyToLane;
+	}
+
+	public int[][] getLaneAssign() {
+		return laneToKey;
+	}
+
+	public int[] getScratchAssign() {
+		return laneToScratch;
+	}
+
+	public int[] getSkinOffset() {
+		return laneToSkinOffset;
+	}
+
+	public int[] getPlayer() {
+		return laneToPlayer;
+	}
+
+	public int[][] getScratchToKey() {
+		return scratchToKey;
+	}
+}

--- a/src/bms/player/beatoraja/play/LaneProperty.java
+++ b/src/bms/player/beatoraja/play/LaneProperty.java
@@ -2,15 +2,36 @@ package bms.player.beatoraja.play;
 
 import bms.model.Mode;
 
-import java.util.List;
-
 public class LaneProperty {
 
+	/**
+	 * 入力キーからレーンへの対応
+	 */
 	private final int[] keyToLane;
+
+	/**
+	 * レーンから入力キー（複数）への対応
+	 */
 	private final int[][] laneToKey;
+
+	/**
+	 * レーンが何個目のスクラッチか
+	 */
 	private final int[] laneToScratch;
+
+	/**
+	 * レーンからスキンに使用する番号への対応
+	 */
 	private final int[] laneToSkinOffset;
+
+	/**
+	 * レーンからプレイヤー番号への対応
+	 */
 	private final int[] laneToPlayer;
+
+	/**
+	 * 各スクラッチを処理する入力キー（2個ずつ）
+	 */
 	private final int[][] scratchToKey;
 
 	public LaneProperty(Mode mode) {
@@ -62,27 +83,27 @@ public class LaneProperty {
 		}
 	}
 
-	public int[] getKeyAssign() {
+	public int[] getKeyLaneAssign() {
 		return keyToLane;
 	}
 
-	public int[][] getLaneAssign() {
+	public int[][] getLaneKeyAssign() {
 		return laneToKey;
 	}
 
-	public int[] getScratchAssign() {
+	public int[] getLaneScratchAssign() {
 		return laneToScratch;
 	}
 
-	public int[] getSkinOffset() {
+	public int[] getLaneSkinOffset() {
 		return laneToSkinOffset;
 	}
 
-	public int[] getPlayer() {
+	public int[] getLanePlayer() {
 		return laneToPlayer;
 	}
 
-	public int[][] getScratchToKey() {
+	public int[][] getScratchKeyAssign() {
 		return scratchToKey;
 	}
 }

--- a/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/src/bms/player/beatoraja/skin/SkinObject.java
@@ -1,5 +1,6 @@
 package bms.player.beatoraja.skin;
 
+import bms.player.beatoraja.MainController;
 import bms.player.beatoraja.MainState;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
@@ -186,7 +187,7 @@ public abstract class SkinObject implements Disposable {
 	public Rectangle getDestination(long time, MainState state) {
 		final int timer = dsttimer;
 
-		if (timer != 0 && timer < 256) {
+		if (timer != 0 && timer < MainController.timerCount) {
 			final long stime = state.getTimer()[timer];
 			if (stime == Long.MIN_VALUE) {
 				return null;

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -582,6 +582,10 @@ public class SkinProperty {
 	public static final int VALUE_JUDGE_2P_DURATION = 526;
 	public static final int VALUE_JUDGE_3P_DURATION = 527;
 
+	// 拡張数値定義
+	public static final int VALUE_JUDGE_1P_KEY20 = 1520;
+	public static final int VALUE_JUDGE_1P_KEY_MAX = 1599;
+
 	public static final int SLIDER_LANECOVER = 4;
 	public static final int SLIDER_LANECOVER2 = 5;
 

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -117,22 +117,22 @@ public class SkinProperty {
 	public static final int TIMER_RESULT_UPDATESCORE = 152;
 
 	// 拡張版TIMER
-	public static final int TIMER_BOMB_1P_SCRATCH2 = 1000;
 	public static final int TIMER_BOMB_1P_KEY10 = 1010;
-	public static final int TIMER_BOMB_2P_SCRATCH2 = 1100;
+	public static final int TIMER_BOMB_1P_KEY99 = 1099;
 	public static final int TIMER_BOMB_2P_KEY10 = 1110;
-	public static final int TIMER_HOLD_1P_SCRATCH2 = 1200;
+	public static final int TIMER_BOMB_2P_KEY99 = 1199;
 	public static final int TIMER_HOLD_1P_KEY10 = 1210;
-	public static final int TIMER_HOLD_2P_SCRATCH2 = 1300;
+	public static final int TIMER_HOLD_1P_KEY99 = 1299;
 	public static final int TIMER_HOLD_2P_KEY10 = 1310;
-	public static final int TIMER_KEYON_1P_SCRATCH2 = 1400;
+	public static final int TIMER_HOLD_2P_KEY99 = 1399;
 	public static final int TIMER_KEYON_1P_KEY10 = 1410;
-	public static final int TIMER_KEYON_2P_SCRATCH2 = 1500;
+	public static final int TIMER_KEYON_1P_KEY99 = 1499;
 	public static final int TIMER_KEYON_2P_KEY10 = 1510;
-	public static final int TIMER_KEYOFF_1P_SCRATCH2 = 1600;
+	public static final int TIMER_KEYON_2P_KEY99 = 1599;
 	public static final int TIMER_KEYOFF_1P_KEY10 = 1610;
-	public static final int TIMER_KEYOFF_2P_SCRATCH2 = 1700;
+	public static final int TIMER_KEYOFF_1P_KEY99 = 1699;
 	public static final int TIMER_KEYOFF_2P_KEY10 = 1710;
+	public static final int TIMER_KEYOFF_2P_KEY99 = 1799;
 
 	// 選曲専用
 	public static final int SLIDER_MUSICSELECT_POSITION = 1;
@@ -587,12 +587,10 @@ public class SkinProperty {
 	public static final int VALUE_JUDGE_3P_DURATION = 527;
 
 	// 拡張数値定義
-	public static final int VALUE_JUDGE_1P_SCRATCH2 = 1500;
 	public static final int VALUE_JUDGE_1P_KEY10 = 1510;
-	public static final int VALUE_JUDGE_1P_KEY_MAX = 1599;
-	public static final int VALUE_JUDGE_2P_SCRATCH2 = 1600;
+	public static final int VALUE_JUDGE_1P_KEY99 = 1599;
 	public static final int VALUE_JUDGE_2P_KEY10 = 1610;
-	public static final int VALUE_JUDGE_2P_KEY_MAX = 1699;
+	public static final int VALUE_JUDGE_2P_KEY99 = 1699;
 
 	public static final int SLIDER_LANECOVER = 4;
 	public static final int SLIDER_LANECOVER2 = 5;

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -66,6 +66,8 @@ public class SkinProperty {
 	public static final int TIMER_BOMB_2P_KEY9 = 69;
 	public static final int TIMER_HOLD_1P_SCRATCH = 70;
 	public static final int TIMER_HOLD_1P_KEY1 = 71;
+	public static final int TIMER_HOLD_2P_SCRATCH = 80;
+	public static final int TIMER_HOLD_2P_KEY1 = 81;
 	public static final int TIMER_KEYON_1P_SCRATCH = 100;
 	public static final int TIMER_KEYON_1P_KEY1 = 101;
 	public static final int TIMER_KEYON_1P_KEY2 = 102;
@@ -113,6 +115,24 @@ public class SkinProperty {
 	public static final int TIMER_RESULTGRAPH_BEGIN = 150;
 	public static final int TIMER_RESULTGRAPH_END = 151;
 	public static final int TIMER_RESULT_UPDATESCORE = 152;
+
+	// 拡張版TIMER
+	public static final int TIMER_BOMB_1P_SCRATCH2 = 1000;
+	public static final int TIMER_BOMB_1P_KEY10 = 1010;
+	public static final int TIMER_BOMB_2P_SCRATCH2 = 1100;
+	public static final int TIMER_BOMB_2P_KEY10 = 1110;
+	public static final int TIMER_HOLD_1P_SCRATCH2 = 1200;
+	public static final int TIMER_HOLD_1P_KEY10 = 1210;
+	public static final int TIMER_HOLD_2P_SCRATCH2 = 1300;
+	public static final int TIMER_HOLD_2P_KEY10 = 1310;
+	public static final int TIMER_KEYON_1P_SCRATCH2 = 1400;
+	public static final int TIMER_KEYON_1P_KEY10 = 1410;
+	public static final int TIMER_KEYON_2P_SCRATCH2 = 1500;
+	public static final int TIMER_KEYON_2P_KEY10 = 1510;
+	public static final int TIMER_KEYOFF_1P_SCRATCH2 = 1600;
+	public static final int TIMER_KEYOFF_1P_KEY10 = 1610;
+	public static final int TIMER_KEYOFF_2P_SCRATCH2 = 1700;
+	public static final int TIMER_KEYOFF_2P_KEY10 = 1710;
 
 	// 選曲専用
 	public static final int SLIDER_MUSICSELECT_POSITION = 1;

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -575,6 +575,10 @@ public class SkinProperty {
 
 	public static final int VALUE_JUDGE_1P_SCRATCH = 500;
 	public static final int VALUE_JUDGE_1P_KEY1 = 501;
+	public static final int VALUE_JUDGE_1P_KEY9 = 509;
+	public static final int VALUE_JUDGE_2P_SCRATCH = 510;
+	public static final int VALUE_JUDGE_2P_KEY1 = 511;
+	public static final int VALUE_JUDGE_2P_KEY9 = 519;
 	public static final int VALUE_JUDGE_1P = 520;
 	public static final int VALUE_JUDGE_2P = 521;
 	public static final int VALUE_JUDGE_3P = 522;
@@ -583,8 +587,12 @@ public class SkinProperty {
 	public static final int VALUE_JUDGE_3P_DURATION = 527;
 
 	// 拡張数値定義
-	public static final int VALUE_JUDGE_1P_KEY20 = 1520;
+	public static final int VALUE_JUDGE_1P_SCRATCH2 = 1500;
+	public static final int VALUE_JUDGE_1P_KEY10 = 1510;
 	public static final int VALUE_JUDGE_1P_KEY_MAX = 1599;
+	public static final int VALUE_JUDGE_2P_SCRATCH2 = 1600;
+	public static final int VALUE_JUDGE_2P_KEY10 = 1610;
+	public static final int VALUE_JUDGE_2P_KEY_MAX = 1699;
 
 	public static final int SLIDER_LANECOVER = 4;
 	public static final int SLIDER_LANECOVER2 = 5;

--- a/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
+++ b/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
@@ -4,77 +4,45 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
 
 public class SkinPropertyMapper {
 
-	public static int bombTimerId(int player, boolean scratch, int index) {
+	public static int bombTimerId(int player, int key) {
 		if (player < 2) {
-			if (scratch) {
-				if (index == 0) {
-					return TIMER_BOMB_1P_SCRATCH + player * 10;
-				} else if (index < 11) {
-					return TIMER_BOMB_1P_SCRATCH2 + index - 1 + player * 100;
-				}
-			} else {
-				if (index < 9) {
-					return TIMER_BOMB_1P_KEY1 + index + player * 10;
-				} else if (index < 99) {
-					return TIMER_BOMB_1P_KEY10 + index - 9 + player * 100;
-				}
+			if (key < 10) {
+				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+			} else if (key < 100) {
+				return TIMER_BOMB_1P_KEY10 + key - 10 + player * 100;
 			}
 		}
 		return -1;
 	}
 
-	public static int holdTimerId(int player, boolean scratch, int index) {
+	public static int holdTimerId(int player, int key) {
 		if (player < 2) {
-			if (scratch) {
-				if (index == 0) {
-					return TIMER_HOLD_1P_SCRATCH + player * 10;
-				} else if (index < 11) {
-					return TIMER_HOLD_1P_SCRATCH2 + index - 1 + player * 100;
-				}
-			} else {
-				if (index < 9) {
-					return TIMER_HOLD_1P_KEY1 + index + player * 10;
-				} else if (index < 99) {
-					return TIMER_HOLD_1P_KEY10 + index - 9 + player * 100;
-				}
+			if (key < 10) {
+				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+			} else if (key < 100) {
+				return TIMER_HOLD_1P_KEY10 + key - 10 + player * 100;
 			}
 		}
 		return -1;
 	}
 
-	public static int keyOnTimerId(int player, boolean scratch, int index) {
+	public static int keyOnTimerId(int player, int key) {
 		if (player < 2) {
-			if (scratch) {
-				if (index == 0) {
-					return TIMER_KEYON_1P_SCRATCH + player * 10;
-				} else if (index < 11) {
-					return TIMER_KEYON_1P_SCRATCH2 + index - 1 + player * 100;
-				}
-			} else {
-				if (index < 9) {
-					return TIMER_KEYON_1P_KEY1 + index + player * 10;
-				} else if (index < 99) {
-					return TIMER_KEYON_1P_KEY10 + index - 9 + player * 100;
-				}
+			if (key < 10) {
+				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+			} else if (key < 100) {
+				return TIMER_KEYON_1P_KEY10 + key - 10 + player * 100;
 			}
 		}
 		return -1;
 	}
 
-	public static int keyOffTimerId(int player, boolean scratch, int index) {
+	public static int keyOffTimerId(int player, int key) {
 		if (player < 2) {
-			if (scratch) {
-				if (index == 0) {
-					return TIMER_KEYOFF_1P_SCRATCH + player * 10;
-				} else if (index < 11) {
-					return TIMER_KEYOFF_1P_SCRATCH2 + index - 1 + player * 100;
-				}
-			} else {
-				if (index < 9) {
-					return TIMER_KEYOFF_1P_KEY1 + index + player * 10;
-				} else if (index < 99) {
-					return TIMER_KEYOFF_1P_KEY10 + index - 9 + player * 100;
-				}
+			if (key < 10) {
+				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+			} else if (key < 100) {
+				return TIMER_KEYOFF_1P_KEY10 + key - 10 + player * 100;
 			}
 		}
 		return -1;
@@ -83,23 +51,15 @@ public class SkinPropertyMapper {
 
 	public static boolean isKeyJudgeValueId(int valueId) {
 		return (valueId >= VALUE_JUDGE_1P_SCRATCH && valueId <= VALUE_JUDGE_2P_KEY9)
-				|| (valueId >= VALUE_JUDGE_1P_SCRATCH2 && valueId <= VALUE_JUDGE_2P_KEY_MAX);
+				|| (valueId >= VALUE_JUDGE_1P_KEY10 && valueId <= VALUE_JUDGE_2P_KEY99);
 	}
 
-	public static int keyJudgeValueId(int player, boolean scratch, int index) {
+	public static int keyJudgeValueId(int player, int key) {
 		if (player < 2) {
-			if (scratch) {
-				if (index == 0) {
-					return VALUE_JUDGE_1P_SCRATCH + player * 10;
-				} else if (index < 11) {
-					return VALUE_JUDGE_1P_SCRATCH2 + index - 1 + player * 100;
-				}
-			} else {
-				if (index < 9) {
-					return VALUE_JUDGE_1P_KEY1 + index + player * 10;
-				} else if (index < 99) {
-					return VALUE_JUDGE_1P_KEY10 + index - 9 + player * 100;
-				}
+			if (key < 10) {
+				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+			} else if (key < 100) {
+				return VALUE_JUDGE_1P_KEY10 + key - 10 + player * 100;
 			}
 		}
 		return -1;

--- a/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
+++ b/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
@@ -1,0 +1,107 @@
+package bms.player.beatoraja.skin;
+
+import static bms.player.beatoraja.skin.SkinProperty.*;
+
+public class SkinPropertyMapper {
+
+	public static int bombTimerId(int player, boolean scratch, int index) {
+		if (player < 2) {
+			if (scratch) {
+				if (index == 0) {
+					return TIMER_BOMB_1P_SCRATCH + player * 10;
+				} else if (index < 11) {
+					return TIMER_BOMB_1P_SCRATCH2 + index - 1 + player * 100;
+				}
+			} else {
+				if (index < 9) {
+					return TIMER_BOMB_1P_KEY1 + index + player * 10;
+				} else if (index < 99) {
+					return TIMER_BOMB_1P_KEY10 + index - 9 + player * 100;
+				}
+			}
+		}
+		return -1;
+	}
+
+	public static int holdTimerId(int player, boolean scratch, int index) {
+		if (player < 2) {
+			if (scratch) {
+				if (index == 0) {
+					return TIMER_HOLD_1P_SCRATCH + player * 10;
+				} else if (index < 11) {
+					return TIMER_HOLD_1P_SCRATCH2 + index - 1 + player * 100;
+				}
+			} else {
+				if (index < 9) {
+					return TIMER_HOLD_1P_KEY1 + index + player * 10;
+				} else if (index < 99) {
+					return TIMER_HOLD_1P_KEY10 + index - 9 + player * 100;
+				}
+			}
+		}
+		return -1;
+	}
+
+	public static int keyOnTimerId(int player, boolean scratch, int index) {
+		if (player < 2) {
+			if (scratch) {
+				if (index == 0) {
+					return TIMER_KEYON_1P_SCRATCH + player * 10;
+				} else if (index < 11) {
+					return TIMER_KEYON_1P_SCRATCH2 + index - 1 + player * 100;
+				}
+			} else {
+				if (index < 9) {
+					return TIMER_KEYON_1P_KEY1 + index + player * 10;
+				} else if (index < 99) {
+					return TIMER_KEYON_1P_KEY10 + index - 9 + player * 100;
+				}
+			}
+		}
+		return -1;
+	}
+
+	public static int keyOffTimerId(int player, boolean scratch, int index) {
+		if (player < 2) {
+			if (scratch) {
+				if (index == 0) {
+					return TIMER_KEYOFF_1P_SCRATCH + player * 10;
+				} else if (index < 11) {
+					return TIMER_KEYOFF_1P_SCRATCH2 + index - 1 + player * 100;
+				}
+			} else {
+				if (index < 9) {
+					return TIMER_KEYOFF_1P_KEY1 + index + player * 10;
+				} else if (index < 99) {
+					return TIMER_KEYOFF_1P_KEY10 + index - 9 + player * 100;
+				}
+			}
+		}
+		return -1;
+	}
+
+
+	public static boolean isKeyJudgeValueId(int valueId) {
+		return (valueId >= VALUE_JUDGE_1P_SCRATCH && valueId <= VALUE_JUDGE_2P_KEY9)
+				|| (valueId >= VALUE_JUDGE_1P_SCRATCH2 && valueId <= VALUE_JUDGE_2P_KEY_MAX);
+	}
+
+	public static int keyJudgeValueId(int player, boolean scratch, int index) {
+		if (player < 2) {
+			if (scratch) {
+				if (index == 0) {
+					return VALUE_JUDGE_1P_SCRATCH + player * 10;
+				} else if (index < 11) {
+					return VALUE_JUDGE_1P_SCRATCH2 + index - 1 + player * 100;
+				}
+			} else {
+				if (index < 9) {
+					return VALUE_JUDGE_1P_KEY1 + index + player * 10;
+				} else if (index < 99) {
+					return VALUE_JUDGE_1P_KEY10 + index - 9 + player * 100;
+				}
+			}
+		}
+		return -1;
+	}
+}

--- a/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
+++ b/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
@@ -7,7 +7,7 @@ public class SkinPropertyMapper {
 	public static int bombTimerId(int player, int key) {
 		if (player < 2) {
 			if (key < 10) {
-				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+				return TIMER_BOMB_1P_SCRATCH + key + player * 10;
 			} else if (key < 100) {
 				return TIMER_BOMB_1P_KEY10 + key - 10 + player * 100;
 			}
@@ -18,7 +18,7 @@ public class SkinPropertyMapper {
 	public static int holdTimerId(int player, int key) {
 		if (player < 2) {
 			if (key < 10) {
-				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+				return TIMER_HOLD_1P_SCRATCH + key + player * 10;
 			} else if (key < 100) {
 				return TIMER_HOLD_1P_KEY10 + key - 10 + player * 100;
 			}
@@ -29,7 +29,7 @@ public class SkinPropertyMapper {
 	public static int keyOnTimerId(int player, int key) {
 		if (player < 2) {
 			if (key < 10) {
-				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+				return TIMER_KEYON_1P_SCRATCH + key + player * 10;
 			} else if (key < 100) {
 				return TIMER_KEYON_1P_KEY10 + key - 10 + player * 100;
 			}
@@ -40,7 +40,7 @@ public class SkinPropertyMapper {
 	public static int keyOffTimerId(int player, int key) {
 		if (player < 2) {
 			if (key < 10) {
-				return VALUE_JUDGE_1P_SCRATCH + key + player * 10;
+				return TIMER_KEYOFF_1P_SCRATCH + key + player * 10;
 			} else if (key < 100) {
 				return TIMER_KEYOFF_1P_KEY10 + key - 10 + player * 100;
 			}
@@ -52,6 +52,22 @@ public class SkinPropertyMapper {
 	public static boolean isKeyJudgeValueId(int valueId) {
 		return (valueId >= VALUE_JUDGE_1P_SCRATCH && valueId <= VALUE_JUDGE_2P_KEY9)
 				|| (valueId >= VALUE_JUDGE_1P_KEY10 && valueId <= VALUE_JUDGE_2P_KEY99);
+	}
+
+	public static int getKeyJudgeValuePlayer(int valueId) {
+		if (valueId >= VALUE_JUDGE_1P_SCRATCH && valueId <= VALUE_JUDGE_2P_KEY9) {
+			return (valueId - VALUE_JUDGE_1P_SCRATCH) / 10;
+		} else {
+			return (valueId - VALUE_JUDGE_1P_KEY10) / 100;
+		}
+	}
+
+	public static int getKeyJudgeValueOffset(int valueId) {
+		if (valueId >= VALUE_JUDGE_1P_SCRATCH && valueId <= VALUE_JUDGE_2P_KEY9) {
+			return (valueId - VALUE_JUDGE_1P_SCRATCH) % 10;
+		} else {
+			return (valueId - VALUE_JUDGE_1P_KEY10) % 100 + 10;
+		}
 	}
 
 	public static int keyJudgeValueId(int player, int key) {

--- a/src/bms/player/beatoraja/skin/SkinSourceImage.java
+++ b/src/bms/player/beatoraja/skin/SkinSourceImage.java
@@ -1,5 +1,6 @@
 package bms.player.beatoraja.skin;
 
+import bms.player.beatoraja.MainController;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
 import bms.player.beatoraja.MainState;
@@ -51,7 +52,7 @@ public class SkinSourceImage implements SkinSource {
 			return 0;
 		}
 
-		if (timer != 0 && timer < 256) {
+		if (timer != 0 && timer < MainController.timerCount) {
 			if (state.getTimer()[timer] == Long.MIN_VALUE) {
 				return 0;
 			}


### PR DESCRIPTION
This is a preparation for extension of 24key or other modes.

### Skin Property

* Defined new timers and values of KEY10--KEY99.
* Because existing ids and new ids are not continuous, I defined `SkinPropertyMapper` to keep codes in game logic clean.

### JudgeManager and KeyInputProcessor refactoring

* Using SkinPropertyMapper.
* `JudgeManager` has some mode-dependent tables describing mapping between lanes and keys, which can be used also in `KeyInputProcessor`. So I moved them to new class `LaneProperty` while generalizing them so that they are easy to extend.

### Reviewing

* Please check that:
  - key beams and bombs are appropriately displayed in each mode.
  - LN, CN, HCN, BSS, etc. are appropriately judged.
  - index out of range exceptions or null pointer exceptions do not occur.
* If the names of variables and methods are inappropriate, please correct them.