### PR TITLE
Fix table accessor and music select screen for songs without MD5

### DIFF
--- a/src/bms/player/beatoraja/TableDataAccessor.java
+++ b/src/bms/player/beatoraja/TableDataAccessor.java
@@ -210,7 +210,12 @@ public class TableDataAccessor {
 							SongData[] songs = new SongData[g.getHash().length];
 							for(int i = 0;i < songs.length;i++) {
 								songs[i] = new SongData();
-								songs[i].setMd5(g.getHash()[i]);
+								final String hash = g.getHash()[i];
+								if (hash.length() == 32) {
+									songs[i].setMd5(hash);
+								} else if (hash.length() == 64) {
+									songs[i].setSha256(hash);
+								}
 							}
 							cd.setSong(songs);
 							List<CourseData.CourseDataConstraint> l = new ArrayList<>();

--- a/src/bms/player/beatoraja/select/Bar.java
+++ b/src/bms/player/beatoraja/select/Bar.java
@@ -415,7 +415,7 @@ class TableBar extends DirectoryBar {
 			for (SongData hash : course.getSong()) {
 				SongData song = null;
 				for(SongData sd :songs) {
-					if(hash.getMd5().equals(sd.getMd5()) || hash.getSha256().equals(sd.getSha256())) {
+					if((hash.getMd5().length() > 0 && hash.getMd5().equals(sd.getMd5())) || (hash.getSha256().length() > 0 && hash.getSha256().equals(sd.getSha256()))) {
 						song = sd;
 						break;
 					}
@@ -491,7 +491,8 @@ class HashBar extends DirectoryBar {
         for(SongData element : elements) {
             boolean exist = false;
             for (SongData song : songs) {
-                if(element.getMd5().equals(song.getMd5()) || element.getSha256().equals(song.getSha256())) {
+                if((element.getMd5().length() > 0 && element.getMd5().equals(song.getMd5()))
+                        || (element.getSha256().length() > 0 && element.getSha256().equals(song.getSha256()))) {
                     songbars.add(new SongBar(song));
                     exist = true;
                     break;


### PR DESCRIPTION
* Fixed a bug that hash folders make wrong results if data does not have MD5.
* Allow `Course` to have SHA-256 as hash.
  - [jbmstable-parser](https://github.com/exch-bms2/jbmstable-parser) のダウンロードしたコースデータからハッシュを取得する部分もMD5とSHA-256の両方を想定するように微修正するのが好ましいですが別件ということにします。（修正なしでも `md5` フィールドにSHA-256を格納することができるので動作上は問題ありませんが）