### PR TITLE
Extend key configuration

### DIFF
--- a/src/bms/player/beatoraja/Config.java
+++ b/src/bms/player/beatoraja/Config.java
@@ -208,17 +208,17 @@ public class Config {
 
 	private PlayConfig mode7 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default14(),
-			new PlayConfig.ControllerConfig[1],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default7() },
 			PlayConfig.MidiConfig.default7());
 
 	private PlayConfig mode14 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default14(),
-			new PlayConfig.ControllerConfig[2],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default7(), PlayConfig.ControllerConfig.default7() },
 			PlayConfig.MidiConfig.default14());
 
 	private PlayConfig mode9 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default9(),
-			new PlayConfig.ControllerConfig[1],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default9() },
 			PlayConfig.MidiConfig.default9());
 
 	private int musicselectinput = 0;

--- a/src/bms/player/beatoraja/Config.java
+++ b/src/bms/player/beatoraja/Config.java
@@ -694,7 +694,7 @@ public class Config {
 		if(mode14 == null || mode14.getController().length < 2) {
 			mode14 = new PlayConfig(
 					PlayConfig.KeyboardConfig.default14(),
-					new PlayConfig.ControllerConfig[2],
+					new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default7(), PlayConfig.ControllerConfig.default7() },
 					MidiConfig.default14());
 			Logger.getGlobal().warning("mode14のPlayConfigを再構成");
 		}

--- a/src/bms/player/beatoraja/Config.java
+++ b/src/bms/player/beatoraja/Config.java
@@ -207,30 +207,19 @@ public class Config {
 	private String vlcpath = "";
 
 	private PlayConfig mode7 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-					Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-					Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
-			MidiConfig.default7());
+			PlayConfig.KeyboardConfig.default14(),
+			new PlayConfig.ControllerConfig[1],
+			PlayConfig.MidiConfig.default7());
 
 	private PlayConfig mode14 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-					Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-					Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 },
-				{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-						BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
-			MidiConfig.default14());
+			PlayConfig.KeyboardConfig.default14(),
+			new PlayConfig.ControllerConfig[2],
+			PlayConfig.MidiConfig.default14());
 
 	private PlayConfig mode9 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.G, Keys.B, Keys.COMMA, Keys.L,
-					Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN, Keys.SHIFT_RIGHT,
-					Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
-			MidiConfig.default9());
+			PlayConfig.KeyboardConfig.default9(),
+			new PlayConfig.ControllerConfig[1],
+			PlayConfig.MidiConfig.default9());
 
 	private int musicselectinput = 0;
 
@@ -704,13 +693,8 @@ public class Config {
 
 		if(mode14 == null || mode14.getController().length < 2) {
 			mode14 = new PlayConfig(
-					new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-							Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-							Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-					new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-							BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 },
-						{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-								BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
+					PlayConfig.KeyboardConfig.default14(),
+					new PlayConfig.ControllerConfig[2],
 					MidiConfig.default14());
 			Logger.getGlobal().warning("mode14のPlayConfigを再構成");
 		}

--- a/src/bms/player/beatoraja/PlayConfig.java
+++ b/src/bms/player/beatoraja/PlayConfig.java
@@ -279,6 +279,7 @@ public class PlayConfig {
 		private Input select;
 
 		public Input[] getKeys() { return keys; }
+		public void setKeys(Input[] keys) { this.keys = keys; }
 		public Input getStart() { return start; }
 		public Input getSelect() { return select; }
 		public void setStart(Input input) { start = input; }

--- a/src/bms/player/beatoraja/PlayConfig.java
+++ b/src/bms/player/beatoraja/PlayConfig.java
@@ -153,9 +153,15 @@ public class PlayConfig {
 			return select;
 		}
 
-		public void setAssign(int[] keys, int start, int select) {
+		public void setKeyAssign(int[] keys) {
 			this.keys = keys;
+		}
+
+		public void setStart(int start) {
 			this.start = start;
+		}
+
+		public void setSelect(int select) {
 			this.select = select;
 		}
 
@@ -211,9 +217,15 @@ public class PlayConfig {
 
 		public int getSelect() { return select; }
 
-		public void setAssign(int[] keys, int start, int select) {
+		public void setKeyAssign(int[] keys) {
 			this.keys = keys;
+		}
+
+		public void setStart(int start) {
 			this.start = start;
+		}
+
+		public void setSelect(int select) {
 			this.select = select;
 		}
 		
@@ -284,26 +296,12 @@ public class PlayConfig {
 			select = new Input(Input.Type.NOTE, 48);
 		}
 
-		public Input getAssignment(int index) {
-			if (index < keys.length) {
-				return keys[index];
-			} else if (index == 18) {
-				return start;
-			} else if (index == 19) {
-				return select;
-			} else {
-				return null;
-			}
+		public Input getKeyAssign(int index) {
+			return keys[index];
 		}
 
-		public void setAssignment(int index, Input input) {
-			if (index < keys.length) {
-				keys[index] = input;
-			} else if (index == 18) {
-				start = input;
-			} else if (index == 19) {
-				select = input;
-			}
+		public void setKeyAssign(int index, Input input) {
+			keys[index] = input;
 		}
 
 		public static MidiConfig default7() {

--- a/src/bms/player/beatoraja/PlayConfig.java
+++ b/src/bms/player/beatoraja/PlayConfig.java
@@ -44,7 +44,6 @@ public class PlayConfig {
 	private MidiConfig midi = new MidiConfig();
 	
 	public PlayConfig() {
-		controller[0] = new ControllerConfig();
 	}
 	
 	public PlayConfig(KeyboardConfig keyboard, ControllerConfig[] controllers, MidiConfig midi) {

--- a/src/bms/player/beatoraja/PlayConfig.java
+++ b/src/bms/player/beatoraja/PlayConfig.java
@@ -37,9 +37,9 @@ public class PlayConfig {
 	 */
 	private boolean enablelift = false;
 
-	private KeyboardConfig keyboard;
+	private KeyboardConfig keyboard = new KeyboardConfig();
 	
-	private ControllerConfig[] controller = new ControllerConfig[1];
+	private ControllerConfig[] controller = new ControllerConfig[] { ControllerConfig.default7() };
 
 	private MidiConfig midi = new MidiConfig();
 	

--- a/src/bms/player/beatoraja/PlayConfig.java
+++ b/src/bms/player/beatoraja/PlayConfig.java
@@ -37,9 +37,7 @@ public class PlayConfig {
 	 */
 	private boolean enablelift = false;
 
-	private int[] keyassign = { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT,
-			Keys.CONTROL_LEFT, Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE,
-			Keys.UNKNOWN, Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W };
+	private KeyboardConfig keyboard;
 	
 	private ControllerConfig[] controller = new ControllerConfig[1];
 
@@ -49,21 +47,18 @@ public class PlayConfig {
 		controller[0] = new ControllerConfig();
 	}
 	
-	public PlayConfig(int[] keyassign, int[][] controller, MidiConfig midi) {
-		this.keyassign = keyassign;
-		this.controller = new ControllerConfig[controller.length];
-		for(int i = 0;i < controller.length;i++) {
-			this.controller[i] = new ControllerConfig(controller[i]);
-		}
+	public PlayConfig(KeyboardConfig keyboard, ControllerConfig[] controllers, MidiConfig midi) {
+		this.keyboard = keyboard;
+		this.controller = controllers.clone();
 		this.midi = midi;
 	}
 		
-	public int[] getKeyassign() {
-		return keyassign;
+	public KeyboardConfig getKeyboardConfig() {
+		return keyboard;
 	}
 
-	public void setKeyassign(int[] keyassign) {
-		this.keyassign = keyassign;
+	public void setKeyboardConfig(KeyboardConfig keyboard) {
+		this.keyboard = keyboard;
 	}
 
 	public ControllerConfig[] getController() {
@@ -126,20 +121,78 @@ public class PlayConfig {
 		this.enablelift = enablelift;
 	}
 
+	public static class KeyboardConfig {
+
+		private int[] keys = { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT,
+				Keys.CONTROL_LEFT, Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE,
+				Keys.UNKNOWN, Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT };
+
+		private int start = Keys.Q;
+
+		private int select = Keys.W;
+
+		public KeyboardConfig() {
+
+		}
+
+		public KeyboardConfig(int[] keys, int start, int select) {
+			this.keys = keys;
+			this.start = start;
+			this.select = select;
+		}
+
+		public int[] getKeyAssign() {
+			return keys;
+		}
+
+		public int getStart() {
+			return start;
+		}
+
+		public int getSelect() {
+			return select;
+		}
+
+		public void setAssign(int[] keys, int start, int select) {
+			this.keys = keys;
+			this.start = start;
+			this.select = select;
+		}
+
+		public static KeyboardConfig default14() {
+			return new KeyboardConfig();
+		}
+
+		public static KeyboardConfig default9() {
+			KeyboardConfig config = new KeyboardConfig();
+			config.keys = new int [] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.G, Keys.B, Keys.COMMA, Keys.L,
+					Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN, Keys.SHIFT_RIGHT,
+					Keys.CONTROL_RIGHT };
+			config.start = Keys.Q;
+			config.select = Keys.W;
+			return config;
+		}
+	}
+
 	public static class ControllerConfig {
 
 		private String name = "";
 
-		private int[] assign = { BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8,
-				BMKeys.BUTTON_2, BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9,
-				BMKeys.BUTTON_10 };
+		private int[] keys = { BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8,
+				BMKeys.BUTTON_2, BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN };
+
+		private int start = BMKeys.BUTTON_9;
+
+		private int select = BMKeys.BUTTON_10;
 
 		public ControllerConfig() {
 			
 		}
 		
-		public ControllerConfig(int[] assign) {
-			this.assign = assign;
+		public ControllerConfig(int[] keys, int start, int select) {
+			this.keys = keys;
+			this.start = start;
+			this.select = select;
 		}
 		
 		public String getName() {
@@ -150,15 +203,27 @@ public class PlayConfig {
 			this.name = name;
 		}
 
-		public int[] getAssign() {
-			return assign;
+		public int[] getKeyAssign() {
+			return keys;
 		}
 
-		public void setAssign(int[] assign) {
-			this.assign = assign;
+		public int getStart() { return start; }
+
+		public int getSelect() { return select; }
+
+		public void setAssign(int[] keys, int start, int select) {
+			this.keys = keys;
+			this.start = start;
+			this.select = select;
 		}
 		
-		
+		public static ControllerConfig default7() {
+			return new ControllerConfig();
+		}
+
+		public static ControllerConfig default9() {
+			return new ControllerConfig();
+		}
 	}
 
 	public static class MidiConfig {

--- a/src/bms/player/beatoraja/PlayerConfig.java
+++ b/src/bms/player/beatoraja/PlayerConfig.java
@@ -92,29 +92,18 @@ public class PlayerConfig {
 	private SkinConfig[] skin;
 
 	private PlayConfig mode7 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-					Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-					Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
+			PlayConfig.KeyboardConfig.default14(),
+			new PlayConfig.ControllerConfig[1],
 			PlayConfig.MidiConfig.default7());
 
 	private PlayConfig mode14 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-					Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-					Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 },
-				{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-						BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
+			PlayConfig.KeyboardConfig.default14(),
+			new PlayConfig.ControllerConfig[2],
 			PlayConfig.MidiConfig.default14());
 
 	private PlayConfig mode9 = new PlayConfig(
-			new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.G, Keys.B, Keys.COMMA, Keys.L,
-					Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN, Keys.SHIFT_RIGHT,
-					Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-			new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-					BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
+			PlayConfig.KeyboardConfig.default9(),
+			new PlayConfig.ControllerConfig[1],
 			PlayConfig.MidiConfig.default9());
 
 	private int musicselectinput = 0;
@@ -355,13 +344,8 @@ public class PlayerConfig {
 
 		if(mode14 == null || mode14.getController().length < 2) {
 			mode14 = new PlayConfig(
-					new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V, Keys.SHIFT_LEFT, Keys.CONTROL_LEFT,
-							Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH, Keys.APOSTROPHE, Keys.UNKNOWN,
-							Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W },
-					new int[][] {{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-							BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 },
-						{ BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8, BMKeys.BUTTON_2,
-								BMKeys.BUTTON_5, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_9, BMKeys.BUTTON_10 }},
+					PlayConfig.KeyboardConfig.default14(),
+					new PlayConfig.ControllerConfig[2],
 					PlayConfig.MidiConfig.default14());
 			Logger.getGlobal().warning("mode14のPlayConfigを再構成");
 		}

--- a/src/bms/player/beatoraja/PlayerConfig.java
+++ b/src/bms/player/beatoraja/PlayerConfig.java
@@ -93,17 +93,17 @@ public class PlayerConfig {
 
 	private PlayConfig mode7 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default14(),
-			new PlayConfig.ControllerConfig[1],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default7() },
 			PlayConfig.MidiConfig.default7());
 
 	private PlayConfig mode14 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default14(),
-			new PlayConfig.ControllerConfig[2],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default7(), PlayConfig.ControllerConfig.default7() },
 			PlayConfig.MidiConfig.default14());
 
 	private PlayConfig mode9 = new PlayConfig(
 			PlayConfig.KeyboardConfig.default9(),
-			new PlayConfig.ControllerConfig[1],
+			new PlayConfig.ControllerConfig[] { PlayConfig.ControllerConfig.default9() },
 			PlayConfig.MidiConfig.default9());
 
 	private int musicselectinput = 0;

--- a/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -32,20 +32,19 @@ public class KeyConfiguration extends MainState {
 	private static final String[] MODE = { "7 KEYS", "9 KEYS", "14 KEYS" };
 
 	private static final String[][] KEYS = {
-			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "F-SCR", "R-SCR" },
-			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "8 KEY", "9 KEY" },
+			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "F-SCR", "R-SCR", "START", "SELECT" },
+			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "8 KEY", "9 KEY", "START", "SELECT" },
 			{ "1P-1 KEY", "1P-2 KEY", "1P-3 KEY", "1P-4 KEY", "1P-5 KEY", "1P-6 KEY", "1P-7 KEY", "1P-F-SCR",
 					"1P-R-SCR", "2P-1 KEY", "2P-2 KEY", "2P-3 KEY", "2P-4 KEY", "2P-5 KEY", "2P-6 KEY", "2P-7 KEY",
-					"2P-F-SCR", "2P-R-SCR" } };
-	private static final String[] CONTROLKEYS = { "START", "SELECT" };
-	private static final int[][] KEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 } };
-	private static final int[][] BMKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23, 24, 25, 26, 27, 28 } };
-	private static final int[][] MIDIKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 } };
+					"2P-F-SCR", "2P-R-SCR", "START", "SELECT" } };
+	private static final int[][] KEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, -1, -2 } };
+	private static final int[][] BMKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23, 24, 25, 26, 27, 28, -1, -2 } };
+	private static final int[][] MIDIKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, -1, -2 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, -1, -2 } };
 
 	private static final String[] SELECTKEY = {"2dx sp", "popn", "2dx dp"};
 
@@ -56,6 +55,16 @@ public class KeyConfiguration extends MainState {
 
 	private ShapeRenderer shape;
 
+	private BMSPlayerInputProcessor input;
+	private KeyBoardInputProcesseor keyboard;
+	private BMControllerInputProcessor[] controllers;
+	private MidiInputProcessor midiinput;
+
+	private PlayerConfig config;
+	private PlayConfig pc;
+	private KeyboardConfig keyboardConfig;
+	private ControllerConfig[] controller;
+	private MidiConfig midiconfig;
 
 	public KeyConfiguration(MainController main) {
 		super(main);
@@ -70,25 +79,17 @@ public class KeyConfiguration extends MainState {
 		parameter.size = 20;
 		titlefont = generator.generateFont(parameter);
 		shape = new ShapeRenderer();
+
+		input = getMainController().getInputProcessor();
+		keyboard = input.getKeyBoardInputProcesseor();
+		controllers = input.getBMInputProcessor();
+		midiinput = input.getMidiInputProcessor();
+		setMode(0);
 	}
 
 	public void render() {
 		final MainController main = getMainController();
 		final SpriteBatch sprite = main.getSpriteBatch();
-		BMSPlayerInputProcessor input = main.getInputProcessor();
-		PlayerConfig config = getMainController().getPlayerResource().getPlayerConfig();
-		BMControllerInputProcessor[] controllers = input.getBMInputProcessor();
-		MidiInputProcessor midiinput = input.getMidiInputProcessor();
-
-		String[] keys = KEYS[mode];
-		int[] keysa = KEYSA[mode];
-		int[] bmkeysa = BMKEYSA[mode];
-		int[] midikeysa = MIDIKEYSA[mode];
-		final PlayConfig pc = (mode == 0 ? config.getMode7() : (mode == 1 ? config.getMode9() : config
-				.getMode14()));
-		KeyboardConfig keyboardConfig = pc.getKeyboardConfig();
-		ControllerConfig[] controller = pc.getController();
-		MidiConfig midiconfig = pc.getMidiConfig();
 
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -96,6 +97,20 @@ public class KeyConfiguration extends MainState {
 		boolean[] cursor = input.getCursorState();
 		long[] cursortime = input.getCursorTime();
 		boolean[] number = input.getNumberState();
+		if (cursor[2] && cursortime[2] != 0) {
+			cursortime[2] = 0;
+			setMode((mode + KEYS.length - 1) % KEYS.length);
+		}
+		if (cursor[3] && cursortime[3] != 0) {
+			cursortime[3] = 0;
+			setMode((mode + 1) % KEYS.length);
+		}
+
+		String[] keys = KEYS[mode];
+		int[] keysa = KEYSA[mode];
+		int[] bmkeysa = BMKEYSA[mode];
+		int[] midikeysa = MIDIKEYSA[mode];
+
 		if (cursor[0] && cursortime[0] != 0) {
 			cursortime[0] = 0;
 			cursorpos = (cursorpos + keys.length - 1) % keys.length;
@@ -103,14 +118,6 @@ public class KeyConfiguration extends MainState {
 		if (cursor[1] && cursortime[1] != 0) {
 			cursortime[1] = 0;
 			cursorpos = (cursorpos + 1) % keys.length;
-		}
-		if (cursor[2] && cursortime[2] != 0) {
-			cursortime[2] = 0;
-			mode = (mode + KEYS.length - 1) % KEYS.length;
-		}
-		if (cursor[3] && cursortime[3] != 0) {
-			cursortime[3] = 0;
-			mode = (mode + 1) % KEYS.length;
 		}
 
 		if (number[1] && input.getNumberTime()[1] != 0) {
@@ -154,23 +161,20 @@ public class KeyConfiguration extends MainState {
 		}
 
 		if (keyinput && input.getKeyBoardInputProcesseor().getLastPressedKey() != -1) {
-			keyboardConfig.getKeyAssign()[keysa[cursorpos]] = input.getKeyBoardInputProcesseor().getLastPressedKey();
+			setKeyboardKeyAssign(keysa[cursorpos]);
 			// System.out.println(input.getKeyBoardInputProcesseor().getLastPressedKey());
 			keyinput = false;
 		}
 		for (BMControllerInputProcessor bmc : controllers) {
 			if (keyinput && bmc.getLastPressedButton() != -1) {
-				int index = bmkeysa[cursorpos];
-				if(bmc.getController().getName().equals(controller[index / 20].getName())) {
-					controller[index / 20].getKeyAssign()[bmkeysa[cursorpos] % 20] = bmc.getLastPressedButton();
-				}
+				setControllerKeyAssign(bmkeysa[cursorpos], bmc);
 //				System.out.println(bmc.getLastPressedButton());
 				keyinput = false;
 				break;
 			}
 		}
 		if (keyinput && midiinput.hasLastPressedKey()) {
-			midiconfig.setAssignment(midikeysa[cursorpos], midiinput.getLastPressedKey());
+			setMidiKeyAssign(midikeysa[cursorpos]);
 			keyinput = false;
 		}
 
@@ -202,19 +206,99 @@ public class KeyConfiguration extends MainState {
 			sprite.begin();
 			titlefont.setColor(Color.WHITE);
 			titlefont.draw(sprite, keys[i], 50, 598 - i * 24);
-			titlefont.draw(sprite, Keys.toString(keyboardConfig.getKeyAssign()[keysa[i]]), 202, 598 - i * 24);
-			
-			int index = bmkeysa[i];
-			
-			titlefont.draw(sprite, BMControllerInputProcessor.BMKeys.toString(controller[index / 20].getKeyAssign()[index % 20]), 352, 598 - i * 24);
-
-			titlefont.draw(sprite, midiconfig.getAssignment(midikeysa[i]).toString(), 502, 598 - i * 24);
+			titlefont.draw(sprite, Keys.toString(getKeyboardKeyAssign(keysa[i])), 202, 598 - i * 24);
+			titlefont.draw(sprite, BMControllerInputProcessor.BMKeys.toString(getControllerKeyAssign(bmkeysa[i])), 352, 598 - i * 24);
+			titlefont.draw(sprite, getMidiKeyAssign(midikeysa[i]).toString(), 502, 598 - i * 24);
 			sprite.end();
 		}
 
 		if (input.isExitPressed()) {
 			input.setExitPressed(false);
 			main.changeState(MainController.STATE_SELECTMUSIC);
+		}
+	}
+
+	private void setMode(int mode) {
+		this.mode = mode;
+		config = getMainController().getPlayerResource().getPlayerConfig();
+		switch (mode) {
+		case 0:
+			pc = config.getMode7();
+			break;
+		case 1:
+			pc = config.getMode9();
+			break;
+		case 2:
+			pc = config.getMode14();
+			break;
+		default:
+			pc = config.getMode7();
+		}
+		keyboardConfig = pc.getKeyboardConfig();
+		controller = pc.getController();
+		midiconfig = pc.getMidiConfig();
+	}
+
+	private int getKeyboardKeyAssign(int index) {
+		if (index >= 0) {
+			return keyboardConfig.getKeyAssign()[index];
+		} else if (index == -1) {
+			return keyboardConfig.getStart();
+		} else if (index == -2) {
+			return keyboardConfig.getSelect();
+		}
+		return 0;
+	}
+
+	private void setKeyboardKeyAssign(int index) {
+		if (index >= 0) {
+			keyboardConfig.getKeyAssign()[index] = keyboard.getLastPressedKey();
+		} else if (index == -1) {
+			keyboardConfig.setStart(keyboard.getLastPressedKey());
+		} else if (index == -2) {
+			keyboardConfig.setSelect(keyboard.getLastPressedKey());
+		}
+	}
+
+	private int getControllerKeyAssign(int index) {
+		if (index >= 0) {
+			return controller[index / 20].getKeyAssign()[index % 20];
+		} else if (index == -1) {
+			return controller[0].getStart();
+		} else if (index == -2) {
+			return controller[0].getSelect();
+		}
+		return 0;
+	}
+
+	private void setControllerKeyAssign(int index, BMControllerInputProcessor bmc) {
+		if (index >= 0 && bmc.getController().getName().equals(controller[index / 20].getName())) {
+			controller[index / 20].getKeyAssign()[index % 20] = bmc.getLastPressedButton();
+		} else if (index == -1 && bmc.getController().getName().equals(controller[0].getName())) {
+			controller[0].setStart(bmc.getLastPressedButton());
+		} else if (index == -2 && bmc.getController().getName().equals(controller[0].getName())) {
+			controller[0].setSelect(bmc.getLastPressedButton());
+		}
+	}
+
+	private MidiConfig.Input getMidiKeyAssign(int index) {
+		if (index >= 0) {
+			return midiconfig.getKeyAssign(index);
+		} else if (index == -1) {
+			return midiconfig.getStart();
+		} else if (index == -2) {
+			return midiconfig.getSelect();
+		}
+		return new MidiConfig.Input();
+	}
+
+	private void setMidiKeyAssign(int index) {
+		if (index >= 0) {
+			midiconfig.setKeyAssign(index, midiinput.getLastPressedKey());
+		} else if (index == -1) {
+			midiconfig.setStart(midiinput.getLastPressedKey());
+		} else if (index == -2) {
+			midiconfig.setSelect(midiinput.getLastPressedKey());
 		}
 	}
 

--- a/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -1,7 +1,9 @@
 package bms.player.beatoraja.config;
 
 import bms.player.beatoraja.*;
+import bms.player.beatoraja.PlayConfig.KeyboardConfig;
 import bms.player.beatoraja.PlayConfig.ControllerConfig;
+import bms.player.beatoraja.PlayConfig.MidiConfig;
 import bms.player.beatoraja.decide.MusicDecideSkin;
 import bms.player.beatoraja.input.*;
 
@@ -30,19 +32,20 @@ public class KeyConfiguration extends MainState {
 	private static final String[] MODE = { "7 KEYS", "9 KEYS", "14 KEYS" };
 
 	private static final String[][] KEYS = {
-			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "F-SCR", "R-SCR", "START", "SELECT" },
-			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "8 KEY", "9 KEY", "START", "SELECT" },
+			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "F-SCR", "R-SCR" },
+			{ "1 KEY", "2 KEY", "3 KEY", "4 KEY", "5 KEY", "6 KEY", "7 KEY", "8 KEY", "9 KEY" },
 			{ "1P-1 KEY", "1P-2 KEY", "1P-3 KEY", "1P-4 KEY", "1P-5 KEY", "1P-6 KEY", "1P-7 KEY", "1P-F-SCR",
 					"1P-R-SCR", "2P-1 KEY", "2P-2 KEY", "2P-3 KEY", "2P-4 KEY", "2P-5 KEY", "2P-6 KEY", "2P-7 KEY",
-					"2P-F-SCR", "2P-R-SCR", "START", "SELECT" } };
-	private static final int[][] KEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 18, 19 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 18, 19 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 } };
-	private static final int[][] BMKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23, 24, 25, 26, 27, 28, 9, 10 } };
-	private static final int[][] MIDIKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8, 18, 19 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 18, 19 },
-			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 } };
+					"2P-F-SCR", "2P-R-SCR" } };
+	private static final String[] CONTROLKEYS = { "START", "SELECT" };
+	private static final int[][] KEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 } };
+	private static final int[][] BMKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 }, { 0, 1, 2, 3, 4, 5, 6, 7, 8, 20, 21, 22, 23, 24, 25, 26, 27, 28 } };
+	private static final int[][] MIDIKEYSA = { { 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8 },
+			{ 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17 } };
 
 	private static final String[] SELECTKEY = {"2dx sp", "popn", "2dx dp"};
 
@@ -83,9 +86,9 @@ public class KeyConfiguration extends MainState {
 		int[] midikeysa = MIDIKEYSA[mode];
 		final PlayConfig pc = (mode == 0 ? config.getMode7() : (mode == 1 ? config.getMode9() : config
 				.getMode14()));
-		int[] keyassign = pc.getKeyassign();
+		KeyboardConfig keyboardConfig = pc.getKeyboardConfig();
 		ControllerConfig[] controller = pc.getController();
-		PlayConfig.MidiConfig midiconfig = pc.getMidiConfig();
+		MidiConfig midiconfig = pc.getMidiConfig();
 
 		Gdx.gl.glClearColor(0, 0, 0, 1);
 		Gdx.gl.glClear(GL20.GL_COLOR_BUFFER_BIT);
@@ -151,7 +154,7 @@ public class KeyConfiguration extends MainState {
 		}
 
 		if (keyinput && input.getKeyBoardInputProcesseor().getLastPressedKey() != -1) {
-			keyassign[keysa[cursorpos]] = input.getKeyBoardInputProcesseor().getLastPressedKey();
+			keyboardConfig.getKeyAssign()[keysa[cursorpos]] = input.getKeyBoardInputProcesseor().getLastPressedKey();
 			// System.out.println(input.getKeyBoardInputProcesseor().getLastPressedKey());
 			keyinput = false;
 		}
@@ -159,7 +162,7 @@ public class KeyConfiguration extends MainState {
 			if (keyinput && bmc.getLastPressedButton() != -1) {
 				int index = bmkeysa[cursorpos];
 				if(bmc.getController().getName().equals(controller[index / 20].getName())) {
-					controller[index / 20].getAssign()[bmkeysa[cursorpos] % 20] = bmc.getLastPressedButton();					
+					controller[index / 20].getKeyAssign()[bmkeysa[cursorpos] % 20] = bmc.getLastPressedButton();
 				}
 //				System.out.println(bmc.getLastPressedButton());
 				keyinput = false;
@@ -199,11 +202,11 @@ public class KeyConfiguration extends MainState {
 			sprite.begin();
 			titlefont.setColor(Color.WHITE);
 			titlefont.draw(sprite, keys[i], 50, 598 - i * 24);
-			titlefont.draw(sprite, Keys.toString(keyassign[keysa[i]]), 202, 598 - i * 24);
+			titlefont.draw(sprite, Keys.toString(keyboardConfig.getKeyAssign()[keysa[i]]), 202, 598 - i * 24);
 			
 			int index = bmkeysa[i];
 			
-			titlefont.draw(sprite, BMControllerInputProcessor.BMKeys.toString(controller[index / 20].getAssign()[index % 20]), 352, 598 - i * 24);
+			titlefont.draw(sprite, BMControllerInputProcessor.BMKeys.toString(controller[index / 20].getKeyAssign()[index % 20]), 352, 598 - i * 24);
 
 			titlefont.draw(sprite, midiconfig.getAssignment(midikeysa[i]).toString(), 502, 598 - i * 24);
 			sprite.end();

--- a/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.logging.Logger;
 
 import bms.player.beatoraja.Config;
+import bms.player.beatoraja.PlayConfig.ControllerConfig;
 import com.badlogic.gdx.controllers.Controller;
 import com.badlogic.gdx.controllers.ControllerListener;
 import com.badlogic.gdx.controllers.PovDirection;
@@ -48,20 +49,19 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice implements 
         private Config config;
         
 	public BMControllerInputProcessor(BMSPlayerInputProcessor bmsPlayerInputProcessor, Controller controller,
-			int[] buttons) {
+	                                  ControllerConfig controllerConfig) {
 		super(Type.BM_CONTROLLER);
 		config = new Config();
 		koc = config.getJKOC();
 		this.bmsPlayerInputProcessor = bmsPlayerInputProcessor;
 		this.controller = controller;
-		this.setControllerKeyAssign(buttons);
+		this.setConfig(controllerConfig);
 	}
 
-	public void setControllerKeyAssign(int[] buttons) {
-		this.buttons = new int[] { buttons[0], buttons[1], buttons[2], buttons[3], buttons[4], buttons[5], buttons[6],
-				buttons[7], buttons[8] };
-		this.start = buttons[9];
-		this.select = buttons[10];
+	public void setConfig(ControllerConfig controllerConfig) {
+		this.buttons = controllerConfig.getKeyAssign().clone();
+		this.start = controllerConfig.getStart();
+		this.select = controllerConfig.getSelect();
 	}
 	
 	public Controller getController() {

--- a/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
+import bms.player.beatoraja.PlayConfig.KeyboardConfig;
 import bms.player.beatoraja.PlayConfig.ControllerConfig;
 import bms.player.beatoraja.PlayConfig.MidiConfig;
 import bms.player.beatoraja.Resolution;
@@ -30,16 +31,12 @@ public class BMSPlayerInputProcessor {
 	private MidiInputProcessor midiinput;
 
 	public BMSPlayerInputProcessor(Resolution resolution) {
-		kbinput = new KeyBoardInputProcesseor(this, new int[] { Keys.Z, Keys.S, Keys.X, Keys.D, Keys.C, Keys.F, Keys.V,
-				Keys.SHIFT_LEFT, Keys.CONTROL_LEFT, Keys.COMMA, Keys.L, Keys.PERIOD, Keys.SEMICOLON, Keys.SLASH,
-				Keys.APOSTROPHE, Keys.UNKNOWN, Keys.SHIFT_RIGHT, Keys.CONTROL_RIGHT, Keys.Q, Keys.W }, resolution);
+		kbinput = new KeyBoardInputProcesseor(this, KeyboardConfig.default14(), resolution);
 		// Gdx.input.setInputProcessor(kbinput);
 		List<BMControllerInputProcessor> bminput = new ArrayList<BMControllerInputProcessor>();
 		for (Controller controller : Controllers.getControllers()) {
 			Logger.getGlobal().info("コントローラーを検出 : " + controller.getName());
-			BMControllerInputProcessor bm = new BMControllerInputProcessor(this, controller, new int[] {
-					BMKeys.BUTTON_3, BMKeys.BUTTON_6, BMKeys.BUTTON_2, BMKeys.BUTTON_7, BMKeys.BUTTON_1,
-					BMKeys.BUTTON_4, BMKeys.LEFT, BMKeys.UP, BMKeys.DOWN, BMKeys.BUTTON_8, BMKeys.BUTTON_9 });
+			BMControllerInputProcessor bm = new BMControllerInputProcessor(this, controller, new ControllerConfig());
 			// controller.addListener(bm);
 			bminput.add(bm);
 		}
@@ -112,8 +109,8 @@ public class BMSPlayerInputProcessor {
 		}
 	}
 
-	public void setKeyassign(int[] keyassign) {
-		kbinput.setKeyAssign(keyassign);
+	public void setKeyboardConfig(KeyboardConfig config) {
+		kbinput.setConfig(config);
 	}
         
 	public void setControllerConfig(ControllerConfig[] configs) {
@@ -129,7 +126,7 @@ public class BMSPlayerInputProcessor {
 				}
 				if(controller.getController().getName().equals(configs[i].getName())) {
 					player = i;
-					controller.setControllerKeyAssign(configs[i].getAssign());
+					controller.setConfig(configs[i]);
 					b[i] = true;
 					break;
 				}

--- a/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.input;
 
 import java.util.Arrays;
 
+import bms.player.beatoraja.PlayConfig.KeyboardConfig;
 import bms.player.beatoraja.Resolution;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.InputProcessor;
@@ -36,17 +37,16 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 
 	private Resolution resolution;
 
-	public KeyBoardInputProcesseor(BMSPlayerInputProcessor bmsPlayerInputProcessor, int[] keys, Resolution resolution) {
+	public KeyBoardInputProcesseor(BMSPlayerInputProcessor bmsPlayerInputProcessor, KeyboardConfig config, Resolution resolution) {
 		super(Type.KEYBOARD);
 		this.bmsPlayerInputProcessor = bmsPlayerInputProcessor;
-		this.setKeyAssign(keys);
+		this.setConfig(config);
 		this.resolution = resolution;
 	}
 
-	public void setKeyAssign(int[] keys) {
-		this.keys = new int[] { keys[0], keys[1], keys[2], keys[3], keys[4], keys[5], keys[6], keys[7], keys[8],
-				keys[9], keys[10], keys[11], keys[12], keys[13], keys[14], keys[15], keys[16], keys[17] };
-		this.control = new int[] { keys[18], keys[19] };
+	public void setConfig(KeyboardConfig config) {
+		this.keys = config.getKeyAssign().clone();
+		this.control = new int[] { config.getStart(), config.getSelect() };
 	}
 
 	public boolean keyDown(int keycode) {

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -254,7 +254,7 @@ public class BMSPlayer extends MainState {
 		PlayConfig pc = (model.getMode() == Mode.BEAT_5K || model.getMode() == Mode.BEAT_7K ? config.getMode7()
 				: (model.getMode() == Mode.BEAT_10K || model.getMode() == Mode.BEAT_14K ? config.getMode14()
 						: config.getMode9()));
-		input.setKeyassign(pc.getKeyassign());
+		input.setKeyboardConfig(pc.getKeyboardConfig());
 		input.setControllerConfig(pc.getController());
 		input.setMidiConfig(pc.getMidiConfig());
 		lanerender = new LaneRenderer(this, model);

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -140,7 +140,7 @@ public class MusicSelector extends MainState {
 		final BMSPlayerInputProcessor input = main.getInputProcessor();
 		PlayConfig pc = (config.getMusicselectinput() == 0 ? config.getMode7()
 				: (config.getMusicselectinput() == 1 ? config.getMode9() : config.getMode14()));
-		input.setKeyassign(pc.getKeyassign());
+		input.setKeyboardConfig(pc.getKeyboardConfig());
 		input.setControllerConfig(pc.getController());
 		input.setMidiConfig(pc.getMidiConfig());
 		bar.updateBar();


### PR DESCRIPTION
This PR changes some key configuration data structure in `PlayConfig` for future extension and refactors `KeyConfiguration`.

### PlayConfig changes

* Keyboard: `int[] keyassign` -> new class `KeyboardConfig`.
* BM Controller: `int[] assign` -> `int[] keys`, `int start` and `int select`.
* `start` and `select` are separated from keys for extensibility.
* These changes will reset user's key configuration data (except midi) made with old versions.