### PR TITLE
for beatoraja in UNC Path (such as a NAS)

### DIFF
--- a/beatoraja-config.bat
+++ b/beatoraja-config.bat
@@ -1,3 +1,5 @@
 REM *** Set system-wide "_JAVA_OPTIONS" environment variable to use OpenGL pipeline (improved performance of > 30% potentially. Also use anti-aliasing for non-LR2 fonts, and finally allow Swing framework to utilize AA and GTKLookAndFeel for config window. ***
 set _JAVA_OPTIONS='-Dsun.java2d.opengl=true -Dawt.useSystemAAFontSettings=on -Dswing.aatext=true -Dswing.defaultlaf=com.sun.java.swing.plaf.gtk.GTKLookAndFeel'
+pushd %~dp0
 java -Xms1g -Xmx4g -jar beatoraja.jar -c
+popd


### PR DESCRIPTION
ほんのちょっとした違いでしかありませんが、この2行を加えることで、beatoraja本体一式をUNCパス上、例えばNASに保存しているような特殊な環境（ちなみにウチの環境です。）、例：\\MY_NAS\BMS_software\beatoraja\~~ といったパスでも利用することができました。

※ドライブ文字を割り当ててネットワークドライブにしろよという突っ込みもあるにはあるのでしょうけど……