### PR TITLE
fix exch-bms2/beatoraja#165 IIDX premium controller does not work on Linux

### DIFF
--- a/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.input;
 
 
+import java.io.File;
 import java.util.Arrays;
 import java.util.logging.Logger;
 
@@ -195,7 +196,9 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice implements 
 			}
 		}
 
-		float analogScratchX = axis[1];
+		// Linux : axis[0]
+		// Windows : axis[1]
+		float analogScratchX = File.separatorChar == '\\' ? axis[1] :  axis[0];
 		if (oldAnalogScratchX > 1) {
 			oldAnalogScratchX = analogScratchX;
 			activeAnalogScratch = false;


### PR DESCRIPTION
exch-bms2/beatoraja#165

Tested on `Ubuntu 16.04`.
(I confirmed that I did not degrade on `Windows 10`.)

***
* OS判定色々ありますが今の主流って何なんですかね…
* 同様の問題がアナログじゃないコントローラでも発生しそうですが未検証です。