### PR TITLE
Accept resolutions smaller than the display in window mode

### DIFF
--- a/src/bms/player/beatoraja/MainLoader.java
+++ b/src/bms/player/beatoraja/MainLoader.java
@@ -145,6 +145,10 @@ public class MainLoader extends Application {
 		return LwjglApplicationConfiguration.getDisplayModes();
 	}
 
+	public static Graphics.DisplayMode getDesktopDisplayMode() {
+		return LwjglApplicationConfiguration.getDesktopDisplayMode();
+	}
+
 	@Override
 	public void start(javafx.stage.Stage primaryStage) throws Exception {
 		Config config = readConfig();

--- a/src/bms/player/beatoraja/PlayConfigurationView.fxml
+++ b/src/bms/player/beatoraja/PlayConfigurationView.fxml
@@ -33,7 +33,7 @@
                      <children>
                         <VBox prefHeight="200.0" prefWidth="552.0" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
                            <children>
-                              <CheckBox fx:id="fullscreen" mnemonicParsing="false" prefHeight="25.0" prefWidth="133.0" text="%FULLSCREEN" />
+                              <CheckBox fx:id="fullscreen" onAction="#updateResolutions" mnemonicParsing="false" prefHeight="25.0" prefWidth="133.0" text="%FULLSCREEN" />
                               <HBox alignment="CENTER_LEFT" prefHeight="30.0" prefWidth="552.0">
                                  <children>
                                     <Label text="%RESOLUTION" />

--- a/src/bms/player/beatoraja/PlayConfigurationView.java
+++ b/src/bms/player/beatoraja/PlayConfigurationView.java
@@ -235,16 +235,6 @@ public class PlayConfigurationView implements Initializable {
 			}
 		});
 		resolution.setButtonCell(new ResolutionListCell());
-		resolution.getItems().clear();
-		Graphics.DisplayMode[] displays = MainLoader.getAvailableDisplayMode();
-		for(Resolution r : Resolution.values()) {
-			for(Graphics.DisplayMode display : displays) {
-				if(display.width == r.width && display.height == r.height) {
-					resolution.getItems().add(r);
-					break;
-				}
-			}
-		}
 		initComboBox(scoreop, new String[] { "OFF", "MIRROR", "RANDOM", "R-RANDOM", "S-RANDOM", "SPIRAL", "H-RANDOM",
 				"ALL-SCR", "RANDOM-EX", "S-RANDOM-EX" });
 		initComboBox(gaugeop, new String[] { "ASSIST EASY", "EASY", "NORMAL", "HARD", "EX-HARD", "HAZARD" });
@@ -291,8 +281,9 @@ public class PlayConfigurationView implements Initializable {
 	 */
 	public void update(Config config) {
 		this.config = config;
-		resolution.setValue(config.getResolution());
 		fullscreen.setSelected(config.isFullscreen());
+		updateResolutions();
+		resolution.setValue(config.getResolution());
 		vsync.setSelected(config.isVsync());
 		bgaop.setValue(config.getBga());
 		bgaexpand.setValue(config.getBgaExpand());
@@ -334,6 +325,32 @@ public class PlayConfigurationView implements Initializable {
 
 		updateAudioDriver();
 		updatePlayer();
+	}
+
+	@FXML
+	public void updateResolutions() {
+		Resolution oldValue = resolution.getValue();
+		resolution.getItems().clear();
+		if (fullscreen.isSelected()) {
+			Graphics.DisplayMode[] displays = MainLoader.getAvailableDisplayMode();
+			for(Resolution r : Resolution.values()) {
+				for(Graphics.DisplayMode display : displays) {
+					if(display.width == r.width && display.height == r.height) {
+						resolution.getItems().add(r);
+						break;
+					}
+				}
+			}
+		} else {
+			Graphics.DisplayMode display = MainLoader.getDesktopDisplayMode();
+			for(Resolution r : Resolution.values()) {
+				if (r.width <= display.width && r.height <= display.height) {
+					resolution.getItems().add(r);
+				}
+			}
+		}
+		resolution.setValue(resolution.getItems().contains(oldValue)
+				? oldValue : resolution.getItems().get(resolution.getItems().size() - 1));
 	}
 
 	public void updatePlayer() {


### PR DESCRIPTION
* Some devices with weird display size or aspect ratio (for example, MacBook) may reject some resolutions even if they are smaller than the display. Such resolutions should still be accepted in window mode.

* 私のMacBook Airの画面サイズ自体はHDより大きいのですが、HDのディスプレイモードに対応していないので（ウィンドウモードであっても）HDが選択できないという問題がありました。そのため、ウィンドウモードの場合は画面サイズ以下の解像度を選択できるように改善しました。