### PR TITLE
Enable all devices in practice mode

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -263,8 +263,10 @@ public class BMSPlayer extends MainState {
 
 		final BMSPlayerInputProcessor input = main.getInputProcessor();
 		input.setMinimumInputDutration(conf.getInputduration());
-		if (autoplay == 0 || autoplay == 2) {
+		if (autoplay == 0) {
 			input.setExclusiveDeviceType(resource.getPlayDeviceType());
+		} else if (autoplay == 2) {
+			input.enableAllDevices();
 		} else {
 			input.disableAllDevices();
 		}


### PR DESCRIPTION
Device restriction in practice mode had some problems:

* When beatoraja is invoked by an external viewer with command line arguments, input is always restricted to the keyboard.
* The second and further plays in practice mode accept all devices.

So I modified the behavior to enable all devices.

`-p` 引数で起動した場合はデバイス制限のタイミングを遅らせるなどの方法も考えられますが、ややこしいですし practice mode では制限の必要性が薄いので無制限に変更しました。