### PR TITLE
Add combo timer and Change PG value when gauge max For PMS

### DIFF
--- a/skin/default/play9.json
+++ b/skin/default/play9.json
@@ -215,6 +215,7 @@
 		{"id":"gauge-e4", "src":3, "x":15, "y":17, "w":5, "h":17},
 		
 		{"id":"judgef-pg", "src":4, "x":0, "y":0, "w":180, "h":100, "divy":2, "cycle":100},
+		{"id":"judgef-pg2", "src":4, "x":0, "y":50, "w":180, "h":150, "divy":3, "cycle":100},
 		{"id":"judgef-gr", "src":4, "x":0, "y":150, "w":180, "h":50},
 		{"id":"judgef-gd", "src":4, "x":0, "y":200, "w":180, "h":50},
 		{"id":"judgef-bd", "src":4, "x":0, "y":250, "w":180, "h":50},
@@ -284,6 +285,7 @@
 		{"id":451, "src":0, "x":0, "y":565, "w":100, "h":15, "divx":10, "digit":4, "ref":312},
 		
 		{"id":"judgen-pg", "src":4, "x":200, "y":0, "w":300, "h":100, "divx":10, "divy":2, "digit":6, "ref":75, "cycle":100},
+		{"id":"judgen-pg2", "src":4, "x":200, "y":50, "w":300, "h":150, "divx":10, "divy":3, "digit":6, "ref":75, "cycle":100},
 		{"id":"judgen-gr", "src":4, "x":200, "y":150, "w":300, "h":50, "divx":10, "digit":6, "ref":75},
 		{"id":"judgen-gd", "src":4, "x":200, "y":200, "w":300, "h":50, "divx":10, "digit":6, "ref":75},
 		{"id":"judgen-bd", "src":4, "x":200, "y":250, "w":300, "h":50, "divx":10, "digit":6, "ref":75},
@@ -391,30 +393,38 @@
 			{"id":"judgef-ms", "loop":-1, "timer":46 ,"offset":50, "dst":[
 				{"time":0, "x":375, "y":240, "w":140, "h":20},
 				{"time":500}
+			]},
+			{"id":"judgef-pg2", "loop":-1, "timer":46 ,"offset":50, "dst":[
+				{"time":0, "x":375, "y":240, "w":140, "h":20},
+				{"time":500}
 			]}
 		],
 		"numbers":[
-			{"id":"judgen-pg", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-pg", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-gr", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-gr", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-gd", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-gd", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-bd", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-bd", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-pr", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-pr", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]},
-			{"id":"judgen-ms", "loop":-1, "timer":46, "dst":[
+			{"id":"judgen-ms", "loop":-1, "timer":346, "dst":[
+				{"time":0, "x":70, "y":-30, "w":20, "h":20},
+				{"time":500}
+			]},
+			{"id":"judgen-pg2", "loop":-1, "timer":346, "dst":[
 				{"time":0, "x":70, "y":-30, "w":20, "h":20},
 				{"time":500}
 			]}
@@ -448,30 +458,38 @@
 				{"id":"judgef-ms", "loop":-1, "timer":47 ,"offset":50, "dst":[
 					{"time":0, "x":570, "y":240, "w":140, "h":20},
 					{"time":500}
+				]},
+				{"id":"judgef-pg2", "loop":-1, "timer":47 ,"offset":50, "dst":[
+					{"time":0, "x":570, "y":240, "w":140, "h":20},
+					{"time":500}
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":47, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":347, "dst":[
+					{"time":0, "x":70, "y":-30, "w":20, "h":20},
+					{"time":500}
+				]},
+				{"id":"judgen-pg2", "loop":-1, "timer":347, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]}
@@ -505,30 +523,38 @@
 				{"id":"judgef-ms", "loop":-1, "timer":247 ,"offset":50, "dst":[
 					{"time":0, "x":765, "y":240, "w":140, "h":20},
 					{"time":500}
+				]},
+				{"id":"judgef-pg2", "loop":-1, "timer":247 ,"offset":50, "dst":[
+					{"time":0, "x":765, "y":240, "w":140, "h":20},
+					{"time":500}
 				]}
 			],
 			"numbers":[
-				{"id":"judgen-pg", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-pg", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gr", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-gr", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-gd", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-gd", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-bd", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-bd", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-pr", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-pr", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]},
-				{"id":"judgen-ms", "loop":-1, "timer":247, "dst":[
+				{"id":"judgen-ms", "loop":-1, "timer":348, "dst":[
+					{"time":0, "x":70, "y":-30, "w":20, "h":20},
+					{"time":500}
+				]},
+				{"id":"judgen-pg2", "loop":-1, "timer":348, "dst":[
 					{"time":0, "x":70, "y":-30, "w":20, "h":20},
 					{"time":500}
 				]}
@@ -761,19 +787,19 @@
 			{"time":500}
 		]},
 		{"id":2012},
-		{"id":"judge-early", "loop":-1, "timer":247 ,"op":[911,1262],"offset":50, "dst":[
+		{"id":"judge-early", "loop":-1, "timer":247 ,"op":[911,1362],"offset":50, "dst":[
 			{"time":0, "x":810, "y":290, "w":50, "h":20},
 			{"time":500}
 		]},
-		{"id":"judge-late", "loop":-1, "timer":247 ,"op":[911,1263],"offset":50, "dst":[
+		{"id":"judge-late", "loop":-1, "timer":247 ,"op":[911,1363],"offset":50, "dst":[
 			{"time":0, "x":810, "y":290, "w":50, "h":20},
 			{"time":500}
 		]},
-		{"id":"judgems-3pp", "loop":-1, "timer":247 ,"op":[912,261],"offset":50, "dst":[
+		{"id":"judgems-3pp", "loop":-1, "timer":247 ,"op":[912,361],"offset":50, "dst":[
 			{"time":0, "x":810, "y":290, "w":10, "h":20},
 			{"time":500}
 		]},
-		{"id":"judgems-3pg", "loop":-1, "timer":247 ,"op":[912,-261],"offset":50, "dst":[
+		{"id":"judgems-3pg", "loop":-1, "timer":247 ,"op":[912,-361],"offset":50, "dst":[
 			{"time":0, "x":810, "y":290, "w":10, "h":20},
 			{"time":500}
 		]},

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -537,6 +537,7 @@ public class JudgeManager {
 	}
 
 	private final int[] JUDGE_TIMER = { TIMER_JUDGE_1P, TIMER_JUDGE_2P, TIMER_JUDGE_3P };
+	private final int[] COMBO_TIMER = { TIMER_COMBO_1P, TIMER_COMBO_2P, TIMER_COMBO_3P };
 
 	private void update(int lane, Note n, int time, int judge, int fast) {
 		if (judge < 5) {
@@ -567,6 +568,12 @@ public class JudgeManager {
 		final int lanelength = sckeyassign.length;
 		if (judgenow.length > 0) {
 			main.getTimer()[JUDGE_TIMER[lane / (lanelength / judgenow.length)]] = main.getNowTime();
+			if(judgenow.length >= 3) {
+				for(int i = 0 ; i < COMBO_TIMER.length ; i++) {
+					if(i != lane / (lanelength / judgenow.length)) main.getTimer()[COMBO_TIMER[i]] = Long.MIN_VALUE;
+				}
+			}
+			main.getTimer()[COMBO_TIMER[lane / (lanelength / judgenow.length)]] = main.getNowTime();
 			judgenow[lane / (lanelength / judgenow.length)] = judge + 1;
 			judgecombo[lane / (lanelength / judgenow.length)] = main.getJudgeManager().getCourseCombo();
 		}

--- a/src/bms/player/beatoraja/play/SkinJudge.java
+++ b/src/bms/player/beatoraja/play/SkinJudge.java
@@ -60,8 +60,9 @@ public class SkinJudge extends SkinObject {
 
     @Override
     public void draw(SkinObjectRenderer sprite, long time, MainState state) {
-        final int judgenow = ((BMSPlayer)state).getJudgeManager().getNowJudge()[index] - 1;
+        int judgenow = ((BMSPlayer)state).getJudgeManager().getNowJudge()[index] - 1;
         final int judgecombo = ((BMSPlayer)state).getJudgeManager().getNowCombo()[index];
+	final GrooveGauge gauge = ((BMSPlayer)state).getGauge();
 
         if(judgenow < 0) {
             return;
@@ -70,6 +71,9 @@ public class SkinJudge extends SkinObject {
         if (r != null) {
             int shift = 0;
             if (judgenow < 3) {
+		if(judgenow == 0 && judge.length >= 7 && gauge.getValue() == gauge.getMaxValue()) {
+                    judgenow = 6;
+            	}
             	count[judgenow].draw(sprite, time, judgecombo, state, r.x, r.y);
             	shift = count[judgenow].getLength() / 2;
             }

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -42,6 +42,9 @@ public class SkinProperty {
 	public static final int TIMER_JUDGE_1P = 46;
 	public static final int TIMER_JUDGE_2P = 47;
 	public static final int TIMER_JUDGE_3P = 247;
+	public static final int TIMER_COMBO_1P = 346;
+	public static final int TIMER_COMBO_2P = 347;
+	public static final int TIMER_COMBO_3P = 348;
 	public static final int TIMER_FULLCOMBO_1P = 48;
 	public static final int TIMER_FULLCOMBO_2P = 49;
 	public static final int TIMER_BOMB_1P_SCRATCH = 50;


### PR DESCRIPTION
- PMSプレイスキン用にコンボ表示を1列のみにするためのTIMERを追加しました。
- ゲージMAX時のPGの判定文字色を変化させるために、src/bms/player/beatoraja/play/SkinJudge.java内のjudgenowの値をゲージMAX時のPGは6とするようにしました。
- default 9keysスキンを上記仕様が反映するように変更しました。また、3PのE/Lのopの値を直しました。