### PR TITLE
Set default playing device type

### DIFF
--- a/src/bms/player/beatoraja/PlayerResource.java
+++ b/src/bms/player/beatoraja/PlayerResource.java
@@ -43,7 +43,7 @@ public class PlayerResource {
 
 	private int auto;
 
-	private BMSPlayerInputDevice playDevice;
+	private BMSPlayerInputDevice.Type playDeviceType;
 
 	private List<CourseData.CourseDataConstraint> constraint = new ArrayList();
 
@@ -110,6 +110,7 @@ public class PlayerResource {
 		this.config = config;
 		this.pconfig = pconfig;
 		this.bmsresource = new BMSResource(audio, config);
+		this.playDeviceType = BMSPlayerInputDevice.Type.KEYBOARD;
 	}
 
 	public void clear() {
@@ -396,11 +397,11 @@ public class PlayerResource {
 		return stagefile;
 	}
 
-	public BMSPlayerInputDevice getPlayDevice() {
-		return playDevice;
+	public BMSPlayerInputDevice.Type getPlayDeviceType() {
+		return playDeviceType;
 	}
 
-	public void setPlayDevice(BMSPlayerInputDevice playDevice) {
-		this.playDevice = playDevice;
+	public void setPlayDeviceType(BMSPlayerInputDevice.Type playDeviceType) {
+		this.playDeviceType = playDeviceType;
 	}
 }

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -247,7 +247,7 @@ public class BMSPlayer extends MainState {
 		final BMSPlayerInputProcessor input = main.getInputProcessor();
 		input.setMinimumInputDutration(conf.getInputduration());
 		if (autoplay == 0 || autoplay == 2) {
-			input.setExclusiveDeviceType(resource.getPlayDevice().getType());
+			input.setExclusiveDeviceType(resource.getPlayDeviceType());
 		} else {
 			input.disableAllDevices();
 		}
@@ -606,7 +606,7 @@ public class BMSPlayer extends MainState {
 		replay.gauge = config.getGauge();
 
 		score.setMinbp(score.getEbd() + score.getLbd() + score.getEpr() + score.getLpr() + score.getEms() + score.getLms() + resource.getSongdata().getNotes() - notes);
-		score.setDeviceType(resource.getPlayDevice() != null ? resource.getPlayDevice().getType() : null);
+		score.setDeviceType(resource.getPlayDeviceType());
 		return score;
 	}
 

--- a/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
+++ b/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
@@ -278,11 +278,15 @@ public class MusicSelectInputProcessor {
                 if (select.isPressed(keystate, keytime, KEY_PLAY, true) || (cursor[3] && cursortime[3] != 0)) {
                     // play
                     cursortime[3] = 0;
-                    resource.setPlayDevice(input.getLastKeyChangedDevice());
+                    if (input.getLastKeyChangedDevice() != null) {
+                        resource.setPlayDeviceType(input.getLastKeyChangedDevice().getType());
+                    }
                     select.selectSong(0);
                 } else if (select.isPressed(keystate, keytime, KEY_PRACTICE, true)) {
                     // practice mode
-                    resource.setPlayDevice(input.getLastKeyChangedDevice());
+                    if (input.getLastKeyChangedDevice() != null) {
+                        resource.setPlayDeviceType(input.getLastKeyChangedDevice().getType());
+                    }
                     select.selectSong(2);
                 } else if (select.isPressed(keystate, keytime, KEY_AUTO, true)) {
                     // auto play

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -835,16 +835,18 @@ public class MusicSelector extends MainState {
 	public void executeClickEvent(int id) {
 		switch (id) {
 		case BUTTON_PLAY:
-			getMainController().getPlayerResource()
-					.setPlayDevice(getMainController().getInputProcessor().getLastKeyChangedDevice());
+			if (getMainController().getInputProcessor().getLastKeyChangedDevice() != null) {
+				getMainController().getPlayerResource().setPlayDeviceType(getMainController().getInputProcessor().getLastKeyChangedDevice().getType());
+			}
 			play = 0;
 			break;
 		case BUTTON_AUTOPLAY:
 			play = 1;
 			break;
 		case BUTTON_PRACTICE:
-			getMainController().getPlayerResource()
-					.setPlayDevice(getMainController().getInputProcessor().getLastKeyChangedDevice());
+			if (getMainController().getInputProcessor().getLastKeyChangedDevice() != null) {
+				getMainController().getPlayerResource().setPlayDeviceType(getMainController().getInputProcessor().getLastKeyChangedDevice().getType());
+			}
 			play = 2;
 			break;
 		case BUTTON_REPLAY:


### PR DESCRIPTION
This fixes a NullPointerException that occurs on entering playing screen if any playing keys have never been pressed (i.e. using only the mouse and arrow keys to select a song).