### PR TITLE
Enable HS change during play in practice mode

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -482,12 +482,14 @@ public class BMSPlayer extends MainState {
 				setTimerOff(TIMER_PM_CHARA_2P_NEUTRAL);
 			}
 			control.setEnableControl(false);
+			control.setEnableCursor(false);
 			practice.processInput(input);
 
 			if (input.getKeystate()[0] && resource.mediaLoadFinished() && now > skin.getLoadstart() + skin.getLoadend()
 					&& now - startpressedtime > 1000) {
 				PracticeProperty property = practice.getPracticeProperty();
 				control.setEnableControl(true);
+				control.setEnableCursor(true);
 				if (property.freq != 100) {
 					model.setFrequency(property.freq / 100f);
 					if (getMainController().getConfig().getAudioFreqOption() == Config.AUDIO_PLAY_FREQ) {


### PR DESCRIPTION
* Practiceモードのプレイ中にハイスピの設定が利かなかったので修正
* キー処理部分をモードごとに別メソッドに分けて整理、さらに24key用の処理を追加
* Practiceモードの待機状態でハイスピ設定を可能にする修正を見越して、干渉する矢印キーの入力を無効にするメソッドを追加