### PR TITLE
Fix keyboard-24k-double crashes

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayerRule.java
+++ b/src/bms/player/beatoraja/play/BMSPlayerRule.java
@@ -15,6 +15,7 @@ public enum BMSPlayerRule {
     POPN_5K(GaugeProperty.PMS, JudgeProperty.PMS),
     POPN_9K(GaugeProperty.PMS, JudgeProperty.PMS),
     KEYBOARD_24K(GaugeProperty.KEYBOARD, JudgeProperty.KEYBOARD),
+    KEYBOARD_24K_DOUBLE(GaugeProperty.KEYBOARD, JudgeProperty.KEYBOARD),
     LR2(GaugeProperty.LR2, JudgeProperty.Default),
     Default(GaugeProperty.Default, JudgeProperty.Default),
     ;

--- a/src/bms/player/beatoraja/play/GrooveGauge.java
+++ b/src/bms/player/beatoraja/play/GrooveGauge.java
@@ -135,12 +135,7 @@ public class GrooveGauge {
 		if(id >= 0) {
 			if(gauge == null) {
 				Mode mode = model.getMode();
-				for(BMSPlayerRule rule : BMSPlayerRule.values()) {
-					if(rule.name().equals(mode.name())) {
-						gauge = rule.gauge;
-						break;
-					}
-				}
+				gauge = BMSPlayerRule.getBMSPlayerRule(mode).gauge;
 			}
 			if(gauge != null) {
 				return create(model, id, gauge);


### PR DESCRIPTION
* Added `KEYBOARD_24K_DOUBLE` rule.
* Avoid null gauge in `GrooveGauge.create()`.