### PR TITLE
Change gauge type when "continue until end of song option" is on

### DIFF
--- a/src/bms/player/beatoraja/PlayerResource.java
+++ b/src/bms/player/beatoraja/PlayerResource.java
@@ -96,11 +96,16 @@ public class PlayerResource {
 	 * 最大コンボ数。コースプレイ時の引継ぎに使用
 	 */
 	private int maxcombo;
+	/**
+	 * 元々のゲージオプション
+	 */
+	private int orgGaugeOption = 0;
 
 	public PlayerResource(AudioDriver audio, Config config, PlayerConfig pconfig) {
 		this.config = config;
 		this.pconfig = pconfig;
 		this.bmsresource = new BMSResource(audio, config, pconfig);
+		this.orgGaugeOption = pconfig.getGauge();
 	}
 
 	public void clear() {
@@ -382,5 +387,13 @@ public class PlayerResource {
 
 	public BMSResource getBMSResource() {
 		return bmsresource;
+	}
+
+	public int getOrgGaugeOption() {
+		return orgGaugeOption;
+	}
+
+	public void setOrgGaugeOption(int orgGaugeOption) {
+		this.orgGaugeOption = orgGaugeOption;
 	}
 }

--- a/src/bms/player/beatoraja/decide/MusicDecide.java
+++ b/src/bms/player/beatoraja/decide/MusicDecide.java
@@ -28,6 +28,8 @@ public class MusicDecide extends MainState {
 		play(SOUND_DECIDE);
 
 		loadSkin(SkinType.DECIDE);
+
+		main.getPlayerResource().setOrgGaugeOption(main.getPlayerResource().getPlayerConfig().getGauge());
 	}
 
 	public void render() {

--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -353,6 +353,9 @@ public class CourseResult extends MainState {
 			if (saveReplay[index] == -1 && resource.isUpdateScore()) {
 				// 保存されているリプレイデータがない場合は、EASY以上で自動保存
 				ReplayData[] rd = resource.getCourseReplay();
+				for(int i = 0; i < rd.length - 1; i++) {
+					rd[i].gauge = rd[rd.length - 1].gauge;
+				}
 				main.getPlayDataAccessor().wrireReplayData(rd, resource.getCourseBMSModels(),
 						resource.getPlayerConfig().getLnmode(), index, resource.getConstraint());
 				saveReplay[index] = 1;

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -139,6 +139,7 @@ public class MusicResult extends MainState {
 						main.changeState(MainController.STATE_GRADE_RESULT);
 					}
 				} else {
+					main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
 					ResultKeyProperty.ResultKey key = null;
 					for(int i = 0; i < property.getAssignLength(); i++) {
 						if(property.getAssign(i) == ResultKeyProperty.ResultKey.REPLAY_DIFFERENT && keystate[i]) {

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -621,6 +621,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 					}
 					TextureRegion[][] gauge;
 					if(values[14] == 3 && divx * divy % 6 == 0) {
+						//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、発光表赤、発光表緑の順にsrc分割
 						gauge = new TextureRegion[(divx * divy) / 6][12];
 						final int w = values[5];
 						final int h = values[6];
@@ -668,7 +669,65 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 						if(values[13] == 0) {
 							gauger = new SkinGauge(gauge, values[10], values[9], mode == Mode.POPN_9K ? 24 : 50, 0, mode == Mode.POPN_9K ? 0 : 3, 33);
 						} else {
-							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);							
+							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
+						}
+
+						skin.add(gauger);
+					}
+				}
+			}
+		});
+		addCommandWord(new CommandWord("SRC_GROOVEGAUGE_EX") {
+			//JSONスキンと同形式版 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑の順にsrc分割
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				if (values[2] < imagelist.size() && imagelist.get(values[2]) != null) {
+					int playside = values[1];
+					int divx = values[7];
+					if (divx <= 0) {
+						divx = 1;
+					}
+					int divy = values[8];
+					if (divy <= 0) {
+						divy = 1;
+					}
+					TextureRegion[][] gauge;
+					if(values[14] == 3 && divx * divy % 12 == 0) {
+						//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑、発光表赤、発光表緑、発光EX表赤、発光EX表緑の順にsrc分割
+						gauge = new TextureRegion[(divx * divy) / 12][12];
+						final int w = values[5];
+						final int h = values[6];
+						for (int x = 0; x < divx; x++) {
+							for (int y = 0; y < divy; y++) {
+								if ((y * divx + x) / 12 < gauge.length) {
+										gauge[(y * divx + x) / 12][(y * divx + x) % 12] = new TextureRegion(
+												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
+												values[4] + h * y / divy, w / divx, h / divy);
+								}
+							}
+						}
+					} else {
+						gauge = new TextureRegion[(divx * divy) / 8][8];
+						final int w = values[5];
+						final int h = values[6];
+						for (int x = 0; x < divx; x++) {
+							for (int y = 0; y < divy; y++) {
+								if ((y * divx + x) / 8 < gauge.length) {
+									gauge[(y * divx + x) / 8][(y * divx + x) % 8] = new TextureRegion(
+											(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
+											values[4] + h * y / divy, w / divx, h / divy);
+								}
+							}
+						}
+					}
+					groovex = values[11];
+					groovey = values[12];
+					if (gauger == null) {
+						if(values[13] == 0) {
+							gauger = new SkinGauge(gauge, values[10], values[9], mode == Mode.POPN_9K ? 24 : 50, 0, mode == Mode.POPN_9K ? 0 : 3, 33);
+						} else {
+							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
 						}
 						
 						skin.add(gauger);


### PR DESCRIPTION
途中落ち無しオプションがオンの時に、減少型ゲージでゲージが尽きた場合は1つ下のゲージに切り替わるようにしました。通常段位ゲージでは切り替わらずに曲の最後でFAILEDになります。
また、LR2スキンでもゲージ切り替えを出来るようにするために、JSONスキンと同じsrc分割順でEXゲージ粒まで定義出来る「SRC_GROOVEGAUGE_EX」を追加しました。