### PR TITLE
Improvement of imageset definition on LR2skin

### DIFF
--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -173,7 +173,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 			}
 		});
 
-				addCommandWord(new CommandWord("IMAGESET") {
+		addCommandWord(new CommandWord("IMAGESET") {
 			@Override
 			public void execute(String[] str) {
 				int gr = Integer.parseInt(str[2]);

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -173,18 +173,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 			}
 		});
 
-				addCommandWord(new CommandWord("SET_IMAGESET") {
-			@Override
-			public void execute(String[] str) {
-				imagesetarray.clear();
-				part = null;
-				cycle = Integer.parseInt(str[1]);
-				timer = Integer.parseInt(str[2]);
-				ref = Integer.parseInt(str[3]);
-			}
-		});
-
-		addCommandWord(new CommandWord("SRC_IMAGESET") {
+				addCommandWord(new CommandWord("IMAGESET") {
 			@Override
 			public void execute(String[] str) {
 				int gr = Integer.parseInt(str[2]);
@@ -195,12 +184,16 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 			}
 		});
 
-		addCommandWord(new CommandWord("END_IMAGESET") {
+		addCommandWord(new CommandWord("SRC_IMAGESET") {
 			@Override
 			public void execute(String[] str) {
-				TextureRegion[][] tr = imagesetarray.toArray(new TextureRegion[imagesetarray.size()][]);
-				part = new SkinImage(tr, timer, cycle);
-				part.setReferenceID(ref);
+				int[] values = parseInt(str);
+				TextureRegion[][] tr = new TextureRegion[values[4]][];
+				for (int i = 0; i < values[4]; i++) {
+					tr[i] = (TextureRegion[]) imagesetarray.get(values[5+i]);
+				}
+				part = new SkinImage(tr, values[2], values[1]);
+				part.setReferenceID(values[3]);
 				if (part != null) {
 					skin.add(part);
 				}
@@ -523,9 +516,6 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 	SkinText text = null;
 	String line = null;
 
-	int timer;
-	int cycle;
-	int ref;
 	List <Object> imagesetarray = new ArrayList<Object>();
 
 	protected void loadSkin0(Skin skin, File f, MainState state, Map<Integer, Boolean> option) throws IOException {


### PR DESCRIPTION
実際にスキン定義を書いたら冗長になってしまったのでもう少し簡潔に書けるように改善しました。

#IMAGESET,(null),gr,x,y,w,h,divx,divy
IMAGESETで使う画像パーツを登録します。
#IMAGEと同じように登録した順から番号が振られます。

#SRC_IMAGESET,cycle,timer,ref,len,pr,pr,pr...
lenに画像パーツを使う数を入力します。
prに登録した画像パーツの番号を入力します。