### PR TITLE
 Allow key sound multi-definition

### DIFF
--- a/src/bms/player/beatoraja/audio/ASIODriver.java
+++ b/src/bms/player/beatoraja/audio/ASIODriver.java
@@ -123,8 +123,8 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 	}
 
 	@Override
-	protected void stop(int channel) {
-		mixer.stop(channel);
+	protected void stop(PCM id, int channel) {
+		mixer.stop(id, channel);
 	}
 
 	@Override
@@ -232,9 +232,9 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 			}
 		}
 
-		public void stop(int channel) {
+		public void stop(PCM id, int channel) {
 			for (int i = 0; i < inputs.length; i++) {
-				if (inputs[i].channel == channel) {
+				if (inputs[i].pcm == id && inputs[i].channel == channel) {
 					inputs[i].pos = -1;
 				}
 			}

--- a/src/bms/player/beatoraja/audio/ASIODriver.java
+++ b/src/bms/player/beatoraja/audio/ASIODriver.java
@@ -103,13 +103,13 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 	}
 
 	@Override
-	protected synchronized void play(PCM id, float volume) {
-		mixer.put(id, volume, false);
+	protected synchronized void play(PCM pcm, int channel, float volume) {
+		mixer.put(pcm, channel, volume, false);
 	}
 
 	@Override
 	protected void play(AudioElement<PCM> id, float volume, boolean loop) {
-		id.id = mixer.put(id.audio, volume, loop);
+		id.id = mixer.put(id.audio, -1, volume, loop);
 	}
 
 	@Override
@@ -120,6 +120,11 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 	@Override
 	protected void stop(PCM id) {
 		mixer.stop(id);
+	}
+
+	@Override
+	protected void stop(int channel) {
+		mixer.stop(channel);
 	}
 
 	@Override
@@ -194,7 +199,7 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 			}
 		}
 
-		public long put(PCM pcm, float volume, boolean loop) {
+		public long put(PCM pcm, int channel, float volume, boolean loop) {
 			for (int i = 0; i < inputs.length; i++) {
 				if (inputs[i].pos == -1) {
 					inputs[i].pcm = pcm;
@@ -202,6 +207,7 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 					inputs[i].volume = volume;
 					inputs[i].loop = loop;
 					inputs[i].id = idcount++;
+					inputs[i].channel = channel;
 					inputs[i].pos = 0;
 					return inputs[i].id;
 				}
@@ -221,6 +227,14 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 		public void stop(PCM id) {
 			for (int i = 0; i < inputs.length; i++) {
 				if (inputs[i].pcm == id) {
+					inputs[i].pos = -1;
+				}
+			}
+		}
+
+		public void stop(int channel) {
+			for (int i = 0; i < inputs.length; i++) {
+				if (inputs[i].channel == channel) {
 					inputs[i].pos = -1;
 				}
 			}
@@ -257,5 +271,6 @@ public class ASIODriver extends AbstractAudioDriver<PCM> implements AsioDriverLi
 		public int pos = -1;
 		public boolean loop;
 		public long id;
+		public int channel = -1;
 	}
 }

--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -73,12 +73,14 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 	/**
 	 * キー音を再生する
 	 * 
-	 * @param id
+	 * @param wav
 	 *            音源データ
+	 * @param channel
+	 *            定義番号/音声チャンネル番号
 	 * @param volume
 	 *            ボリューム(0.0-1.0)
 	 */
-	protected abstract void play(T id, float volume);
+	protected abstract void play(T wav, int channel, float volume);
 
 	/**
 	 * 効果音を再生する
@@ -109,6 +111,14 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 	 *            音源データ
 	 */
 	protected abstract void stop(T id);
+
+	/**
+	 * 音源データが再生されていれば停止する
+	 *
+	 * @param channel
+	 *            定義番号/音声チャンネル番号
+	 */
+	protected abstract void stop(int channel);
 
 	public void play(String p, float volume, boolean loop) {
 		if (p == null || p.length() == 0) {
@@ -296,16 +306,16 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 			}
 			final long starttime = n.getMicroStarttime();
 			final long duration = n.getMicroDuration();
+			stop(id);
 			if (starttime == 0 && duration == 0) {
 				final T wav = (T) wavmap[id];
 				if (wav != null) {
-					stop(wav);
-					play(wav, volume);
+					play(wav, id, volume);
 				}
 			} else {
 				for (SliceWav<T> slice : slicesound[id]) {
 					if (slice.starttime == starttime && slice.duration == duration) {
-						play(slice.wav, volume);
+						play(slice.wav, id, volume);
 						// System.out.println("slice WAV play - ID:" + id +
 						// " start:" + starttime + " duration:" + duration);
 						break;
@@ -346,21 +356,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		if (id < 0) {
 			return;
 		}
-		final long starttime = n.getMicroStarttime();
-		final long duration = n.getMicroDuration();
-		if (starttime == 0 && duration == 0) {
-			final T sound = (T) wavmap[id];
-			if (sound != null) {
-				stop(sound);
-			}
-		} else {
-			for (SliceWav<T> slice : slicesound[id]) {
-				if (slice.starttime == starttime && slice.duration == duration) {
-					stop((T) slice.wav);
-					break;
-				}
-			}
-		}
+		stop(id);
 	}
 
 	public float getProgress() {

--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -115,10 +115,12 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 	/**
 	 * 音源データが再生されていれば停止する
 	 *
+	 * @param id
+	 *            音源データ
 	 * @param channel
 	 *            定義番号/音声チャンネル番号
 	 */
-	protected abstract void stop(int channel);
+	protected abstract void stop(T id, int channel);
 
 	public void play(String p, float volume, boolean loop) {
 		if (p == null || p.length() == 0) {
@@ -306,15 +308,16 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 			}
 			final long starttime = n.getMicroStarttime();
 			final long duration = n.getMicroDuration();
-			stop(id);
 			if (starttime == 0 && duration == 0) {
 				final T wav = (T) wavmap[id];
 				if (wav != null) {
+					stop(wav, id);
 					play(wav, id, volume);
 				}
 			} else {
 				for (SliceWav<T> slice : slicesound[id]) {
 					if (slice.starttime == starttime && slice.duration == duration) {
+						stop(slice.wav, id);
 						play(slice.wav, id, volume);
 						// System.out.println("slice WAV play - ID:" + id +
 						// " start:" + starttime + " duration:" + duration);
@@ -356,7 +359,21 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 		if (id < 0) {
 			return;
 		}
-		stop(id);
+		final long starttime = n.getMicroStarttime();
+		final long duration = n.getMicroDuration();
+		if (starttime == 0 && duration == 0) {
+			final T sound = (T) wavmap[id];
+			if (sound != null) {
+				stop(sound, id);
+			}
+		} else {
+			for (SliceWav<T> slice : slicesound[id]) {
+				if (slice.starttime == starttime && slice.duration == duration) {
+					stop((T) slice.wav, id);
+					break;
+				}
+			}
+		}
 	}
 
 	public float getProgress() {

--- a/src/bms/player/beatoraja/audio/GdxAudioDeviceDriver.java
+++ b/src/bms/player/beatoraja/audio/GdxAudioDeviceDriver.java
@@ -23,7 +23,7 @@ public class GdxAudioDeviceDriver extends AbstractAudioDriver {
 	}
 
 	@Override
-	protected void play(Object id, float volume) {
+	protected void play(Object wav, int channel, float volume) {
 		// TODO Auto-generated method stub
 		
 	}
@@ -44,5 +44,11 @@ public class GdxAudioDeviceDriver extends AbstractAudioDriver {
 	protected void stop(Object id) {
 		// TODO Auto-generated method stub
 		
+	}
+
+	@Override
+	protected void stop(int channel) {
+		// TODO Auto-generated method stub
+
 	}
 }

--- a/src/bms/player/beatoraja/audio/GdxAudioDeviceDriver.java
+++ b/src/bms/player/beatoraja/audio/GdxAudioDeviceDriver.java
@@ -47,7 +47,7 @@ public class GdxAudioDeviceDriver extends AbstractAudioDriver {
 	}
 
 	@Override
-	protected void stop(int channel) {
+	protected void stop(Object id, int channel) {
 		// TODO Auto-generated method stub
 
 	}

--- a/src/bms/player/beatoraja/audio/GdxSoundDriver.java
+++ b/src/bms/player/beatoraja/audio/GdxSoundDriver.java
@@ -142,12 +142,12 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 	}
 
 	@Override
-	protected void stop(int channel) {
+	protected void stop(Sound id, int channel) {
 		if (soundthread) {
-			mixer.stop(channel);
+			mixer.stop(id, channel);
 		} else {
 			for (int i = 0; i < sounds.length; i++) {
-				if (sounds[i].sound != null && sounds[i].channel == channel) {
+				if (sounds[i].sound == id && sounds[i].channel == channel) {
 					sounds[i].sound.stop(sounds[i].id);
 					sounds[i].sound = null;
 				}
@@ -176,9 +176,9 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 			cpos = (cpos + 1) % this.sound.length;
 		}
 
-		public synchronized void stop(int channel) {
+		public synchronized void stop(Sound snd, int channel) {
 			for (int i = 0; i < sound.length; i++) {
-				if (sound[i] != null && this.channels[i] == channel) {
+				if (sound[i] == snd && this.channels[i] == channel) {
 					sound[i].stop(ids[i]);
 					sound[i] = null;
 				}

--- a/src/bms/player/beatoraja/audio/GdxSoundDriver.java
+++ b/src/bms/player/beatoraja/audio/GdxSoundDriver.java
@@ -102,12 +102,12 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 	
 	
 	@Override
-	protected void play(Sound id, float volume) {
+	protected void play(Sound pcm, int channel, float volume) {
 		if(soundthread) {
-			mixer.put(id, volume);
+			mixer.put(pcm, channel, volume);
 		} else {
 			synchronized (lock) {
-				id.play(volume);
+				pcm.play(volume);
 			}
 		}
 	}
@@ -132,6 +132,10 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 	}
 
 	@Override
+	protected void stop(int channel) {
+	}
+
+	@Override
 	protected void disposeKeySound(Sound pcm) {
 		pcm.dispose();
 	}
@@ -143,7 +147,7 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 		private int cpos;
 		private int pos;
 
-		public synchronized void put(Sound sound, float volume) {
+		public synchronized void put(Sound sound, int channel, float volume) {
 			this.sound[cpos] = sound;
 			this.volume[cpos] = volume;
 			cpos = (cpos + 1) % this.sound.length;

--- a/src/bms/player/beatoraja/audio/PortAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/PortAudioDriver.java
@@ -123,13 +123,13 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 	}
 
 	@Override
-	protected synchronized void play(PCM id, float volume) {
-		mixer.put(id, volume, false);
+	protected synchronized void play(PCM pcm, int channel, float volume) {
+		mixer.put(pcm, channel, volume, false);
 	}
 
 	@Override
 	protected void play(AudioElement<PCM> id, float volume, boolean loop) {
-		id.id = mixer.put(id.audio, volume, loop);
+		id.id = mixer.put(id.audio, -1, volume, loop);
 	}
 
 	@Override
@@ -140,6 +140,11 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 	@Override
 	protected void stop(PCM id) {
 		mixer.stop(id);
+	}
+
+	@Override
+	protected void stop(int channel) {
+		mixer.stop(channel);
 	}
 
 	@Override
@@ -185,7 +190,7 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 			}
 		}
 
-		public long put(PCM pcm, float volume, boolean loop) {
+		public long put(PCM pcm, int channel, float volume, boolean loop) {
 			for (int i = 0; i < inputs.length; i++) {
 				if (inputs[i].pos == -1) {
 					inputs[i].pcm = pcm;
@@ -193,6 +198,7 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 					inputs[i].volume = volume;
 					inputs[i].loop = loop;
 					inputs[i].id = idcount++;
+					inputs[i].channel = channel;
 					inputs[i].pos = 0;
 					return inputs[i].id;
 				}
@@ -212,6 +218,14 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 		public void stop(PCM id) {
 			for (int i = 0; i < inputs.length; i++) {
 				if (inputs[i].pcm == id) {
+					inputs[i].pos = -1;
+				}
+			}
+		}
+
+		public void stop(int channel) {
+			for (int i = 0; i < inputs.length; i++) {
+				if (inputs[i].channel == channel) {
 					inputs[i].pos = -1;
 				}
 			}
@@ -253,5 +267,6 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 		public int pos = -1;
 		public boolean loop;
 		public long id;
+		public int channel = -1;
 	}
 }

--- a/src/bms/player/beatoraja/audio/PortAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/PortAudioDriver.java
@@ -143,8 +143,8 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 	}
 
 	@Override
-	protected void stop(int channel) {
-		mixer.stop(channel);
+	protected void stop(PCM id, int channel) {
+		mixer.stop(id, channel);
 	}
 
 	@Override
@@ -223,9 +223,9 @@ public class PortAudioDriver extends AbstractAudioDriver<PCM> {
 			}
 		}
 
-		public void stop(int channel) {
+		public void stop(PCM id, int channel) {
 			for (int i = 0; i < inputs.length; i++) {
-				if (inputs[i].channel == channel) {
+				if (inputs[i].pcm == id && inputs[i].channel == channel) {
 					inputs[i].pos = -1;
 				}
 			}


### PR DESCRIPTION
* Make playbacks of overloaded (defined in multiple channels) key sounds as artists expect.

同一のWAVが複数のチャンネル（定義番号）で定義されていた場合、あるチャンネルの再生時に他のチャンネルも停止していたのを修正（多重定義によるノイズ回避のテクニックが有効になるように変更）

* `stop(T id, int channel)` メソッドでは代わりにチャンネルのみ指定するということも考えられますが、それだとBMSONのスライスノーツがノイジーになるかもしれないので、音声データとチャンネルの両方が一致する音声のみ停止するようにしました。
* `GdxAudioDeviceDriver` では最近再生した有限個の音声のidを記憶しています。これは不完全な方法であり、長い音声は履歴から消えて `stop(T id, int channel)` で停止できなくなるかもしれません。それでも `stop(T id)` では停止できるのであまり支障はないと思います。（ `AbstractAudioDriver` の `stop(Note n = null)` では `stop(T id)` のほうを呼び出しているので、曲終了後など確実に停止してほしいタイミングでは停止してくれるはずです）
