### PR TITLE
Fix stereo sound playback problem

### DIFF
--- a/src/bms/player/beatoraja/audio/ASIODriver.java
+++ b/src/bms/player/beatoraja/audio/ASIODriver.java
@@ -200,9 +200,9 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 					inputs[i].pcm = pcm;
 					inputs[i].sample = pcm.getSample();
 					inputs[i].volume = volume;
-					inputs[i].pos = 0;
 					inputs[i].loop = loop;
 					inputs[i].id = idcount++;
+					inputs[i].pos = 0;
 					return inputs[i].id;
 				}
 			}
@@ -231,19 +231,21 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 			final int channel = buffer.length;
 
 			for (int i = 0; i < size; i++) {
-				for (int j = 0; j < channel; j++) {
-					float wav = 0;
-					for (MixerInput input : inputs) {
-						if (input.pos != -1) {
-							wav += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
-							input.pos++;
-							if (input.pos == input.sample.length) {
-								input.pos = input.loop ? 0 : -1;
-							}
+				float wav_l = 0;
+				float wav_r = 0;
+				for (MixerInput input : inputs) {
+					if (input.pos != -1) {
+						wav_l += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
+						input.pos++;
+						wav_r += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
+						input.pos++;
+						if (input.pos == input.sample.length) {
+							input.pos = input.loop ? 0 : -1;
 						}
 					}
-					buffer[j][i] = wav;
 				}
+				buffer[0][i] = wav_l;
+				buffer[1][i] = wav_r;
 			}
 		}
 	}

--- a/src/bms/player/beatoraja/audio/PortAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/PortAudioDriver.java
@@ -191,9 +191,9 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 					inputs[i].pcm = pcm;
 					inputs[i].sample = pcm.getSample();
 					inputs[i].volume = volume;
-					inputs[i].pos = 0;
 					inputs[i].loop = loop;
 					inputs[i].id = idcount++;
+					inputs[i].pos = 0;
 					return inputs[i].id;
 				}
 			}
@@ -220,18 +220,22 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 		public void run() {
 			while(!stop) {
 				try {
-					for (int i = 0; i < buffer.length; i++) {
-						float wav = 0;
+					for (int i = 0; i < buffer.length; i+=2) {
+						float wav_l = 0;
+						float wav_r = 0;
 						for (MixerInput input : inputs) {
 							if (input.pos != -1) {
-								wav += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
+								wav_l += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
+								input.pos++;
+								wav_r += ((float) input.sample[input.pos]) * input.volume / Short.MAX_VALUE;
 								input.pos++;
 								if (input.pos == input.sample.length) {
 									input.pos = input.loop ? 0 : -1;
 								}
 							}
 						}
-						buffer[i] = wav;
+						buffer[i] = wav_l;
+						buffer[i+1] = wav_r;
 					}
 					
 					stream.write( buffer, buffer.length / 2);					


### PR DESCRIPTION
Fixed a problem that stereo sounds are occasionally played incorrectly.

再生側のスレッドがループで片方のチャンネルを読み進めたタイミングで `put` が呼ばれるとその音声のステレオが反転して再生されてしまっていたので、処理順序を変更して隙が生じないようにしました。本当は `synchronized` を使うのが良いのかもしれませんが、処理の負荷が心配なのでこの変更にとどめました。 `put` 自体を複数のスレッドから呼び出したりしない限りは大丈夫なはずです。