### PR TITLE
[Temporary fix] Set controller config at launch.

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -261,7 +261,7 @@ public class MainController extends ApplicationAdapter {
 		final long t = System.currentTimeMillis();
 		sprite = new SpriteBatch();
 
-		input = new BMSPlayerInputProcessor(config);
+		input = new BMSPlayerInputProcessor(config, player);
 		switch(config.getAudioDriver()) {
 		case Config.AUDIODRIVER_SOUND:
 			audio = new GdxSoundDriver();


### PR DESCRIPTION
起動時にキーコンフィグが読み込まれていなかったのを暫定修正。
TODO:前回終了時のMode参照による復元

***

Set controller config at launch. (Temporary fix)
TODO:Restoration by Mode reference at the last termination.