### PR TITLE
Add POMYU chara loader For PMS LR2SKIN, Music end margin and Modify PMS LATE BAD

### DIFF
--- a/src/bms/player/beatoraja/MainState.java
+++ b/src/bms/player/beatoraja/MainState.java
@@ -404,6 +404,10 @@ public abstract class MainState {
 				return getJudgeCount(5, true);
 			case NUMBER_LATE_MISS:
 				return getJudgeCount(5, false);
+			case NUMBER_POOR_PLUS_MISS:
+				return getJudgeCount(4, true) + getJudgeCount(4, false) + getJudgeCount(5, true) + getJudgeCount(5, false);
+			case NUMBER_BAD_PLUS_POOR_PLUS_MISS:
+				return getJudgeCount(3, true) + getJudgeCount(3, false) + getJudgeCount(4, true) + getJudgeCount(4, false) + getJudgeCount(5, true) + getJudgeCount(5, false);
 			case NUMBER_TOTALEARLY:
 				int ecount = 0;
 				for (int i = 1; i < 6; i++) {

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -475,6 +475,8 @@ public class BMSPlayer extends MainState {
 				lanerender.init(model);
 				judge.init(model, resource);
 				notes = 0;
+				PMcharaLastnotes[0] = 0;
+				PMcharaLastnotes[1] = 0;
 				starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / property.freq;
 				playtime = (property.endtime + 1000) * 100 / property.freq + TIME_MARGIN;
 				bga.prepare(this);
@@ -510,6 +512,7 @@ public class BMSPlayer extends MainState {
 			break;
 		// プレイ
 		case STATE_PLAY:
+			notes = this.judge.getPastNotes();
 			final long deltatime = micronow - prevtime;
 			final long deltaplay = deltatime * (100 - playspeed) / 100;
 			PracticeProperty property = practice.getPracticeProperty();
@@ -821,9 +824,7 @@ public class BMSPlayer extends MainState {
 	}
 
 	public void update(int lane, int judge, int time, int fast) {
-		if (judge < 5) {
-			notes++;
-		}
+		notes = this.judge.getPastNotes();
 
 		if (this.judge.getCombo() == 0) {
 			bga.setMisslayerTme(time);

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -538,7 +538,7 @@ public class BMSPlayer extends MainState {
 			setTimer(TIMER_GAUGE_MAX_1P, g == gauge.getMaxValue());
 
 			if(timer[TIMER_PM_CHARA_1P_NEUTRAL] != Long.MIN_VALUE && now - timer[TIMER_PM_CHARA_1P_NEUTRAL] >= skin.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) && (now - timer[TIMER_PM_CHARA_1P_NEUTRAL]) % skin.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
-				if(PMcharaLastnotes[0] != notes) {
+				if(PMcharaLastnotes[0] != notes && judge.getPMcharaJudge() > 0) {
 					if(judge.getPMcharaJudge() == 1 || judge.getPMcharaJudge() == 2) {
 						if(g == gauge.getMaxValue()) timer[TIMER_PM_CHARA_1P_FEVER] = now;
 						else timer[TIMER_PM_CHARA_1P_GREAT] = now;
@@ -548,11 +548,11 @@ public class BMSPlayer extends MainState {
 				}
 			}
 			if(timer[TIMER_PM_CHARA_2P_NEUTRAL] != Long.MIN_VALUE && now - timer[TIMER_PM_CHARA_2P_NEUTRAL] >= skin.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) && (now - timer[TIMER_PM_CHARA_2P_NEUTRAL]) % skin.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
-				if(PMcharaLastnotes[1] != notes) {
+				if(PMcharaLastnotes[1] != notes && judge.getPMcharaJudge() > 0) {
 					if(judge.getPMcharaJudge() >= 1 && judge.getPMcharaJudge() <= 3) timer[TIMER_PM_CHARA_2P_BAD] = now;
 					else timer[TIMER_PM_CHARA_2P_GREAT] = now;
 					timer[TIMER_PM_CHARA_2P_NEUTRAL] = Long.MIN_VALUE;
-				} else PMcharaLastnotes[1] = notes;
+				}
 			}
 			for(int i = TIMER_PM_CHARA_1P_FEVER; i <= TIMER_PM_CHARA_2P_BAD; i++) {
 				if(i != TIMER_PM_CHARA_2P_NEUTRAL && timer[i] != Long.MIN_VALUE && now - timer[i] >= skin.getPMcharaTime(i - TIMER_PM_CHARA_1P_NEUTRAL)) {

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -1119,7 +1119,11 @@ public class BMSPlayer extends MainState {
 		}
 		return super.getImageIndex(id);
 	}
-	
+
+	public boolean isNoteEnd() {
+		return notes == getMainController().getPlayerResource().getSongdata().getNotes();
+	}
+
 	public Mode getMode() {
 		return model.getMode();
 	}

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -439,7 +439,7 @@ public class BMSPlayer extends MainState {
                 timer[TIMER_FADEOUT] = Long.MIN_VALUE;
                 timer[TIMER_ENDOFNOTE_1P] = Long.MIN_VALUE;
 
-				for(int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_MUSIC_END; i++) timer[i] = Long.MIN_VALUE;
+				for(int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_PM_CHARA_DANCE; i++) timer[i] = Long.MIN_VALUE;
 			}
 			if(timer[TIMER_PM_CHARA_1P_NEUTRAL] == Long.MIN_VALUE || timer[TIMER_PM_CHARA_2P_NEUTRAL] == Long.MIN_VALUE){
 				timer[TIMER_PM_CHARA_1P_NEUTRAL] = now;

--- a/src/bms/player/beatoraja/play/ControlInputProcessor.java
+++ b/src/bms/player/beatoraja/play/ControlInputProcessor.java
@@ -158,8 +158,7 @@ public class ControlInputProcessor {
 		}
 		long now = System.currentTimeMillis();
 		if((input.startPressed() && input.isSelectPressed() && now - exitpressedtime > 1000 )||
-				(player.getTimer()[TIMER_ENDOFNOTE_1P] != Long.MIN_VALUE &&
-				now > player.getTimer()[TIMER_ENDOFNOTE_1P] && (input.startPressed() || input.isSelectPressed()))){
+				(player.isNoteEnd() && (input.startPressed() || input.isSelectPressed()))){
 			input.startChanged(false);
 			input.setSelectPressed(false);
 			player.stopPlay();

--- a/src/bms/player/beatoraja/play/JudgeAlgorithm.java
+++ b/src/bms/player/beatoraja/play/JudgeAlgorithm.java
@@ -72,7 +72,7 @@ public enum JudgeAlgorithm {
 						&& ((LongNote) judgenote).isEnd())) {
 					if (note == null || note.getState() != 0 || compare(note, judgenote, ptime, judgetable)) {
 						if (!(miss == MissCondition.ONE && (judgenote.getState() != 0
-								|| (judgenote.getState() == 0 && judgenote.getPlayTime() != 0 && dtime >= judgetable[2][1])))) {
+								|| (judgenote.getState() == 0 && judgenote.getPlayTime() != 0 && (dtime > judgetable[2][1] || dtime < judgetable[2][0]))))) {
 							if (judgenote.getState() != 0) {
 								judge = (dtime >= judgetable[4][0] && dtime <= judgetable[4][1]) ? 5 : 6;
 							} else {

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -561,6 +561,7 @@ public class JudgeManager {
 	private void update(int lane, Note n, int time, int judge, int fast) {
 		if (judgeVanish[judge]) {
 			n.setState(judge + 1);
+			pastNotes++;
 		}
 		if(miss == MissCondition.ONE && judge == 4 && n.getPlayTime() != 0) {
 			return;

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -121,6 +121,11 @@ public class JudgeManager {
 
 	private final JudgeAlgorithm algorithm;
 
+	/**
+	 * PMS キャラ用 判定
+	 */
+	private int PMcharaJudge = 0;
+
 	public JudgeManager(BMSPlayer main) {
 		this.main = main;
 		algorithm = main.getMainController().getPlayerResource().getConfig().getJudgealgorithm();
@@ -571,6 +576,7 @@ public class JudgeManager {
 		if (judge <= ((PlaySkin)main.getSkin()).getJudgetimer()) {
 			main.getTimer()[SkinPropertyMapper.bombTimerId(player[lane], offset[lane])] = main.getNowTime();
 		}
+		PMcharaJudge = judge + 1;
 
 		final int lanelength = sckeyassign.length;
 		if (judgenow.length > 0) {
@@ -688,5 +694,9 @@ public class JudgeManager {
 
 	public int[][] getJudgeTable(boolean sc) {
 		return sc ? sjudge : njudge;
+	}
+
+	public int getPMcharaJudge() {
+		return PMcharaJudge;
 	}
 }

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -122,6 +122,11 @@ public class JudgeManager {
 	private final JudgeAlgorithm algorithm;
 
 	/**
+	 * 処理済ノート数
+	 */
+	private int pastNotes = 0;
+
+	/**
 	 * PMS キャラ用 判定
 	 */
 	private int PMcharaJudge = 0;
@@ -147,6 +152,8 @@ public class JudgeManager {
 		combocond = rule.combo;
 		miss = rule.miss;
 		judgeVanish = rule.judgeVanish;
+		pastNotes = 0;
+		PMcharaJudge = 0;
 
 		keyassign = main.getLaneProperty().getKeyLaneAssign();
 		offset = main.getLaneProperty().getLaneSkinOffset();
@@ -694,6 +701,10 @@ public class JudgeManager {
 
 	public int[][] getJudgeTable(boolean sc) {
 		return sc ? sjudge : njudge;
+	}
+
+	public int getPastNotes() {
+		return pastNotes;
 	}
 
 	public int getPMcharaJudge() {

--- a/src/bms/player/beatoraja/play/KeyInputProccessor.java
+++ b/src/bms/player/beatoraja/play/KeyInputProccessor.java
@@ -29,6 +29,9 @@ class KeyInputProccessor {
 
 	private final LaneProperty laneProperty;
 
+	//キービーム停止用
+	private boolean keyBeamStop = false;
+
 	public KeyInputProccessor(BMSPlayer player, LaneProperty laneProperty) {
 		this.player = player;
 		this.laneProperty = laneProperty;
@@ -54,13 +57,15 @@ class KeyInputProccessor {
 			final int offset = laneoffset[lane];
 			boolean pressed = false;
 			boolean scratch = false;
-			for (int key : laneProperty.getLaneKeyAssign()[lane]) {
-				if (keystate[key] || auto_presstime[key] != Long.MIN_VALUE) {
-					pressed = true;
-					if(laneProperty.getLaneScratchAssign()[lane] != -1
-							&& scratchKey[laneProperty.getLaneScratchAssign()[lane]] != key) {
-						scratch = true;
-						scratchKey[laneProperty.getLaneScratchAssign()[lane]] = key;
+			if(!keyBeamStop) {
+				for (int key : laneProperty.getLaneKeyAssign()[lane]) {
+					if (keystate[key] || auto_presstime[key] != Long.MIN_VALUE) {
+						pressed = true;
+						if(laneProperty.getLaneScratchAssign()[lane] != -1
+								&& scratchKey[laneProperty.getLaneScratchAssign()[lane]] != key) {
+							scratch = true;
+							scratchKey[laneProperty.getLaneScratchAssign()[lane]] = key;
+						}
 					}
 				}
 			}
@@ -102,9 +107,14 @@ class KeyInputProccessor {
 
 	public void stopJudge() {
 		if (judge != null) {
+			keyBeamStop = true;
 			judge.stop = true;
 			judge = null;
 		}
+	}
+
+	public void setKeyBeamStop(boolean inputStop) {
+		this.keyBeamStop = inputStop;
 	}
 
 	/**

--- a/src/bms/player/beatoraja/play/PlaySkin.java
+++ b/src/bms/player/beatoraja/play/PlaySkin.java
@@ -31,6 +31,11 @@ public class PlaySkin extends Skin {
 	 */
 	private int close;
 
+	/**
+	 * STATE_FINISHEDからフェードアウトを開始するまでのマージン(ms)
+	 */
+	private int finishMargin = 0;
+
 	private int loadstart;
 	private int loadend;
 	
@@ -75,6 +80,14 @@ public class PlaySkin extends Skin {
 
 	public void setClose(int close) {
 		this.close = close;
+	}
+
+	public int getFinishMargin() {
+		return finishMargin;
+	}
+
+	public void setFinishMargin(int finishMargin) {
+		this.finishMargin = finishMargin;
 	}
 
 	public int getPlaystart() {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -146,6 +146,7 @@ public class JSONSkinLoader extends SkinLoader{
 				((PlaySkin) skin).setClose(sk.close);
 				((PlaySkin) skin).setPlaystart(sk.playstart);
 				((PlaySkin) skin).setJudgetimer(sk.judgetimer);
+				((PlaySkin) skin).setFinishMargin(sk.finishmargin);
 			}
 			if (type == SkinType.MUSIC_SELECT) {
 				skin = new MusicSelectSkin(src, dstr);
@@ -958,6 +959,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int close;
 		public int playstart;
 		public int judgetimer = 1;
+		public int finishmargin = 0;
 
 		public Property[] property = new Property[0];
 		public Filepath[] filepath = new Filepath[0];

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -440,10 +440,10 @@ public class Skin {
 	/**
 	 * ぽみゅキャラの各モーションの1周期の時間  0:1P_NEUTRAL 1:1P_FEVER 2:1P_GREAT 3:1P_GOOD 4:1P_BAD 5:2P_NEUTRAL 6:2P_GREAT 7:2P_BAD
 	 */
-	private int PMcharaTime[] = {Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE};
+	private int PMcharaTime[] = {1,1,1,1,1,1,1,1};
 
 	public int getPMcharaTime(int index) {
-		if(index < 0 || index >= PMcharaTime.length) return Integer.MAX_VALUE;
+		if(index < 0 || index >= PMcharaTime.length) return 1;
 		return PMcharaTime[index];
 	}
 

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -436,4 +436,21 @@ public class Skin {
 			this.color = color;
 		}
 	}
+
+	/**
+	 * ぽみゅキャラの各モーションの1周期の時間  0:1P_NEUTRAL 1:1P_FEVER 2:1P_GREAT 3:1P_GOOD 4:1P_BAD 5:2P_NEUTRAL 6:2P_GREAT 7:2P_BAD
+	 */
+	private int PMcharaTime[] = {Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE, Integer.MAX_VALUE};
+
+	public int getPMcharaTime(int index) {
+		if(index < 0 || index >= PMcharaTime.length) return Integer.MAX_VALUE;
+		return PMcharaTime[index];
+	}
+
+	public void setPMcharaTime(int index, int value) {
+		if(index >= 0 && index < PMcharaTime.length && value >= 1) {
+			this.PMcharaTime[index] = value;
+		}
+	}
+
 }

--- a/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/src/bms/player/beatoraja/skin/SkinObject.java
@@ -232,12 +232,20 @@ public abstract class SkinObject implements Disposable {
 			if(rate == 0) {
 				r.set(dst[index].region);
 			} else {
-				final Rectangle r1 = dst[index].region;
-				final Rectangle r2 = dst[index + 1].region;
-				r.x = r1.x + (r2.x - r1.x) * rate;
-				r.y = r1.y + (r2.y - r1.y) * rate;
-				r.width = r1.width + (r2.width - r1.width) * rate;
-				r.height = r1.height + (r2.height - r1.height) * rate;
+				if(acc == 3) {
+					final Rectangle r1 = dst[index].region;
+					r.x = r1.x;
+					r.y = r1.y;
+					r.width = r1.width;
+					r.height = r1.height;
+				} else {
+					final Rectangle r1 = dst[index].region;
+					final Rectangle r2 = dst[index + 1].region;
+					r.x = r1.x + (r2.x - r1.x) * rate;
+					r.y = r1.y + (r2.y - r1.y) * rate;
+					r.width = r1.width + (r2.width - r1.width) * rate;
+					r.height = r1.height + (r2.height - r1.height) * rate;
+				}
 			}
 
 			for(SkinOffset off : this.off) {
@@ -286,13 +294,22 @@ public abstract class SkinObject implements Disposable {
 		if(rate == 0) {
 			c.set(dst[index].color);			
 		} else {
-			final Color r1 = dst[index].color;
-			final Color r2 = dst[index + 1].color;
-			c.r = r1.r + (r2.r - r1.r) * rate;
-			c.g = r1.g + (r2.g - r1.g) * rate;
-			c.b = r1.b + (r2.b - r1.b) * rate;
-			c.a = r1.a + (r2.a - r1.a) * rate;
-			return c;			
+			if(acc == 3) {
+				final Color r1 = dst[index].color;
+				c.r = r1.r;
+				c.g = r1.g;
+				c.b = r1.b;
+				c.a = r1.a;
+				return c;
+			} else {
+				final Color r1 = dst[index].color;
+				final Color r2 = dst[index + 1].color;
+				c.r = r1.r + (r2.r - r1.r) * rate;
+				c.g = r1.g + (r2.g - r1.g) * rate;
+				c.b = r1.b + (r2.b - r1.b) * rate;
+				c.a = r1.a + (r2.a - r1.a) * rate;
+				return c;
+			}
 		}
 		for(SkinOffset off :this.off) {
 			if(off != null) {
@@ -315,7 +332,7 @@ public abstract class SkinObject implements Disposable {
 			return a;
 		}
 		getRate();
-		int a = (rate == 0 ? dst[index].angle :  (int) (dst[index].angle + (dst[index + 1].angle - dst[index].angle) * rate));
+		int a = (rate == 0 || acc == 3 ? dst[index].angle :  (int) (dst[index].angle + (dst[index + 1].angle - dst[index].angle) * rate));
 		for(SkinOffset off :this.off) {
 			if(off != null) {
 				a += off.r;

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -133,6 +133,21 @@ public class SkinProperty {
 	public static final int TIMER_IR_CONNECT_FAIL = 174;
 
 
+	//ぽみゅキャラ用タイマー
+	//ここから
+	public static final int TIMER_PM_CHARA_1P_NEUTRAL = 900;
+	public static final int TIMER_PM_CHARA_1P_FEVER = 901;
+	public static final int TIMER_PM_CHARA_1P_GREAT = 902;
+	public static final int TIMER_PM_CHARA_1P_GOOD = 903;
+	public static final int TIMER_PM_CHARA_1P_BAD = 904;
+	public static final int TIMER_PM_CHARA_2P_NEUTRAL = 905;
+	public static final int TIMER_PM_CHARA_2P_GREAT = 906;
+	public static final int TIMER_PM_CHARA_2P_BAD = 907;
+	public static final int TIMER_MUSIC_END = 908;
+	//FEVERWIN WIN LOSEはOPTION_1P_100とOPTION_1P_BORDER_OR_MOREを用いて分岐
+	public static final int TIMER_PM_CHARA_DANCE = 909;
+	//ここまで連番でお願いします
+
 	// 拡張版TIMER
 	public static final int TIMER_BOMB_1P_KEY10 = 1010;
 	public static final int TIMER_BOMB_1P_KEY99 = 1099;
@@ -154,8 +169,6 @@ public class SkinProperty {
 	public static final int TIMER_HCN_ACTIVE_2P_KEY10 = 1910;
 	public static final int TIMER_HCN_DAMAGE_1P_KEY10 = 2010;
 	public static final int TIMER_HCN_DAMAGE_2P_KEY10 = 2110;
-	public static final int TIMER_GOOD_BOMB_1P_KEY10 = 2210;
-	public static final int TIMER_GOOD_BOMB_2P_KEY10 = 2310;
 
 	public static final int TIMER_MAX = 2999;
 
@@ -307,6 +320,8 @@ public class SkinProperty {
 	public static final int NUMBER_TOTALEARLY = 423;
 	public static final int NUMBER_TOTALLATE = 424;
 	public static final int NUMBER_COMBOBREAK = 425;
+	public static final int NUMBER_POOR_PLUS_MISS = 426;
+	public static final int NUMBER_BAD_PLUS_POOR_PLUS_MISS = 427;
 	public static final int NUMBER_TOTAL_RATE = 115;
 	public static final int NUMBER_TOTAL_RATE_AFTERDOT = 116;
 	public static final int NUMBER_TARGET_SCORE = 121;

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -93,6 +93,13 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 				skin.setLoadend(Integer.parseInt(str[1]));
 			}
 		});
+		addCommandWord(new CommandWord("FINISHMARGIN") {
+			@Override
+			//STATE_FINISHEDからフェードアウトを開始するまでのマージン(ms)
+			public void execute(String[] str) {
+				skin.setFinishMargin(Integer.parseInt(str[1]));
+			}
+		});
 		addCommandWord(new CommandWord("JUDGETIMER") {
 			@Override
 			public void execute(String[] str) {

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -1058,7 +1058,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								}
 								//ハイフンがある時はフレーム補間を行う 60FPSの17msが基準
 								int increaseRate = 1;
-								if(hyphenFlag && frame[motion] > increaseRateThreshold) {
+								if(hyphenFlag && frame[motion] >= increaseRateThreshold) {
 									for(int i = 1; i <= frame[motion]; i++) {
 										if(frame[motion] / i < increaseRateThreshold && frame[motion] % i == 0) {
 											increaseRate = i;

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -3,6 +3,7 @@ package bms.player.beatoraja.skin.lr2;
 import java.io.*;
 import java.util.*;
 import java.util.logging.Logger;
+import static bms.player.beatoraja.skin.SkinProperty.*;
 
 import bms.player.beatoraja.*;
 import bms.player.beatoraja.SkinConfig.Offset;
@@ -11,6 +12,8 @@ import bms.player.beatoraja.select.MusicSelectSkin;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.SkinHeader.*;
 
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
@@ -471,6 +474,114 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 				}
 			}
 		});
+		addCommandWord(new CommandWord("DST_PM_CHARA_1P") {
+			@Override
+			public void execute(String[] str) {
+				//プレイ用 判定連動
+				//x,y,w,h,color,offset,folderpath
+				int[] values = parseInt(str);
+				if (values[3] < 0) {
+					values[1] += values[3];
+					values[3] = -values[3];
+				}
+				if (values[4] < 0) {
+					values[2] += values[4];
+					values[4] = -values[4];
+				}
+				final File imagefile = SkinLoader.getPath(str[7].replace("LR2files\\Theme", "skin").replace("\\", "/"), filemap);
+				if (imagefile.exists()) {
+					PMcharaLoader(imagefile, 0, (values[5] == 1 || values[5] == 2) ? values[5] : 1,
+							values[1] * dstw / srcw, dsth - (values[2] + values[4]) * dsth / srch, values[3] * dstw / srcw, values[4] * dsth / srch,
+							1, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, values[6]);
+				}
+			}
+		});
+		addCommandWord(new CommandWord("DST_PM_CHARA_2P") {
+			@Override
+			public void execute(String[] str) {
+				//プレイ用 判定連動
+				//x,y,w,h,color,offset,folderpath
+				int[] values = parseInt(str);
+				if (values[3] < 0) {
+					values[1] += values[3];
+					values[3] = -values[3];
+				}
+				if (values[4] < 0) {
+					values[2] += values[4];
+					values[4] = -values[4];
+				}
+				final File imagefile = SkinLoader.getPath(str[7].replace("LR2files\\Theme", "skin").replace("\\", "/"), filemap);
+				if (imagefile.exists()) {
+					PMcharaLoader(imagefile, 0, (values[5] == 1 || values[5] == 2) ? values[5] : 1,
+							values[1] * dstw / srcw, dsth - (values[2] + values[4]) * dsth / srch, values[3] * dstw / srcw, values[4] * dsth / srch,
+							2, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, values[6]);
+				}
+			}
+		});
+		addCommandWord(new CommandWord("DST_PM_CHARA_ANIMATION") {
+			@Override
+			public void execute(String[] str) {
+				//プレイ以外用 判定非連動
+				//x,y,w,h,color,animationtype,timer,op1,op2,op3,offset,folderpath
+				//type 0:NEUTRAL 1:FEVER 2:GREAT 3:GOOD 4:BAD 5:FEVERWIN 6:WIN 7:LOSE 8:OJAMA 9:DANCE
+				int[] values = parseInt(str);
+				if(values[6] >= 0 && values[6] <= 9) {
+					if (values[3] < 0) {
+						values[1] += values[3];
+						values[3] = -values[3];
+					}
+					if (values[4] < 0) {
+						values[2] += values[4];
+						values[4] = -values[4];
+					}
+					final File imagefile = SkinLoader.getPath(str[12].replace("LR2files\\Theme", "skin").replace("\\", "/"), filemap);
+					if (imagefile.exists()) {
+						PMcharaLoader(imagefile, values[6] + 6, (values[5] == 1 || values[5] == 2) ? values[5] : 1,
+								values[1] * dstw / srcw, dsth - (values[2] + values[4]) * dsth / srch, values[3] * dstw / srcw, values[4] * dsth / srch,
+								Integer.MIN_VALUE, values[7], values[8], values[9], values[10], values[11]);
+					}
+				}
+			}
+		});
+		addCommandWord(new CommandWord("SRC_PM_CHARA_IMAGE") {
+			@Override
+			public void execute(String[] str) {
+				//color,type,folderpath
+				//type 0:キャラ背景 1:名前画像 2:ハリアイ画像(上半身のみ) 3:ハリアイ画像(全体) 4:キャラアイコン
+				PMcharaPart = null;
+				int[] values = parseInt(str);
+				if(values[2] >= 0 && values[2] <= 4) {
+					final File imagefile = SkinLoader.getPath(str[3].replace("LR2files\\Theme", "skin").replace("\\", "/"), filemap);
+					if (imagefile.exists()) {
+						PMcharaLoader(imagefile, values[2] + 1, (values[1] == 1 || values[1] == 2) ? values[1] : 1,
+								Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE,
+								Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE, Integer.MIN_VALUE);
+					}
+				}
+			}
+		});
+		addCommandWord(new CommandWord("DST_PM_CHARA_IMAGE") {
+			@Override
+			public void execute(String[] str) {
+				//DST_IMAGEと同様
+				if (PMcharaPart != null) {
+					int[] values = parseInt(str);
+					if (values[5] < 0) {
+						values[3] += values[5];
+						values[5] = -values[5];
+					}
+					if (values[6] < 0) {
+						values[4] += values[6];
+						values[6] = -values[6];
+					}
+					PMcharaPart.setDestination(values[2], values[3] * dstw / srcw,
+							dsth - (values[4] + values[6]) * dsth / srch, values[5] * dstw / srcw,
+							values[6] * dsth / srch, values[7], values[8], values[9], values[10], values[11],
+							values[12], values[13], values[14], values[15], values[16], values[17], values[18],
+							values[19], values[20], values[21]);
+				}
+			}
+		});
 
 	}
 
@@ -523,6 +634,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 	SkinNumber num = null;
 	SkinText text = null;
 	String line = null;
+	SkinImage PMcharaPart = null;
 
 	List <Object> imagesetarray = new ArrayList<Object>();
 
@@ -629,4 +741,464 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 		}
 		return null;
 	}
+
+	protected void PMcharaLoader(File imagefile, int type, int color, float dstx, float dsty, float dstw, float dsth, int side, int dsttimer, int dstOp1, int dstOp2, int dstOp3, int dstOffset) {
+		//type 0:プレイ 1:キャラ背景 2:名前画像 3:ハリアイ画像(上半身のみ) 4:ハリアイ画像(全体) 5:キャラアイコン 6:NEUTRAL 7:FEVER 8:GREAT 9:GOOD 10:BAD 11:FEVERWIN 12:WIN 13:LOSE 14:OJAMA 15:DANCE
+		final int PLAY = 0;
+		final int BACKGROUND = 1;
+		final int NAME = 2;
+		final int FACE_UPPER = 3;
+		final int FACE_ALL = 4;
+		final int SELECT_CG = 5;
+		final int NEUTRAL = 6;
+		final int FEVER = 7;
+		final int GREAT = 8;
+		final int GOOD = 9;
+		final int BAD = 10;
+		final int FEVERWIN = 11;
+		final int WIN = 12;
+		final int LOSE = 13;
+		final int OJAMA = 14;
+		final int DANCE = 15;
+
+		if(type < 0 || type > 15) return;
+
+		File chp = null;
+		File chpdir = null;
+
+		if(imagefile.exists() && imagefile.getPath().substring(imagefile.getPath().length()-4,imagefile.getPath().length()).equalsIgnoreCase(".chp")) {
+			chp = new File(imagefile.getPath());
+		} else if (!imagefile.exists() && imagefile.getPath().substring(imagefile.getPath().length()-4,imagefile.getPath().length()).equalsIgnoreCase(".chp")) {
+			chpdir = new File(imagefile.getPath().substring(0, Math.max(imagefile.getPath().lastIndexOf('\\'), imagefile.getPath().lastIndexOf('/')) + 1));
+		} else {
+			if(imagefile.getPath().charAt(imagefile.getPath().length()-1) != '/' && imagefile.getPath().charAt(imagefile.getPath().length()-1) != '\\') chpdir = new File(imagefile.getPath()+"/");
+			else chpdir = new File(imagefile.getPath());
+		}
+		if(chp == null && chpdir != null) {
+			//chpファイルを探す
+			File[] filename = chpdir.listFiles();
+			for(int i = 0; i < filename.length; i++) {
+				if (filename[i].getPath().substring(filename[i].getPath().length()-4,filename[i].getPath().length()).equalsIgnoreCase(".chp")) {
+					chp = new File(filename[i].getPath());
+					break;
+				}
+			}
+		}
+		if(chp == null) return;
+
+		//画像データ 0:#CharBMP 1:#CharBMP2P 2:#CharTex 3:#CharTex2P 4:#CharFace 5:#CharFace2P 6:#SelectCG 7:#SelectCG2P
+		Texture[] CharBMP = new Texture[8];
+		Arrays.fill(CharBMP, null);
+		final int CharBMPIndex = 0;
+		final int CharTexIndex = 2;
+		final int CharFaceIndex = 4;
+		final int SelectCGIndex = 6;
+		//各パラメータ
+		int[][] xywh = new int[256][4];
+		for(int[] i: xywh){
+			Arrays.fill(i, 0);
+		}
+		int anime = 100;
+		int size[] = {0, 0};
+		int frame[] = new int[20];
+		Arrays.fill(frame, Integer.MIN_VALUE);
+		int loop[] = new int[20];
+		Arrays.fill(loop, -1);
+		//最終的な色
+		int setColor = 1;
+		//フレーム補間の基準の時間 60FPSの17ms
+		int increaseRateThreshold = 17;
+		//#Pattern,#Texture,#Layerのデータ
+		List<List<String>> patternData = new ArrayList<List<String>>();
+		for(int i = 0; i < 3; i++) patternData.add(new ArrayList<String>());
+
+		try (BufferedReader br = new BufferedReader(
+			new InputStreamReader(new FileInputStream(chp), "MS932"));) {
+			String line;
+			while ((line = br.readLine()) != null) {
+				if (line.startsWith("#") ) {
+					String[] str = line.split("\t", -1);
+					if (str.length > 1) {
+						List<String> data = PMparseStr(str);
+						if (str[0].equalsIgnoreCase("#CharBMP")) {
+							//#Pattern, #Layer用画像
+							if(data.size() > 1) CharBMP[CharBMPIndex] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#CharBMP2P")) {
+							//#Pattern, #Layer用画像2P
+							if(data.size() > 1) CharBMP[CharBMPIndex+1] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#CharTex")) {
+							//#Texture用画像
+							if(data.size() > 1) CharBMP[CharTexIndex] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#CharTex2P")) {
+							//#Texture用画像2P
+							if(data.size() > 1) CharBMP[CharTexIndex+1] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#CharFace")) {
+							//ハリアイ
+							if(data.size() > 1) CharBMP[CharFaceIndex] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#CharFace2P")) {
+							//ハリアイ2P
+							if(data.size() > 1) CharBMP[CharFaceIndex+1] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#SelectCG")) {
+							//選択画面アイコン
+							if(data.size() > 1) CharBMP[SelectCGIndex] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#SelectCG2P")) {
+							//選択画面アイコン2P
+							if(data.size() > 1) CharBMP[SelectCGIndex+1] = getTexture(chp.getPath().substring(0, Math.max(chp.getPath().lastIndexOf('\\'), chp.getPath().lastIndexOf('/')) + 1) + data.get(1), usecim);
+						} else if(str[0].equalsIgnoreCase("#Patern") || str[0].equalsIgnoreCase("#Pattern")) {
+							//アニメーションデータ  表示優先度低  「ふぃーりんぐぽみゅ せかんど」ではスペルミスのtが一つ足りない#Paternが正式?
+							patternData.get(0).add(line);
+						} else if(str[0].equalsIgnoreCase("#Texture")) {
+							//アニメーションデータ  表示優先度中
+							patternData.get(1).add(line);
+						} else if(str[0].equalsIgnoreCase("#Layer")) {
+							//アニメーションデータ  表示優先度高
+							patternData.get(2).add(line);
+						} else if(str[0].equalsIgnoreCase("#Flame") || str[0].equalsIgnoreCase("#Frame")) {
+							//アニメ速度 動き毎の1枚あたりの時間(ms) 「ふぃーりんぐぽみゅ せかんど」ではスペルミスの#Flameが正式?
+							if(data.size() > 2) {
+								if(PMparseInt(data.get(1)) >= 0 && PMparseInt(data.get(1)) < frame.length) frame[PMparseInt(data.get(1))] = PMparseInt(data.get(2));
+							}
+						} else if(str[0].equalsIgnoreCase("#Anime")) {
+							//#Frame定義の指定がない時のアニメ速度 1枚あたりの時間(ms)
+							if(data.size() > 1) anime = PMparseInt(data.get(1));
+						} else if(str[0].equalsIgnoreCase("#Size")) {
+							//#Patternや背景に用いる大きさ
+							if(data.size() > 2) {
+								size[0] = PMparseInt(data.get(1));
+								size[1] = PMparseInt(data.get(2));
+							}
+						} else if(str[0].length() == 3 && PMparseInt(str[0].substring(1,3), 16) >= 0 && PMparseInt(str[0].substring(1,3), 16) < xywh.length) {
+							//座標定義
+							if(data.size() > xywh[0].length) {
+								for(int i = 0; i < xywh[0].length; i++) {
+									xywh[PMparseInt(str[0].substring(1,3), 16)][i] = PMparseInt(data.get(i+1));
+								}
+							}
+						} else if(str[0].equalsIgnoreCase("#Loop")) {
+							//ループ位置
+							if(data.size() > 2) {
+								if(PMparseInt(data.get(1)) >= 0 && PMparseInt(data.get(1)) < loop.length) loop[PMparseInt(data.get(1))] = PMparseInt(data.get(2));
+							}
+						}
+					}
+				}
+			}
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+
+		//#CharBMPが無い時はreturn
+		if(CharBMP[CharBMPIndex] == null) return;
+		//#CharBMP2Pが存在し、かつ#Texture定義があるときは#CharTex2Pが存在するなら2Pカラーとする
+		if(color == 2 && CharBMP[CharBMPIndex+1] != null
+				&& (patternData.get(1).size() == 0 || (patternData.get(1).size() > 0 && CharBMP[CharTexIndex+1] != null))
+				) setColor = 2;
+		//#Texture定義があるのに#CharTexが無い時はreturn
+		if(setColor == 1 && patternData.get(1).size() > 0 && CharBMP[CharTexIndex] == null) return;
+
+
+		//透過処理 右下の1pixelが透過色 選択画面アイコンは透過しない
+		for(int i = 0; i < SelectCGIndex; i++) {
+			if(CharBMP[i] != null) {
+				Pixmap pixmap = new Pixmap( CharBMP[i].getWidth(), CharBMP[i].getHeight(), Format.RGBA8888 );
+				int transparentColor = CharBMP[i].getTextureData().consumePixmap().getPixel(CharBMP[i].getWidth() - 1, CharBMP[i].getHeight() - 1);
+				for(int x = 0; x < CharBMP[i].getWidth(); x++) {
+					for(int y = 0; y < CharBMP[i].getHeight(); y++) {
+						if(transparentColor != CharBMP[i].getTextureData().consumePixmap().getPixel(x, y)) {
+							pixmap.drawPixel(x, y, CharBMP[i].getTextureData().consumePixmap().getPixel(x, y));
+						}
+					}
+				}
+				CharBMP[i].dispose();
+				CharBMP[i] = new Texture( pixmap );
+				pixmap.dispose();
+			}
+		}
+
+		TextureRegion[] image = new TextureRegion[1];
+		Texture setBMP;
+		int setMotion = Integer.MIN_VALUE;
+		PMcharaPart = null;
+		switch(type) {
+			case BACKGROUND:
+				setBMP = CharBMP[CharBMPIndex + setColor-1];
+				image = new TextureRegion[1];
+				image[0] = new TextureRegion(setBMP, xywh[1][0], xywh[1][1], xywh[1][2], xywh[1][3]);
+				PMcharaPart = new SkinImage(image, 0, 0);
+				skin.add(PMcharaPart);
+				break;
+			case NAME:
+				setBMP = CharBMP[CharBMPIndex + setColor-1];
+				image = new TextureRegion[1];
+				image[0] = new TextureRegion(setBMP, xywh[0][0], xywh[0][1], xywh[0][2], xywh[0][3]);
+				PMcharaPart = new SkinImage(image, 0, 0);
+				skin.add(PMcharaPart);
+				break;
+			case FACE_UPPER:
+				setBMP = setColor == 2 && CharBMP[CharFaceIndex + 1] != null ? CharBMP[CharFaceIndex + 1] : CharBMP[CharFaceIndex];
+				if(setBMP == null) break;
+				image = new TextureRegion[1];
+				image[0] = new TextureRegion(setBMP, 0, 0, 256, 256);
+				PMcharaPart = new SkinImage(image, 0, 0);
+				skin.add(PMcharaPart);
+				break;
+			case FACE_ALL:
+				setBMP = setColor == 2 && CharBMP[CharFaceIndex + 1] != null ? CharBMP[CharFaceIndex + 1] : CharBMP[CharFaceIndex];
+				if(setBMP == null) break;
+				image = new TextureRegion[1];
+				image[0] = new TextureRegion(setBMP, 320, 0, 320, 480);
+				PMcharaPart = new SkinImage(image, 0, 0);
+				skin.add(PMcharaPart);
+				break;
+			case SELECT_CG:
+				setBMP = setColor == 2 && CharBMP[SelectCGIndex + 1] != null ? CharBMP[SelectCGIndex + 1] : CharBMP[SelectCGIndex];
+				if(setBMP == null) break;
+				image = new TextureRegion[1];
+				image[0] = new TextureRegion(setBMP, 0, 0, setBMP.getWidth(), setBMP.getHeight());
+				PMcharaPart = new SkinImage(image, 0, 0);
+				skin.add(PMcharaPart);
+				break;
+			case NEUTRAL:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 1;
+			case FEVER:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 6;
+			case GREAT:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 7;
+			case GOOD:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 8;
+			case BAD:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 4;
+			case FEVERWIN:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 17;
+			case WIN:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 15;
+			case LOSE:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 16;
+			case OJAMA:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 3;
+			case DANCE:
+				if(setMotion == Integer.MIN_VALUE) setMotion = 14;
+			case PLAY:
+				for(int i = 0; i < frame.length; i++) {
+					if(frame[i] == Integer.MIN_VALUE) frame[i] = anime;
+					if(frame[i] < 1) frame[i] = 100;
+				}
+				//ダミー用
+				Pixmap pixmap = new Pixmap( 1, 1, Format.RGBA8888 );
+				Texture transparent = new Texture( pixmap );
+				SkinImage part = null;
+				//#Pattern,#Texture,#Layerの順に描画設定を行う
+				int[] setBMPIndex = {CharBMPIndex,CharTexIndex,CharBMPIndex};
+				for(int patternIndex = 0; patternIndex < 3; patternIndex++) {
+					setBMP = CharBMP[setBMPIndex[patternIndex] + setColor-1];
+					for(int patternDataIndex = 0; patternDataIndex < patternData.get(patternIndex).size(); patternDataIndex++) {
+						String[] str = patternData.get(patternIndex).get(patternDataIndex).split("\t", -1);
+						if (str.length > 1) {
+							int motion = Integer.MIN_VALUE;
+							String dst[] = new String[4];
+							Arrays.fill(dst, "");
+							List<String> data = PMparseStr(str);
+							if(data.size() > 1) motion = PMparseInt(data.get(1));
+							for (int i = 0; i < dst.length; i++) {
+								if(data.size() > i + 2) dst[i] = data.get(i + 2).replaceAll("[^0-9a-fA-F-]", "");
+							}
+							int timer = Integer.MIN_VALUE;
+							int op[] = {0,0,0};
+							if(setMotion != Integer.MIN_VALUE && setMotion == motion) {
+								timer = dsttimer;
+								op[0] = dstOp1;
+								op[1] = dstOp2;
+								op[2] = dstOp3;
+							} else if(setMotion == Integer.MIN_VALUE) {
+								if(side != 2) {
+									if(motion == 1) timer = TIMER_PM_CHARA_1P_NEUTRAL;
+									else if(motion == 6) timer = TIMER_PM_CHARA_1P_FEVER;
+									else if(motion == 7) timer = TIMER_PM_CHARA_1P_GREAT;
+									else if(motion == 8) timer = TIMER_PM_CHARA_1P_GOOD;
+									else if(motion == 4) timer = TIMER_PM_CHARA_1P_BAD;
+									else if(motion >= 15 && motion <= 17) {
+										timer = TIMER_MUSIC_END;
+										if(motion == 15) {
+											op[0] = OPTION_1P_BORDER_OR_MORE;	//WIN
+											op[1] = -OPTION_1P_100;
+										}
+										else if(motion == 16) op[0] = -OPTION_1P_BORDER_OR_MORE;	//LOSE
+										else if(motion == 17) op[0] = OPTION_1P_100;	//FEVERWIN
+									}
+								} else {
+									if(motion == 1) timer = TIMER_PM_CHARA_2P_NEUTRAL;
+									else if(motion == 7) timer = TIMER_PM_CHARA_2P_GREAT;
+									else if(motion == 4) timer = TIMER_PM_CHARA_2P_BAD;
+									else if(motion == 15 || motion == 16) {
+										timer = TIMER_MUSIC_END;
+										if(motion == 15) op[0] = -OPTION_1P_BORDER_OR_MORE;	//WIN
+										else if(motion == 16) op[0] = OPTION_1P_BORDER_OR_MORE;	//LOSE
+									}
+								}
+							}
+							if(timer != Integer.MIN_VALUE
+									&& (dst[0].length() > 0 && dst[0].length() % 2 == 0)
+									&& (dst[1].length() == 0 || (dst[1].length() > 0 && dst[1].length() == dst[0].length()))
+									&& (dst[2].length() == 0 || (dst[2].length() > 0 && dst[2].length() == dst[0].length()))
+									&& (dst[3].length() == 0 || (dst[3].length() > 0 && dst[3].length() == dst[0].length()))
+									) {
+								if(loop[motion] >= dst[0].length() / 2 - 1) loop[motion] = dst[0].length() / 2 - 2;
+								else if(loop[motion] < -1) loop[motion] = -1;
+								int cycle = frame[motion] * dst[0].length() / 2;
+								int loopTime = frame[motion] * (loop[motion]+1);
+								if(setMotion == Integer.MIN_VALUE && timer >= TIMER_PM_CHARA_1P_NEUTRAL && timer < TIMER_MUSIC_END) {
+									skin.setPMcharaTime(timer - TIMER_PM_CHARA_1P_NEUTRAL, cycle);
+								}
+								boolean hyphenFlag = false;
+								for(int i = 1; i < dst.length; i++) {
+									if(dst[i].indexOf("-") != -1) {
+										hyphenFlag = true;
+										break;
+									}
+								}
+								//ハイフンがある時はフレーム補間を行う 60FPSの17msが基準
+								int increaseRate = 1;
+								if(hyphenFlag && frame[motion] > increaseRateThreshold) {
+									for(int i = 1; i <= frame[motion]; i++) {
+										if(frame[motion] / i < increaseRateThreshold && frame[motion] % i == 0) {
+											increaseRate = i;
+											break;
+										}
+									}
+									for(int i = 1; i < dst.length; i++) {
+										int charsIndex = 0;
+										char[] chars = new char[dst[i].length() * increaseRate];
+										for(int j = 0; j < dst[i].length(); j+=2) {
+											for(int k = 0; k < increaseRate; k++) {
+												chars[charsIndex] = dst[i].charAt(j);
+												charsIndex++;
+												chars[charsIndex] = dst[i].charAt(j+1);
+												charsIndex++;
+											}
+										}
+										dst[i] = String.valueOf(chars);
+									}
+								}
+								//DST読み込み
+								double frameTime = frame[motion]/increaseRate;
+								int loopFrame = loop[motion]*increaseRate;
+								int dstxywh[][] = new int[dst[1].length() > 0 ? dst[1].length()/2 : dst[0].length()/2][4];
+								for(int i = 0; i < dstxywh.length;i++){
+									dstxywh[i][0] = 0;
+									dstxywh[i][1] = 0;
+									dstxywh[i][2] = size[0];
+									dstxywh[i][3] = size[1];
+								}
+								int startxywh[] = {0,0,size[0],size[1]};
+								int endxywh[] = {0,0,size[0],size[1]};
+								int count;
+								for(int i = 0; i < dst[1].length(); i+=2) {
+									if(dst[1].length() >= i+2) {
+										if(dst[1].substring(i, i+2).equals("--")) {
+											count = 0;
+											for(int j = i; j < dst[1].length() && dst[1].substring(j, j+2).equals("--"); j+=2) count++;
+											if(PMparseInt(dst[1].substring(i+count*2, i+count*2+2), 16) >= 0 && PMparseInt(dst[1].substring(i+count*2, i+count*2+2), 16) <= 255) endxywh = xywh[PMparseInt(dst[1].substring(i+count*2, i+count*2+2), 16)];
+											for(int j = i; j < dst[1].length() && dst[1].substring(j, j+2).equals("--"); j+=2) {
+												int[] value = new int[dstxywh[0].length];
+												for(int k = 0; k < dstxywh[0].length; k++) {
+													value[k] = startxywh[k] + (endxywh[k] - startxywh[k]) * ((j - i) / 2 + 1) / (count + 1);
+												}
+												System.arraycopy(value,0,dstxywh[j/2],0,value.length);
+											}
+											i += (count - 1) * 2;
+										} else if(PMparseInt(dst[1].substring(i, i+2), 16) >= 0 && PMparseInt(dst[1].substring(i, i+2), 16) <= 255) {
+											startxywh = xywh[PMparseInt(dst[1].substring(i, i+2), 16)];
+											System.arraycopy(startxywh,0,dstxywh[i/2],0,startxywh.length);
+										}
+									}
+								}
+								//alphaとangleの読み込み
+								int alphaAngle[][] = new int[dstxywh.length][2];
+								for(int i = 0; i < alphaAngle.length; i++){
+									alphaAngle[i][0] = 255;
+									alphaAngle[i][1] = 0;
+								}
+								for(int index = 2 ; index < dst.length; index++) {
+									int startValue = 0;
+									int endValue = 0;
+									for(int i = 0; i < dst[index].length(); i+=2) {
+										if(dst[index].length() >= i+2) {
+											if(dst[index].substring(i, i+2).equals("--")) {
+												count = 0;
+												for(int j = i; j < dst[index].length() && dst[index].substring(j, j+2).equals("--"); j+=2) count++;
+												if(PMparseInt(dst[index].substring(i+count*2, i+count*2+2), 16) >= 0 && PMparseInt(dst[index].substring(i+count*2, i+count*2+2), 16) <= 255) {
+													endValue = PMparseInt(dst[index].substring(i+count*2, i+count*2+2), 16);
+													if(index == 3) endValue = Math.round(endValue * 360f / 256f);
+												}
+												for(int j = i; j < dst[index].length() && dst[index].substring(j, j+2).equals("--"); j+=2) {
+													alphaAngle[j/2][index - 2] = startValue + (endValue - startValue) * ((j - i) / 2 + 1) / (count + 1);
+												}
+												i += (count - 1) * 2;
+											} else if(PMparseInt(dst[index].substring(i, i+2), 16) >= 0 && PMparseInt(dst[index].substring(i, i+2), 16) <= 255) {
+												startValue = PMparseInt(dst[index].substring(i, i+2), 16);
+												if(index == 3) startValue = Math.round(startValue * 360f / 256f);;
+												alphaAngle[i/2][index - 2] = startValue;
+											}
+										}
+									}
+								}
+								//ループ開始フレームまで
+								if((loopFrame+increaseRate) != 0) {
+									TextureRegion[] images = new TextureRegion[(loop[motion]+1)];
+									for(int i = 0; i < (loop[motion]+1) * 2; i+=2) {
+										int index = PMparseInt(dst[0].substring(i, i+2), 16);
+										if(index >= 0 && index < xywh.length && xywh[index][2] > 0 && xywh[index][3] > 0) images[i/2] = new TextureRegion(setBMP, xywh[index][0], xywh[index][1], xywh[index][2], xywh[index][3]);
+										else images[i/2] = new TextureRegion(transparent, 0, 0, 1, 1);
+									}
+									part = new SkinImage(images, timer, loopTime);
+									skin.add(part);
+									for(int i = 0; i < (loopFrame+increaseRate); i++) {
+										part.setDestination((int)(frameTime*i),dstx+dstxywh[i][0]*dstw/size[0], dsty+dsth-(dstxywh[i][1]+dstxywh[i][3])*dsth/size[1], dstxywh[i][2]*dstw/size[0], dstxywh[i][3]*dsth/size[1],3,alphaAngle[i][0],255,255,255,1,0,alphaAngle[i][1],0,-1,timer,op[0],op[1],op[2],0);
+									}
+									part.setDestination(loopTime-1,dstx+dstxywh[(loopFrame+increaseRate)-1][0]*dstw/size[0], dsty+dsth-(dstxywh[(loopFrame+increaseRate)-1][1]+dstxywh[(loopFrame+increaseRate)-1][3])*dsth/size[1], dstxywh[(loopFrame+increaseRate)-1][2]*dstw/size[0], dstxywh[(loopFrame+increaseRate)-1][3]*dsth/size[1],3,alphaAngle[(loopFrame+increaseRate)-1][0],255,255,255,1,0,alphaAngle[(loopFrame+increaseRate)-1][1],0,-1,timer,op[0],op[1],op[2],dstOffset);
+								}
+								//ループ開始フレームから
+								TextureRegion[] images = new TextureRegion[dst[0].length() / 2 - (loop[motion]+1)];
+								for(int i = (loop[motion]+1)  * 2; i < dst[0].length(); i+=2) {
+									int index = PMparseInt(dst[0].substring(i, i+2), 16);
+									if(index >= 0 && index < xywh.length && xywh[index][2] > 0 && xywh[index][3] > 0) images[i/2-(loop[motion]+1)] = new TextureRegion(setBMP, xywh[index][0], xywh[index][1], xywh[index][2], xywh[index][3]);
+									else images[i/2-(loop[motion]+1)] = new TextureRegion(transparent, 0, 0, 1, 1);
+								}
+								part = new SkinImage(images, timer, cycle - loopTime);
+								skin.add(part);
+								for(int i = (loopFrame+increaseRate); i < dstxywh.length; i++) {
+									part.setDestination((int)(frameTime*i),dstx+dstxywh[i][0]*dstw/size[0], dsty+dsth-(dstxywh[i][1]+dstxywh[i][3])*dsth/size[1], dstxywh[i][2] * dstw / size[0], dstxywh[i][3] * dsth / size[1],3,alphaAngle[i][0],255,255,255,1,0,alphaAngle[i][1],0,loopTime,timer,op[0],op[1],op[2],0);
+								}
+								part.setDestination(cycle,dstx+dstxywh[dstxywh.length-1][0]*dstw/size[0], dsty+dsth-(dstxywh[dstxywh.length-1][1]+dstxywh[dstxywh.length-1][3])*dsth/size[1], dstxywh[dstxywh.length-1][2] * dstw / size[0], dstxywh[dstxywh.length-1][3] * dsth / size[1],3,alphaAngle[dstxywh.length-1][0],255,255,255,1,0,alphaAngle[dstxywh.length-1][1],0,loopTime,timer,op[0],op[1],op[2],dstOffset);
+							}
+						}
+					}
+				}
+				break;
+		}
+	}
+	private int PMparseInt(String s) {
+		return Integer.parseInt(s.replaceAll("[^0-9-]", ""));
+	}
+	private int PMparseInt(String s, int radix) {
+		return Integer.parseInt(s.replaceAll("[^0-9a-fA-F-]", ""), radix);
+	}
+	private List<String> PMparseStr(String[] s) {
+		List<String> list = new ArrayList<String>();
+		for (int i = 0; i < s.length; i++) {
+			if(s[i].length() > 0) {
+				if(s[i].startsWith("/")) {
+					break;
+				} else if(s[i].indexOf("//") != -1) {
+					list.add(s[i].substring(0, s[i].indexOf("//")));
+					break;
+				} else {
+					list.add(s[i]);
+				}
+			}
+		}
+		return list;
+	}
+
+
 }

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -967,7 +967,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 			case GOOD:
 				if(setMotion == Integer.MIN_VALUE) setMotion = 8;
 			case BAD:
-				if(setMotion == Integer.MIN_VALUE) setMotion = 4;
+				if(setMotion == Integer.MIN_VALUE) setMotion = 10;
 			case FEVERWIN:
 				if(setMotion == Integer.MIN_VALUE) setMotion = 17;
 			case WIN:
@@ -1015,7 +1015,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 									else if(motion == 6) timer = TIMER_PM_CHARA_1P_FEVER;
 									else if(motion == 7) timer = TIMER_PM_CHARA_1P_GREAT;
 									else if(motion == 8) timer = TIMER_PM_CHARA_1P_GOOD;
-									else if(motion == 4) timer = TIMER_PM_CHARA_1P_BAD;
+									else if(motion == 10) timer = TIMER_PM_CHARA_1P_BAD;
 									else if(motion >= 15 && motion <= 17) {
 										timer = TIMER_MUSIC_END;
 										if(motion == 15) {
@@ -1028,7 +1028,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								} else {
 									if(motion == 1) timer = TIMER_PM_CHARA_2P_NEUTRAL;
 									else if(motion == 7) timer = TIMER_PM_CHARA_2P_GREAT;
-									else if(motion == 4) timer = TIMER_PM_CHARA_2P_BAD;
+									else if(motion == 10) timer = TIMER_PM_CHARA_2P_BAD;
 									else if(motion == 15 || motion == 16) {
 										timer = TIMER_MUSIC_END;
 										if(motion == 15) op[0] = -OPTION_1P_BORDER_OR_MORE;	//WIN


### PR DESCRIPTION
ぽみゅキャラ(*.chp)を読めるようにしました。取り敢えずLR2SKINのみの対応です。
関連して曲終了時(STATE_FINISHED)の処理も変更しています。
また、PMS時に早MISS・早BADを出した後でも遅BADが出てしまっていたので出ないようにしました。

「曲終了時関連」
- STATE_FINISHEDからフェードアウトを開始するまでの時間をスキンで指定出来るように変更
- スタートもしくはセレクトを押しながら最後のノートが通過するとゲージがボーダー以上でもFAILEDになってしまうことがあったので、スタート・セレクト単押しでplayer.stopPlay()が発動する条件を変更
- PMS時に早MISS・早BADを出してからGOOD以上で拾わずに見逃した場合に処理済みノート数notesにカウントされていなかったので、処理済みノート数のカウント方法変更
- STATE_FINISHED時にキービームが出ないように変更
- NUMBER_TIMELEFTが負の値にならないように変更

「ぽみゅキャラ関連」
- DSTの「acc = 3：不連続」を有効化
- LR2スキン定義追加
  - #FINISHMARGIN : STATE_FINISHEDからフェードアウトを開始するまでのマージン(ms)
  - #DST_PM_CHARA_1P,x,y,w,h,color,offset,folderpath
  - #DST_PM_CHARA_2P,x,y,w,h,color,offset,folderpath : プレイ用キャラ定義(判定連動) colorは1で1Pカラー、2で2Pカラーがあれば2Pカラーなければ1Pカラー
  - #DST_PM_CHARA_ANIMATION,x,y,w,h,color,animationtype,timer,op1,op2,op3,offset,folderpath
 : プレイ以外用キャラ定義(判定非連動) typeは0:NEUTRAL 1:FEVER 2:GREAT 3:GOOD 4:BAD 5:FEVERWIN 6:WIN 7:LOSE 8:OJAMA 9:DANCE
  - #SRC_PM_CHARA_IMAGE,color,type,folderpath
 : キャラの各種画像 SRC_IMAGEのように使う typeは0:キャラ背景 1:名前画像 2:ハリアイ画像(上半身のみ) 3:ハリアイ画像(全体) 4:キャラアイコン
  - #DST_PM_CHARA_IMAGE : DST_IMAGEと同様の書式
- ぽみゅキャラに関するタイマー追加
  - TIMER_PM_CHARA_1P_NEUTRAL～TIMER_PM_CHARA_2P_BAD : 各キャラ動作中に発動
 #DST_PM_CHARA_1P 2P用
  - TIMER_MUSIC_END : 曲終了時に発動
  - TIMER_PM_CHARA_DANCE : 曲開始時に発動・曲終了時にオフ
- OPTION_1P_0_9～OPTION_1P_100を有効化

また、ご相談したいことがありまして、キャラデータを一か所にまとめ、1P2P別々のデータを参照するようにしたいのですが、そのような仕様の#CUSTOMFILEを新設もしくは仕様変更していただくことはお願い出来ますでしょうか？
LR2のLight Pop EX ( http://misty.orz.hm/lpex.html ) では、#CUSTOMFILEのpathの区切り文字が「/」と「\」で別文字扱いになる仕様を利用して実現していましたが、Windows以外との兼ね合いがあると思うので…