### PR TITLE
Modify DST_NOTE2 for PMS LR2SKIN

### DIFF
--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -281,7 +281,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 		addCommandWord(new CommandWord("DST_NOTE2") {
 			@Override
 			public void execute(String[] str) {
-				lanerender.setDstNote2((int) (dsth - (Integer.parseInt(str[1]) + scale[0] * srch / dsth)));
+				lanerender.setDstNote2((int) (dsth - (Integer.parseInt(str[1]) * dsth / srch + scale[0])));
 			}
 		});
 


### PR DESCRIPTION
スキン解像度と本体設定解像度が異なる時にPMS見逃しPOORのノートの演出の消失点がズレる不具合があったので修正しました。