### PR TITLE
JSON skin improvements

### DIFF
--- a/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
@@ -86,17 +86,28 @@ public class SkinConfigurationView {
 			ComboBox<String> combo = new ComboBox<String>();
 			combo.getItems().setAll(option.contents);
 			combo.getSelectionModel().select(0);
+			int selection = -1;
 			for(SkinConfig.Option o : property.getOption()) {
 				if (o.name.equals(option.name)) {
 					int i = o.value;
 					for(int index = 0;index < option.option.length;index++) {
 						if(option.option[index] == i) {
-							combo.getSelectionModel().select(index);
+							selection = index;
 							break;
 						}
 					}
 					break;
 				}
+			}
+			if (selection < 0 && option.def != null) {
+				for (int index = 0; index < option.option.length; index++) {
+					if (option.contents[index].equals(option.def)) {
+						selection = index;
+					}
+				}
+			}
+			if (selection >= 0) {
+				combo.getSelectionModel().select(selection);
 			}
 
 			Label label = new Label(option.name);

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -79,7 +79,7 @@ public class JSONSkinLoader extends SkinLoader{
 						op[j] = pr.item[j].op;
 						name[j] = pr.item[j].name;
 					}
-					options[i] = new SkinHeader.CustomOption(pr.name, op, name);
+					options[i] = new SkinHeader.CustomOption(pr.name, op, name, pr.def);
 				}
 				header.setCustomOptions(options);
 
@@ -894,6 +894,7 @@ public class JSONSkinLoader extends SkinLoader{
 	public static class Property {
 		public String name;
 		public PropertyItem[] item = new PropertyItem[0];
+		public String def;
 	}
 
 	public static class PropertyItem {

--- a/src/bms/player/beatoraja/skin/SkinHeader.java
+++ b/src/bms/player/beatoraja/skin/SkinHeader.java
@@ -107,11 +107,20 @@ public class SkinHeader {
 		public final String name;
 		public final int[] option;
 		public final String[] contents;
-		
+		public final String def;
+
 		public CustomOption(String name, int[] option, String[] contents) {
 			this.name = name;
 			this.option = option;
 			this.contents = contents;
+			this.def = null;
+		}
+
+		public CustomOption(String name, int[] option, String[] contents, String def) {
+			this.name = name;
+			this.option = option;
+			this.contents = contents;
+			this.def = def;
 		}
 	}
 


### PR DESCRIPTION
* Allow default property values in JSON skins.
* Allow custom file paths (including custom directories) for `include` command in JSON skins.

-----

* カスタムオプションでデフォルト値を指定可能にしました（構文の都合上JSONスキンのみ）。
* JSONスキンでも `include` コマンドでカスタムファイルで指定したパス（ディレクトリを含む）を使用可能にしました。