### PR TITLE
Add KeyConfig DeleteKey

### DIFF
--- a/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -98,6 +98,8 @@ public class KeyConfiguration extends MainState {
 	private ControllerConfig[] controllerConfigs;
 	private MidiConfig midiconfig;
 
+	private boolean deletepressed = false;
+
 	public KeyConfiguration(MainController main) {
 		super(main);
 
@@ -161,6 +163,10 @@ public class KeyConfiguration extends MainState {
 			if (keyinput && midiinput.hasLastPressedKey()) {
 				setMidiKeyAssign(midikeysa[cursorpos]);
 				keyinput = false;
+			}
+			if (input.isDeletePressed()) {
+				deletepressed = true;
+				input.setDeletePressed(false);
 			}
 		} else {
 			if (cursor[0] && cursortime[0] != 0) {
@@ -247,6 +253,12 @@ public class KeyConfiguration extends MainState {
 				main.saveConfig();
 				main.changeState(MainController.STATE_SELECTMUSIC);
 			}
+
+			if (input.isDeletePressed()) {
+				if(!deletepressed) resetKeyAssign(keysa[cursorpos], bmkeysa[cursorpos], midikeysa[cursorpos]);
+				deletepressed = true;
+				input.setDeletePressed(false);
+			} else deletepressed = false;
 		}
 
 		sprite.begin();
@@ -404,6 +416,30 @@ public class KeyConfiguration extends MainState {
 				cc.getKeyAssign()[index] = -1;
 			}
 			midiconfig.setKeyAssign(index, null);
+		}
+	}
+
+	private void resetKeyAssign(int KBIndex, int BMIndex, int MidiIndex) {
+		final int noAssign = -1;
+		if (KBIndex >= 0) keyboardConfig.getKeyAssign()[KBIndex] = noAssign;
+		if(BMIndex >= 0) {
+				for (ControllerConfig cc : controllerConfigs) {
+					cc.getKeyAssign()[BMIndex] = noAssign;
+				}
+		} else if (BMIndex == -1) {
+			for (int i = 0; i < controllerConfigs.length; i++) {
+				controllerConfigs[i].setStart(noAssign);
+			}
+		} else if (BMIndex == -2) {
+			for (int i = 0; i < controllerConfigs.length; i++) {
+				controllerConfigs[i].setSelect(noAssign);
+			}
+		}
+		if(MidiIndex >= 0) midiconfig.setKeyAssign(MidiIndex, null);
+		else if (MidiIndex == -1) {
+			midiconfig.setStart(null);
+		} else if (MidiIndex == -2) {
+			midiconfig.setSelect(null);
 		}
 	}
 

--- a/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -127,6 +127,7 @@ public class BMSPlayerInputProcessor {
 
 	private boolean exitPressed;
 	private boolean enterPressed;
+	private boolean deletePressed;
 
 	boolean[] cursor = new boolean[4];
 	long[] cursortime = new long[4];
@@ -346,6 +347,14 @@ public class BMSPlayerInputProcessor {
 
 	public void setEnterPressed(boolean enterPressed) {
 		this.enterPressed = enterPressed;
+	}
+
+	public boolean isDeletePressed() {
+		return deletePressed;
+	}
+
+	public void setDeletePressed(boolean deletePressed) {
+		this.deletePressed = deletePressed;
 	}
 
 	public boolean[] getFunctionstate() {

--- a/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -45,7 +45,9 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 	private int exit = Keys.ESCAPE;
 
 	private int enter = Keys.ENTER;
-	
+
+	private int delete = Keys.FORWARD_DEL;
+
 	private final IntArray reserved;
 	/**
 	 * 最後に押されたキー
@@ -171,6 +173,11 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 		if (enterpressed != keystate[enter]) {
 			keystate[enter] = enterpressed;
 			this.bmsPlayerInputProcessor.setEnterPressed(enterpressed);
+		}
+		final boolean deletepressed = Gdx.input.isKeyPressed(delete);
+		if (deletepressed != keystate[delete]) {
+			keystate[delete] = deletepressed;
+			this.bmsPlayerInputProcessor.setDeletePressed(deletepressed);
 		}
 	}
 


### PR DESCRIPTION
キーコンフィグにおいて、自作コントローラーなどでプレイ分のボタンしか無い場合にスタートセレクトを解除出来ないので、キーボードのDeleteで解除出来るようにしました。

追記:すみません、勘違いしてました。解除出来なくてもプレイには支障はないですね