### PR TITLE
SkinObject: Fix rendering problem

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/src/bms/player/beatoraja/skin/SkinObject.java
@@ -369,7 +369,9 @@ public abstract class SkinObject implements Disposable {
 		}
 		sprite.setColor(color);
 		sprite.setBlend(dstblend);
-		sprite.setType(dstfilter != 0 && imageType == SkinObjectRenderer.TYPE_NORMAL ? SkinObjectRenderer.TYPE_BILINEAR : imageType);
+		sprite.setType(width == image.getRegionWidth() && height == image.getRegionHeight() ?
+				SkinObjectRenderer.TYPE_NORMAL:
+			dstfilter != 0 && imageType == SkinObjectRenderer.TYPE_NORMAL ? SkinObjectRenderer.TYPE_BILINEAR : imageType);
 		
 		if (angle != 0) {
 			sprite.draw(image, x, y, width, height, centerx , centery, angle);


### PR DESCRIPTION
I discovered that when drawing area is the same as TextureRegion, drawing becomes abnormal if Bilinear is effective. In that case I modified it to disable Bilinear.
In LITONE5, the difficulty level of the music selection screen and the background of the result screen have such symptoms.
(before)
![20171119_074325](https://user-images.githubusercontent.com/4867425/32986262-de2ac4b0-cd11-11e7-8629-dc2c5a287bce.png)
![20171119_062748](https://user-images.githubusercontent.com/4867425/32986311-d5b62bd4-cd12-11e7-97e0-ec0d6531b644.png)
(after)
![20171119_074302](https://user-images.githubusercontent.com/4867425/32986263-df24bae2-cd11-11e7-8dde-c2988cf53d98.png)
![20171119_101844](https://user-images.githubusercontent.com/4867425/32986322-0eb4948e-cd13-11e7-9a9a-77bcda7b658f.png)
