### PR TITLE
Fix judge number position when using LIFT

### DIFF
--- a/skin/default/play10.json
+++ b/skin/default/play10.json
@@ -371,27 +371,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]}
@@ -428,27 +428,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]}

--- a/skin/default/play14.json
+++ b/skin/default/play14.json
@@ -375,27 +375,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}
@@ -432,27 +432,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]}

--- a/skin/default/play24.json
+++ b/skin/default/play24.json
@@ -452,27 +452,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play24_hplus.json
+++ b/skin/default/play24_hplus.json
@@ -452,27 +452,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play24_sep.json
+++ b/skin/default/play24_sep.json
@@ -452,27 +452,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play24double.json
+++ b/skin/default/play24double.json
@@ -634,27 +634,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}
@@ -691,27 +691,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play24double_hplus.json
+++ b/skin/default/play24double_hplus.json
@@ -635,27 +635,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}
@@ -692,27 +692,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play5.json
+++ b/skin/default/play5.json
@@ -318,27 +318,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]}

--- a/skin/default/play5_2.json
+++ b/skin/default/play5_2.json
@@ -318,27 +318,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 					{"time":0, "x":200, "y":0, "w":40, "h":40},
 					{"time":500}
 				]}

--- a/skin/default/play7.json
+++ b/skin/default/play7.json
@@ -320,27 +320,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play7_2.json
+++ b/skin/default/play7_2.json
@@ -320,27 +320,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":200, "y":0, "w":40, "h":40},
 				{"time":500}
 			]}

--- a/skin/default/play9.json
+++ b/skin/default/play9.json
@@ -380,27 +380,27 @@
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46 ,"offsety":50, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]}
@@ -437,27 +437,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":47 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]}
@@ -494,27 +494,27 @@
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":247 ,"offsety":50, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":247, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]}


### PR DESCRIPTION
The positions of `numbers` should not be lifted by LIFT option because they are relative to the judge images.