### PR TITLE
Autoplay keybeam

### DIFF
--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -108,7 +108,7 @@ public class JudgeManager {
 	/**
 	 * オートプレイでキーを押下する最小時間(ms)
 	 */
-	private final int auto_minduration = 100;
+	private final int auto_minduration = 80;
 
 	private final JudgeAlgorithm algorithm;
 

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -169,13 +169,16 @@ public class JudgeManager {
 		// 通過系の判定
 		Arrays.fill(next_inclease, false);
 		
-		for (int key = 0; key < keyassign.length; key++) {
-			final int lane = keyassign[key];
-			if(lane == -1) {
-				continue;
-			}
+		for (int lane = 0; lane < laneassign.length; lane++) {
 			final Lane lanemodel = lanes[lane];
 			lanemodel.mark(prevtime + njudge[4][0]);
+			boolean pressed = false;
+			for (int key : laneassign[lane]) {
+				if (keystate[key]) {
+					pressed = true;
+					break;
+				}
+			}
 			for(Note note = lanemodel.getNote();note != null && note.getTime() <= time;note = lanemodel.getNote()) {
 				if (note instanceof LongNote) {
 					// HCN判定
@@ -189,7 +192,7 @@ public class JudgeManager {
 							passing[lane] = lnote;								
 						}
 					}
-				} else if (note instanceof MineNote && keystate[key]) {
+				} else if (note instanceof MineNote && pressed) {
 					final MineNote mnote = (MineNote) note;
 					// 地雷ノート判定
 					main.getGauge().addValue(-mnote.getDamage());
@@ -227,7 +230,7 @@ public class JudgeManager {
 				}
 			}
 			// HCNゲージ増減判定
-			if (passing[lane] != null && (keystate[key] || (passing[lane].getPair().getState() > 0 && passing[lane].getPair().getState() <= 3) || autoplay)) {
+			if (passing[lane] != null && (pressed || (passing[lane].getPair().getState() > 0 && passing[lane].getPair().getState() <= 3) || autoplay)) {
 				next_inclease[lane] = true;
 			}
 		}

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -237,6 +237,10 @@ public class JudgeManager {
 							if ((lntype != BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
 									|| ln.getType() == LongNote.TYPE_CHARGENOTE
 									|| ln.getType() == LongNote.TYPE_HELLCHARGENOTE) {
+								if (sckeyassign[lane] >= 0 && laneassign[lane].length >= 2) {
+									auto_presstime[laneassign[lane][0]] = Long.MIN_VALUE;
+									auto_presstime[laneassign[lane][1]] = now;
+								}
 								this.update(lane, ln, time, 0, 0);
 								main.play(processing[lane], config.getKeyvolume());
 								processing[lane] = null;
@@ -251,9 +255,10 @@ public class JudgeManager {
 			}
 
 			if (autoplay) {
-				// TODO: BSS終端で逆方向に回す
-				if (auto_presstime[laneassign[lane][0]] != Long.MIN_VALUE && now - auto_presstime[laneassign[lane][0]] > auto_minduration && processing[lane] == null) {
-					auto_presstime[laneassign[lane][0]] = Long.MIN_VALUE;
+				for (int key : laneassign[lane]) {
+					if (auto_presstime[key] != Long.MIN_VALUE && now - auto_presstime[key] > auto_minduration && processing[lane] == null) {
+						auto_presstime[key] = Long.MIN_VALUE;
+					}
 				}
 			}
 		}

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -78,6 +78,7 @@ public class JudgeManager {
 	private int[] sckey;
 	private int[] offset;
 	private int[] player;
+	private int[][] laneassign;
 	/**
 	 * HCNの増減間隔(ms)
 	 */
@@ -103,6 +104,11 @@ public class JudgeManager {
 	private int prevtime;
 
 	private boolean autoplay = false;
+	private long[] auto_presstime;
+	/**
+	 * オートプレイでキーを押下する最小時間(ms)
+	 */
+	private final int auto_minduration = 100;
 
 	private final JudgeAlgorithm algorithm;
 
@@ -129,6 +135,7 @@ public class JudgeManager {
 		offset = main.getLaneProperty().getLaneSkinOffset();
 		player = main.getLaneProperty().getLanePlayer();
 		sckeyassign = main.getLaneProperty().getLaneScratchAssign();
+		laneassign = main.getLaneProperty().getLaneKeyAssign();
 		sckey = new int[model.getMode().scratchKey.length];
 
 		judge = new int[model.getMode().player][model.getMode().key / model.getMode().player + 1];
@@ -137,6 +144,11 @@ public class JudgeManager {
 		passingcount = new int[sckeyassign.length];
 		inclease = new boolean[sckeyassign.length];
 		next_inclease = new boolean[sckeyassign.length];
+		auto_presstime = new long[keyassign.length];
+
+		for (int key = 0; key < keyassign.length; key++) {
+			auto_presstime[key] = Long.MIN_VALUE;
+		}
 
 		final int judgerank = resource.getPlayerConfig().isExpandjudge() ? model.getJudgerank() * 4 : model.getJudgerank();
 		int constraint = 2;
@@ -166,6 +178,8 @@ public class JudgeManager {
 		final Config config = main.getMainController().getPlayerResource().getConfig();
 		final long[] keytime = input.getTime();
 		final boolean[] keystate = input.getKeystate();
+		final long[] timer = main.getTimer();
+		final int now = main.getNowTime();
 		// 通過系の判定
 		Arrays.fill(next_inclease, false);
 		
@@ -202,12 +216,14 @@ public class JudgeManager {
 				if (autoplay) {
 					// ここにオートプレイ処理を入れる
 					if (note instanceof NormalNote && note.getState() == 0) {
+						auto_presstime[laneassign[lane][0]] = now;
 						main.play(note, config.getKeyvolume());
 						this.update(lane, note, time, 0, 0);
 					}
 					if (note instanceof LongNote) {
 						final LongNote ln = (LongNote) note;
 						if (!ln.isEnd() && ln.getState() == 0 && processing[lane] == null) {
+							auto_presstime[laneassign[lane][0]] = now;
 							main.play(note, config.getKeyvolume());
 							if ((lntype == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
 									|| ln.getType() == LongNote.TYPE_LONGNOTE) {
@@ -233,13 +249,19 @@ public class JudgeManager {
 			if (passing[lane] != null && (pressed || (passing[lane].getPair().getState() > 0 && passing[lane].getPair().getState() <= 3) || autoplay)) {
 				next_inclease[lane] = true;
 			}
+
+			if (autoplay) {
+				// TODO: BSS終端で逆方向に回す
+				if (auto_presstime[laneassign[lane][0]] != Long.MIN_VALUE && now - auto_presstime[laneassign[lane][0]] > auto_minduration && processing[lane] == null) {
+					auto_presstime[laneassign[lane][0]] = Long.MIN_VALUE;
+				}
+			}
 		}
 		
 		final boolean[] b = inclease;
 		inclease = next_inclease;
 		next_inclease = b;
 
-		final long[] timer = main.getTimer();
 		for (int lane = 0; lane < passing.length; lane++) {
 			final int offset = main.getLaneProperty().getLaneSkinOffset()[lane];
 			final int timerActive = SkinPropertyMapper.hcnActiveTimerId(main.getLaneProperty().getLanePlayer()[lane], offset);
@@ -260,7 +282,7 @@ public class JudgeManager {
 					passingcount[lane] -= hcnduration;
 				}
 				if(timer[timerActive] == Long.MIN_VALUE) {
-					timer[timerActive] = main.getNowTime();
+					timer[timerActive] = now;
 				}
 				timer[timerDamage] = Long.MIN_VALUE;
 			} else {
@@ -271,7 +293,7 @@ public class JudgeManager {
 					passingcount[lane] += hcnduration;
 				}
 				if(timer[timerDamage] == Long.MIN_VALUE) {
-					timer[timerDamage] = main.getNowTime();
+					timer[timerDamage] = now;
 				}
 				timer[timerActive] = Long.MIN_VALUE;
 			}
@@ -485,7 +507,7 @@ public class JudgeManager {
 			int timerId = SkinPropertyMapper.holdTimerId(player[lane], offset[lane]);
 			if (processing[lane] != null || (passing[lane] != null && inclease[lane])) {
 				if (main.getTimer()[timerId] == Long.MIN_VALUE) {
-					main.getTimer()[timerId] = main.getNowTime();
+					main.getTimer()[timerId] = now;
 				}
 			} else {
 				main.getTimer()[timerId] = Long.MIN_VALUE;
@@ -541,6 +563,10 @@ public class JudgeManager {
 
 	public boolean[] getHellChargeJudges() {
 		return inclease;
+	}
+
+	public long[] getAutoPresstime() {
+		return auto_presstime;
 	}
 
 	/**

--- a/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -43,14 +43,14 @@ class KeyInputProccessor {
 		final long[] timer = player.getTimer();
 		final JudgeManager judge = player.getJudgeManager();
 		final boolean[] keystate = player.getMainController().getInputProcessor().getKeystate();
+		final long[] auto_presstime = judge.getAutoPresstime();
 
 		for (int lane = 0; lane < player.getLaneProperty().getLaneSkinOffset().length; lane++) {
 			// キービームフラグON/OFF
 			final int offset = player.getLaneProperty().getLaneSkinOffset()[lane];
 			boolean pressed = false;
-			for (int i = 0; i < player.getLaneProperty().getLaneKeyAssign()[lane].length; i++) {
-				int key = player.getLaneProperty().getLaneKeyAssign()[lane][i];
-				if (key >= 0 && keystate[key]) {
+			for (int key : player.getLaneProperty().getLaneKeyAssign()[lane]) {
+				if (keystate[key] || auto_presstime[key] != Long.MIN_VALUE) {
 					pressed = true;
 					break;
 				}
@@ -75,9 +75,11 @@ class KeyInputProccessor {
 			for (int s = 0; s < scratch.length; s++) {
 				scratch[s] += s % 2 == 0 ? 2160 - deltatime : deltatime;
 				if (s < player.getLaneProperty().getScratchKeyAssign().length) {
-					if (keystate[player.getLaneProperty().getScratchKeyAssign()[s][0]]) {
+					int key0 = player.getLaneProperty().getScratchKeyAssign()[s][0];
+					int key1 = player.getLaneProperty().getScratchKeyAssign()[s][1];
+					if (keystate[key0] || auto_presstime[key0] != Long.MIN_VALUE) {
 						scratch[s] += deltatime * 2;
-					} else if (keystate[player.getLaneProperty().getScratchKeyAssign()[s][1]]) {
+					} else if (keystate[key1] || auto_presstime[key1] != Long.MIN_VALUE) {
 						scratch[s] += 2160 - deltatime * 2;
 					}
 				}

--- a/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -63,7 +63,7 @@ class KeyInputProccessor {
 					timer[timerOff] = Long.MIN_VALUE;
 				}
 			} else {
-				if (timer[timerOff] == Long.MIN_VALUE) {
+				if (timer[timerOn] != Long.MIN_VALUE) {
 					timer[timerOff] = now;
 					timer[timerOn] = Long.MIN_VALUE;
 				}


### PR DESCRIPTION
* Show keybeams during autoplay
  - Turntables are also rotated
* Fix a bug that key-off timers are played at the beginning of a song

----

* `JudgeManager` 内でビーム表示の処理を行うと煩雑である一方、`keystate` を直接書き換えると危険（中断時に押しっぱなしになってしまい、他の画面の操作に影響してしまうなど）なため、オートプレイ用のキー押下状態を記憶する `auto_presstime` を導入し、それを `KeyInputProcessor` から参照するようにしています。
* デフォルトスキンは、オートプレイ時の見栄えを考慮するとキービームにkey-offのアニメーションも導入したほうが良いかもしれません。