### PR TITLE
GrooveGauge : add LR2 GRADE 

### DIFF
--- a/src/bms/player/beatoraja/ClearType.java
+++ b/src/bms/player/beatoraja/ClearType.java
@@ -2,7 +2,7 @@ package bms.player.beatoraja;
 
 /**
  * クリアタイプ
- * 
+ *
  * @author exch
  */
 public enum ClearType {
@@ -12,7 +12,7 @@ public enum ClearType {
     AssistEasy(2, new int[]{}),
     LightAssistEasy(3, new int[]{0}),
     Easy(4, new int[]{1}),
-    Normal(5, new int[]{2, 6}),
+    Normal(5, new int[]{2, 6, 9}),
     Hard(6, new int[]{3, 7}),
     ExHard(7, new int[]{4, 8}),
     FullCombo(8, new int[]{5}),

--- a/src/bms/player/beatoraja/CourseData.java
+++ b/src/bms/player/beatoraja/CourseData.java
@@ -59,7 +59,8 @@ public class CourseData {
 
     public boolean isClassCourse() {
         for(CourseDataConstraint con : constraint) {
-            if(con == CourseDataConstraint.CLASS || con == CourseDataConstraint.MIRROR || con == CourseDataConstraint.RANDOM) {
+            if(con == CourseDataConstraint.CLASS || con == CourseDataConstraint.MIRROR || con == CourseDataConstraint.RANDOM
+            		|| con == CourseDataConstraint.LR2GRADE) {
                 return true;
             }
         }
@@ -77,7 +78,8 @@ public class CourseData {
         RANDOM(3,"grade_random"),
         NO_SPEED(4,"no_speed"),
         NO_GOOD(5,"no_good"),
-        NO_GREAT(6,"no_great");
+        NO_GREAT(6,"no_great"),
+    	LR2GRADE(7,"lr2grade");
 
         public final int id;
         public final String name;

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -230,7 +230,6 @@ public class BMSPlayer extends MainState {
 		if(resource.getCourseBMSModels() != null){
 			coursetype = 1;
 			for (CourseData.CourseDataConstraint i : resource.getConstraint()) {
-				Logger.getGlobal().info(i.name);
 				if (i == LR2GRADE) {
 					coursetype = 2;
 					break;

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -19,6 +19,7 @@ import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.*;
 
 import static bms.player.beatoraja.CourseData.CourseDataConstraint.NO_SPEED;
+import static bms.player.beatoraja.CourseData.CourseDataConstraint.LR2GRADE;
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
 /**
@@ -170,7 +171,7 @@ public class BMSPlayer extends MainState {
 				score = false;
 			}
 		}
-		
+
 		Logger.getGlobal().info("譜面オプション設定");
 		if (replay != null) {
 			PatternModifier.modify(model, Arrays.asList(replay.pattern));
@@ -225,7 +226,18 @@ public class BMSPlayer extends MainState {
 		}
 		if(replay != null && main.getInputProcessor().getKeystate()[5]) {
 		}
-		gauge = GrooveGauge.create(model, replay != null ? replay.gauge : config.getGauge(), resource.getCourseBMSModels() != null);
+		int coursetype = 0;
+		if(resource.getCourseBMSModels() != null){
+			coursetype = 1;
+			for (CourseData.CourseDataConstraint i : resource.getConstraint()) {
+				Logger.getGlobal().info(i.name);
+				if (i == LR2GRADE) {
+					coursetype = 2;
+					break;
+				}
+			}
+		}
+		gauge = GrooveGauge.create(model, replay != null ? replay.gauge : config.getGauge(), coursetype);
 		FloatArray f = resource.getGauge();
 		if (f != null) {
 			gauge.setValue(f.get(f.size - 1));
@@ -442,7 +454,7 @@ public class BMSPlayer extends MainState {
 			break;
 		// プレイ
 		case STATE_PLAY:
-			final long deltatime = micronow - prevtime;			
+			final long deltatime = micronow - prevtime;
 			final long deltaplay = deltatime * (100 - playspeed) / 100;
 			deltaplaymicro += deltaplay % 1000;
             timer[TIMER_PLAY] += deltaplay / 1000;
@@ -451,7 +463,7 @@ public class BMSPlayer extends MainState {
             	deltaplaymicro -= 1000;
             } else if(deltaplaymicro <= -1000) {
                 timer[TIMER_PLAY]--;;
-            	deltaplaymicro += 1000;            	
+            	deltaplaymicro += 1000;
             }
             timer[TIMER_RHYTHM] += deltatime * (100 - lanerender.getNowBPM() * 100 / 60) / 100000;
             final long ptime = now - timer[TIMER_PLAY];
@@ -554,7 +566,7 @@ public class BMSPlayer extends MainState {
 			}
 			break;
 		}
-		
+
 		prevtime = micronow;
 	}
 
@@ -717,7 +729,7 @@ public class BMSPlayer extends MainState {
 			//フルコン判定
 			if(getTimer()[TIMER_FULLCOMBO_1P] == Long.MIN_VALUE && this.judge.getJudgeCount(3) == 0
 				&& this.judge.getJudgeCount(4) == 0) {
-				getTimer()[TIMER_FULLCOMBO_1P] = getNowTime();				
+				getTimer()[TIMER_FULLCOMBO_1P] = getNowTime();
 			}
 		}
 
@@ -738,7 +750,7 @@ public class BMSPlayer extends MainState {
 		private boolean stop = false;
 
 		private final long starttime;
-		
+
 		public AutoplayThread(long starttime) {
 			this.starttime = starttime;
 		}

--- a/src/bms/player/beatoraja/play/GaugeProperty.java
+++ b/src/bms/player/beatoraja/play/GaugeProperty.java
@@ -17,6 +17,7 @@ public enum GaugeProperty {
             GaugeElementProperty.CLASS,
             GaugeElementProperty.EXCLASS,
             GaugeElementProperty.EXHARDCLASS,
+            GaugeElementProperty.LR2CLASS,
     }),
     PMS(new GaugeElementProperty[]{
             GaugeElementProperty.ASSIST_EASY_PMS,
@@ -28,6 +29,7 @@ public enum GaugeProperty {
             GaugeElementProperty.CLASS_PMS,
             GaugeElementProperty.EXCLASS_PMS,
             GaugeElementProperty.EXHARDCLASS_PMS,
+            GaugeElementProperty.LR2CLASS_PMS,
     }),
     KEYBOARD(new GaugeElementProperty[]{
             GaugeElementProperty.ASSIST_EASY_KB,
@@ -39,6 +41,7 @@ public enum GaugeProperty {
             GaugeElementProperty.CLASS_KB,
             GaugeElementProperty.EXCLASS_KB,
             GaugeElementProperty.EXHARDCLASS_KB,
+            GaugeElementProperty.LR2CLASS_KB,
     }),
     ;
 
@@ -64,6 +67,7 @@ public enum GaugeProperty {
         CLASS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.12f, 0.06f, -1.5f, -3f, -1.5f}, new float[][]{{5, 0.4f},{10, 0.5f},{15, 0.6f},{20, 0.7f},{25, 0.8f}}),
         EXCLASS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.12f, 0.03f, -3.0f, -6.0f, -3.0f}, new float[][]{}),
         EXHARDCLASS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.06f, 0, -5.0f, -10.0f, -5.0f}, new float[][]{}),
+        LR2CLASS(1 ,0 ,100 ,100, 0, new float[]{0.10f, 0.10f, 0.05f, -2f, -3f, -2f}, new float[][]{{30, 0.6f}}),
         
         ASSIST_EASY_PMS(0 ,2, 120, 30, 65, new float[]{1.0f, 1.0f, 0.5f, -1.0f, -2.0f, -2.0f}, new float[][]{}),
         EASY_PMS(0 ,2, 120, 30, 85, new float[]{1.0f, 1.0f, 0.5f, -1.0f, -3.0f, -3.0f}, new float[][]{}),
@@ -74,6 +78,7 @@ public enum GaugeProperty {
         CLASS_PMS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.12f, 0.06f, -1.5f, -3f, -3f}, new float[][]{{5, 0.4f},{10, 0.5f},{15, 0.6f},{20, 0.7f},{25, 0.8f}}),
         EXCLASS_PMS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.12f, 0.03f, -3.0f, -6.0f, -6.0f}, new float[][]{}),
         EXHARDCLASS_PMS(1 ,0 ,100 ,100, 0, new float[]{0.15f, 0.06f, 0, -5.0f, -10.0f, -10.0f}, new float[][]{}),
+        LR2CLASS_PMS(1 ,0 ,100 ,100, 0, new float[]{0.10f, 0.10f, 0.05f, -2f, -3f, -2f}, new float[][]{{30, 0.6f}}),
 
         ASSIST_EASY_KB(0 ,2, 100, 30, 50, new float[]{1.0f, 1.0f, 0.5f, -1.0f, -2.0f, -1.0f}, new float[][]{}),
         EASY_KB(0 ,2, 100, 20, 70, new float[]{1.0f, 1.0f, 0.5f, -1.0f, -3.0f, -1.0f}, new float[][]{}),
@@ -84,6 +89,7 @@ public enum GaugeProperty {
         CLASS_KB(1 ,0 ,100 ,100, 0, new float[]{0.2f, 0.2f, 0.1f, -1.5f, -3f, -1.5f}, new float[][]{{5, 0.4f},{10, 0.5f},{15, 0.6f},{20, 0.7f},{25, 0.8f}}),
         EXCLASS_KB(1 ,0 ,100 ,100, 0, new float[]{0.2f, 0.2f, 0.1f, -3.0f, -6.0f, -3.0f}, new float[][]{}),
         EXHARDCLASS_KB(1 ,0 ,100 ,100, 0, new float[]{0.2f, 0.1f, 0, -5.0f, -10.0f, -5.0f}, new float[][]{}),
+        LR2CLASS_KB(1 ,0 ,100 ,100, 0, new float[]{0.10f, 0.10f, 0.05f, -2f, -3f, -2f}, new float[][]{{30, 0.6f}}),
         ;
 
         /**

--- a/src/bms/player/beatoraja/play/GrooveGauge.java
+++ b/src/bms/player/beatoraja/play/GrooveGauge.java
@@ -21,6 +21,7 @@ public class GrooveGauge {
 	public static final int CLASS = 6;
 	public static final int EXCLASS = 7;
 	public static final int EXHARDCLASS = 8;
+	public static final int LR2CLASS = 9;
 
 	private int type = -1;
 	/**
@@ -138,10 +139,12 @@ public class GrooveGauge {
 		return property.border;
 	}
 
-	public static GrooveGauge create(BMSModel model, int type, boolean grade) {
+	public static GrooveGauge create(BMSModel model, int type, int grade) {
 		int id = -1;
-		if (grade) {	
+		if (grade > 0) {
 			id = type <= 2 ? 6 : (type == 3 ? 7 : 8); 
+			if(grade == 2)
+				id = id == 6 ? 9 : id;
 			// 段位ゲージ
 		} else {
 			id = type;

--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -34,7 +34,7 @@ public class PracticeConfiguration {
 	private BMSModel model;
 
 	private static final String[] GAUGE = { "ASSIST EASY", "EASY", "NORMAL", "HARD", "EX-HARD", "HAZARD", "GRADE",
-			"EX GRADE", "EXHARD GRADE" };
+			"EX GRADE", "EXHARD GRADE", "LR2 GRADE" };
 	private static final String[] RANDOM = { "NORMAL", "MIRROR", "RANDOM", "R-RANDOM", "S-RANDOM", "SPIRAL", "H-RANDOM",
 			"ALL-SCR", "RANDOM-EX", "S-RANDOM-EX" };
 	private static final String[] DPRANDOM = { "NORMAL", "FLIP" };
@@ -122,7 +122,7 @@ public class PracticeConfiguration {
 				}
 				break;
 			case 2:
-				property.gaugetype = (property.gaugetype + 8) % 9;
+				property.gaugetype = (property.gaugetype + 9) % 10;
 				if ((model.getMode() == Mode.POPN_5K || model.getMode() == Mode.POPN_9K) && property.gaugetype >= 3
 						&& property.startgauge > 100) {
 					property.startgauge = 100;
@@ -181,7 +181,7 @@ public class PracticeConfiguration {
 				}
 				break;
 			case 2:
-				property.gaugetype = (property.gaugetype + 1) % 9;
+				property.gaugetype = (property.gaugetype + 1) % 10;
 				if ((model.getMode() == Mode.POPN_5K || model.getMode() == Mode.POPN_9K) && property.gaugetype >= 3 && property.startgauge > 100) {
 					property.startgauge = 100;
 				}

--- a/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
+++ b/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
@@ -57,7 +57,7 @@ public class SkinGaugeGraphObject extends SkinObject {
 			Color.valueOf("ff0000"), Color.valueOf("ffff00"), Color.valueOf("cccccc") };
 	private final Color borderline = Color.valueOf("ff0000");
 	private final Color bordercolor = Color.valueOf("440000");
-	private final int[] typetable = {0,1,2,3,4,5,3,4,5};
+	private final int[] typetable = {0,1,2,3,4,5,3,4,5,3};
 
 	private int color;
 	private FloatArray gauge;

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -476,6 +476,9 @@ public class MusicSelector extends MainState {
 					case NO_GREAT:
 						resource.addConstraint(constraint);
 						break;
+					case LR2GRADE:
+						resource.addConstraint(constraint);
+						break;
 					}
 				}
 				preview.stop();


### PR DESCRIPTION
I added a course constraint "lr2grade".
Courses designated with this constraint will be played at the gauge of LR2.
It does not affect random options, so it is preferable to use it in combination with other constraints.

I confirmed that it was possible to play until update lamp without problems.