### PR TITLE
Fix banner not showing when entering a folder and the first song has a banner

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -303,15 +303,25 @@ public class MusicSelector extends MainState {
 
 		// banner
 		if (current != bannerbar) {
-			bannerbar = current;
-			if (banner != null) {
-				banner.getTexture().dispose();
-				banner = null;
-			}
-			if (bannerbar instanceof SongBar && ((SongBar) bannerbar).getBanner() != null) {
-				banner = new TextureRegion(new Texture(((SongBar) bannerbar).getBanner()));
+			if (current instanceof SongBar == false) {
+				if (banner != null) {
+					banner.getTexture().dispose();
+					banner = null;
+				}
+				bannerbar = current;
+			} else {
+				if (((SongBar) current).getBanner() != null) {
+					banner = new TextureRegion(new Texture(((SongBar) current).getBanner()));
+					bannerbar = current;
+				} else {
+					if (banner != null) {
+						banner.getTexture().dispose();
+						banner = null;
+					}
+				}
 			}
 		}
+
 		sprite.end();
 		// preview music
 		if (current instanceof SongBar) {


### PR DESCRIPTION
On the first frame after entering a folder `getBanner` returns `null`, so we can't do `bannerbar = current` just yet.