### PR TITLE
When is playing BMS, hides mouse cursor.

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -9,6 +9,8 @@ import java.util.function.Consumer;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
 
+import org.lwjgl.input.Mouse;
+
 import bms.player.beatoraja.play.TargetProperty;
 import bms.player.beatoraja.select.bar.TableBar;
 import bms.player.beatoraja.skin.SkinLoader;
@@ -240,6 +242,12 @@ public class MainController extends ApplicationAdapter {
 		case STATE_CONFIG:
 			newState = keyconfig;
 			break;
+		}
+		
+		if(state == STATE_PLAYBMS) {
+		    Mouse.setGrabbed(true);
+		} else {
+		    Mouse.setGrabbed(false);
 		}
 
 		if (newState != null && current != newState) {


### PR DESCRIPTION
When is playing BMS, hides mouse cursor.

***

BMSプレイ時（`STATE_PLAYBMS`時)に、マウスカーソルを非表示にします。
BMSプレイ時にマウス操作があるのであれば、本PRの`Mouse.setGrabbed()`を利用する方法ではなく、[マウスカーソルの大きさを0として見た目上表示させないような方法](https://gist.github.com/mattdesl/4255483#file-hidecursor-java-L46)が良いと思います。

（認識していないだけかもしれませんが、現状プレイ画面でのマウス操作は無いものと思っています）