### PR TITLE
Use lane region to calculate offset values

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -1034,7 +1034,7 @@ public class BMSPlayer extends MainState {
         case OFFSET_LIFT_OBSOLETE:
             if (lanerender.isEnableLift()) {
                 final PlaySkin skin = (PlaySkin) getSkin();
-                offset.y = lanerender.getLiftRegion() * (skin.getHeight() - skin.getLaneGroupRegion()[0].y);
+                offset.y = lanerender.getLiftRegion() * skin.getLaneRegion()[0].height;
             } else {
             	offset.y = 0;
             }
@@ -1045,9 +1045,9 @@ public class BMSPlayer extends MainState {
                 final PlaySkin skin = (PlaySkin) getSkin();
                 if (lanerender.isEnableLift()) {
                     offset.y =  -(1 - lanerender.getLiftRegion()) * lanerender.getLanecover()
-                            * (skin.getHeight() - skin.getLaneGroupRegion()[0].y);
+                            * skin.getLaneRegion()[0].height;
                 } else {
-                    offset.y =  -lanerender.getLanecover() * (skin.getHeight() - skin.getLaneGroupRegion()[0].y);
+                    offset.y =  -lanerender.getLanecover() * skin.getLaneRegion()[0].height;
                 }
             } else {
             	offset.y = 0;

--- a/src/bms/player/beatoraja/play/PlaySkin.java
+++ b/src/bms/player/beatoraja/play/PlaySkin.java
@@ -23,6 +23,7 @@ public class PlaySkin extends Skin {
 	private SkinImage[] bpm = new SkinImage[0];
 	private SkinImage[] stop = new SkinImage[0];
 
+	private Rectangle[] laneregion;
 	private Rectangle[] lanegroupregion;
 
 	private int judgeregion;
@@ -69,6 +70,14 @@ public class PlaySkin extends Skin {
 
 	public void setLaneGroupRegion(Rectangle[] r) {
 		lanegroupregion = r;
+	}
+
+	public Rectangle[] getLaneRegion() {
+		return laneregion;
+	}
+
+	public void setLaneRegion(Rectangle[] r) {
+		laneregion = r;
 	}
 
 	public void setJudgeregion(int jr) {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -525,6 +525,7 @@ public class JSONSkinLoader extends SkinLoader{
 						SkinNote sn = new SkinNote(notes, lnss, mines);
 						sn.setLaneRegion(region, scale, skin);
 						sn.setDstNote2(sk.note.dst2);
+						((PlaySkin) skin).setLaneRegion(region);
 						((PlaySkin) skin).setLaneGroupRegion(gregion);
 						((PlaySkin) skin).setNoteExpansionRate(sk.note.expansionrate);
 						obj = sn;

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -827,6 +827,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			else break;
 		}
 		skin.setJudgeregion(judge_reg);
+		skin.setLaneRegion(laner);
 		skin.setLaneGroupRegion(playerr);
 
 		return skin;


### PR DESCRIPTION
元の計算式ではレーン上端が画面上端と一致しないスキンでoffset値がずれてしまうため、正確に計算できる lane region を使うようにしました。