### PR TITLE
Modify Change gauge type when course play

### DIFF
--- a/src/bms/player/beatoraja/PlayerResource.java
+++ b/src/bms/player/beatoraja/PlayerResource.java
@@ -63,7 +63,7 @@ public class PlayerResource {
 	/**
 	 * ゲージの遷移ログ
 	 */
-	private FloatArray gauge;
+	private FloatArray[] gauge;
 
 	private ReplayData replay;
 
@@ -86,7 +86,7 @@ public class PlayerResource {
 	/**
 	 * コースゲージ履歴
 	 */
-	private List<FloatArray> coursegauge = new ArrayList<FloatArray>();
+	private List<FloatArray[]> coursegauge = new ArrayList<FloatArray[]>();
 
 	private List<ReplayData> courseReplay = new ArrayList<ReplayData>();
 	/**
@@ -303,6 +303,10 @@ public class PlayerResource {
 		}
 	}
 
+	public int getCourseIndex() {
+		return courseindex;
+	}
+
 	public void reloadBMSFile() {
 		if (model != null) {
 			model = loadBMSModel(Paths.get(model.getPath()), pconfig.getLnmode());
@@ -310,11 +314,11 @@ public class PlayerResource {
 		clear();
 	}
 
-	public FloatArray getGauge() {
+	public FloatArray[] getGauge() {
 		return gauge;
 	}
 
-	public void setGauge(FloatArray gauge) {
+	public void setGauge(FloatArray[] gauge) {
 		this.gauge = gauge;
 	}
 
@@ -366,11 +370,11 @@ public class PlayerResource {
 		courseReplay.add(rd);
 	}
 
-	public List<FloatArray> getCourseGauge() {
+	public List<FloatArray[]> getCourseGauge() {
 		return coursegauge;
 	}
 
-	public void addCourseGauge(FloatArray gauge) {
+	public void addCourseGauge(FloatArray[] gauge) {
 		coursegauge.add(gauge);
 	}
 

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -299,9 +299,11 @@ public class BMSPlayer extends MainState {
 			}
 		}
 		gauge = GrooveGauge.create(model, replay != null ? replay.gauge : config.getGauge(), coursetype, gauges);
-		FloatArray f = resource.getGauge();
+		FloatArray[] f = resource.getGauge();
 		if (f != null) {
-			gauge.setValue(f.get(f.size - 1));
+			for(int i = 0; i < f.length; i++) {
+				gauge.setValue(i, f[i].get(f[i].size - 1));
+			}
 		}
 		gaugelog = new FloatArray[gauge.getGaugeTypeLength()];
 		for(int i = 0; i < gaugelog.length; i++) {
@@ -685,7 +687,7 @@ public class BMSPlayer extends MainState {
 				if(config.isContinueUntilEndOfSong() && notes != main.getPlayerResource().getSongdata().getNotes() && !isFailed && gauge.getType() != GrooveGauge.HAZARD) {
 					if(gauge.getType() != GrooveGauge.CLASS) {
 						gauge.downType();
-						config.setGauge(config.getGauge() > 0 ? config.getGauge() - 1 :0);
+						if(resource.getPlayMode() == PlayMode.PLAY) config.setGauge(config.getGauge() > 0 ? config.getGauge() - 1 :0);
 					} else {
 						isFailed = true;
 					}
@@ -725,7 +727,7 @@ public class BMSPlayer extends MainState {
 						}
 					}
 				}
-				resource.setGauge(gaugelog[gauge.getType()]);
+				resource.setGauge(gaugelog);
 				resource.setGrooveGauge(gauge);
 				input.setEnable(true);
 				input.setStartTime(0);
@@ -749,7 +751,10 @@ public class BMSPlayer extends MainState {
 			}
 			if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
 				if(config.isContinueUntilEndOfSong()) {
-					config.setGauge(config.getGauge() + gauge.changeTypeOfClear(gauge.getType()));
+					if(resource.getCourseBMSModels() == null) {
+						int changedGaugeType = gauge.changeTypeOfClear(gauge.getType());
+						if(resource.getPlayMode() == PlayMode.PLAY) config.setGauge(changedGaugeType);
+					}
 				}
 				main.getAudioProcessor().setGlobalPitch(1f);
 				resource.getBGAManager().stop();
@@ -759,7 +764,7 @@ public class BMSPlayer extends MainState {
 				resource.setCombo(judge.getCourseCombo());
 				resource.setMaxcombo(judge.getCourseMaxcombo());
 				saveConfig();
-				resource.setGauge(gaugelog[gauge.getType()]);
+				resource.setGauge(gaugelog);
 				resource.setGrooveGauge(gauge);
 				input.setEnable(true);
 				input.setStartTime(0);

--- a/src/bms/player/beatoraja/play/GrooveGauge.java
+++ b/src/bms/player/beatoraja/play/GrooveGauge.java
@@ -146,6 +146,10 @@ public class GrooveGauge {
 		return  type;
 	}
 
+	public void setType(int type) {
+		this.type = type;
+	}
+
 	public void downType() {
 		type = type > 0 ? type - 1 : 0;
 		cleartype = ClearType.getClearTypeByGauge(type);
@@ -160,8 +164,15 @@ public class GrooveGauge {
 					cleartype = ClearType.getClearTypeByGauge(this.type);
 				}
 			}
+		} else if(type >= CLASS && type <= EXHARDCLASS) {
+			for(int i = CLASS; i <= EXHARDCLASS; i++) {
+				if(value[i] >= property.values[i].border && value[i] != 0) {
+					this.type = i;
+					cleartype = ClearType.getClearTypeByGauge(this.type);
+				}
+			}
 		}
-		return (this.type - type);
+		return this.type;
 	}
 
 	public void setStopUpdate(int type, boolean stopUpdate) {

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -201,7 +201,7 @@ public class JudgeManager {
 
 		this.autoplay = resource.getPlayMode().isAutoPlayMode();
 		
-		FloatArray f = resource.getGauge();
+		FloatArray[] f = resource.getGauge();
 		if (f != null) {
 			setCourseCombo(resource.getCombo());
 			setCourseMaxcombo(resource.getMaxcombo());

--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -59,9 +59,12 @@ public class CourseResult extends MainState {
 		loadSkin(SkinType.COURSE_RESULT);
 
         for(int i = resource.getCourseGauge().size();i < resource.getCourseBMSModels().length;i++) {
-        	FloatArray list = new FloatArray();
-            for(int l = 0;l < (resource.getCourseBMSModels()[i].getLastNoteTime() + 500) / 500;l++) {
-                list.add(0f);
+            FloatArray[] list = new FloatArray[resource.getGrooveGauge().getGaugeTypeLength()];
+            for(int type = 0; type < list.length; type++) {
+                list[type] = new FloatArray();
+                for(int l = 0;l < (resource.getCourseBMSModels()[i].getLastNoteTime() + 500) / 500;l++) {
+                    list[type].add(0f);
+                }
             }
             resource.getCourseGauge().add(list);
         }
@@ -95,6 +98,7 @@ public class CourseResult extends MainState {
 
 		if (main.isTimerOn(TIMER_FADEOUT)) {
 			if (main.getNowTime(TIMER_FADEOUT) > getSkin().getFadeout()) {
+				main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
 				stop(SOUND_CLEAR);
 				stop(SOUND_FAIL);
 				stop(SOUND_CLOSE);
@@ -354,8 +358,8 @@ public class CourseResult extends MainState {
 			if (saveReplay[index] == -1 && resource.isUpdateScore()) {
 				// 保存されているリプレイデータがない場合は、EASY以上で自動保存
 				ReplayData[] rd = resource.getCourseReplay();
-				for(int i = 0; i < rd.length - 1; i++) {
-					rd[i].gauge = rd[rd.length - 1].gauge;
+				for(int i = 0; i < rd.length; i++) {
+					rd[i].gauge = resource.getPlayerConfig().getGauge();
 				}
 				main.getPlayDataAccessor().wrireReplayData(rd, resource.getCourseBMSModels(),
 						resource.getPlayerConfig().getLnmode(), index, resource.getConstraint());

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -117,10 +117,10 @@ public class MusicResult extends MainState {
 				Arrays.fill(keytime, 0);
 
 				if (resource.getCourseBMSModels() != null) {
-					if (resource.getGauge().get(resource.getGauge().size - 1) <= 0) {
+					if (resource.getGauge()[resource.getGrooveGauge().getType()].get(resource.getGauge()[resource.getGrooveGauge().getType()].size - 1) <= 0) {
 						if (resource.getCourseScoreData() != null) {
 							// 未達曲のノーツをPOORとして加算
-							final List<FloatArray> coursegauge = resource.getCourseGauge();
+							final List<FloatArray[]> coursegauge = resource.getCourseGauge();
 							final int cg = resource.getCourseBMSModels().length;
 							for (int i = 0; i < cg; i++) {
 								if (coursegauge.size() <= i) {
@@ -138,6 +138,10 @@ public class MusicResult extends MainState {
 						main.changeState(MainController.STATE_PLAYBMS);
 					} else {
 						// 合格リザルト
+						if(resource.getPlayerConfig().isContinueUntilEndOfSong()) {
+							int changedGaugeType = resource.getGrooveGauge().changeTypeOfClear(resource.getGrooveGauge().getType());
+							if(resource.getPlayMode() == PlayMode.PLAY) resource.getPlayerConfig().setGauge(changedGaugeType + resource.getGrooveGauge().NORMAL - resource.getGrooveGauge().CLASS);
+						}
 						main.changeState(MainController.STATE_GRADE_RESULT);
 					}
 				} else {
@@ -323,8 +327,11 @@ public class MusicResult extends MainState {
 			cscore.setEms(cscore.getEms() + newscore.getEms());
 			cscore.setLms(cscore.getLms() + newscore.getLms());
 			cscore.setMinbp(cscore.getMinbp() + newscore.getMinbp());
-			if (resource.getGauge().get(resource.getGauge().size - 1) > 0) {
+			if (resource.getGauge()[resource.getGrooveGauge().getType()].get(resource.getGauge()[resource.getGrooveGauge().getType()].size - 1) > 0) {
+				int orgGaugeType = resource.getGrooveGauge().getType();
+				if(resource.getPlayerConfig().isContinueUntilEndOfSong() && resource.getCourseIndex() == resource.getCourseBMSModels().length - 1) resource.getGrooveGauge().changeTypeOfClear(resource.getGrooveGauge().getType());
 				cscore.setClear(resource.getGrooveGauge().getClearType().id);
+				if(resource.getPlayerConfig().isContinueUntilEndOfSong() && resource.getCourseIndex() == resource.getCourseBMSModels().length - 1) resource.getGrooveGauge().setType(orgGaugeType);
 			} else {
 				cscore.setClear(Failed.id);
 
@@ -353,7 +360,7 @@ public class MusicResult extends MainState {
 				case PlayerConfig.IR_SEND_ALWAYS:
 					break;
 				case PlayerConfig.IR_SEND_COMPLETE_SONG:
-					FloatArray gauge = resource.getGauge();
+					FloatArray gauge = resource.getGauge()[resource.getGrooveGauge().getType()];
 					send &= gauge.get(gauge.size - 1) > 0.0;
 					break;
 				case PlayerConfig.IR_SEND_UPDATE_SCORE:
@@ -504,7 +511,7 @@ public class MusicResult extends MainState {
 			}
 			return resource.getScoreData().getCombo() - oldscore.getCombo();
 		case NUMBER_GROOVEGAUGE:
-			return (int) resource.getGauge().get(resource.getGauge().size - 1);
+			return (int) resource.getGauge()[resource.getGrooveGauge().getType()].get(resource.getGauge()[resource.getGrooveGauge().getType()].size - 1);
 			case NUMBER_AVERAGE_DURATION:
 			return (int) avgduration;
 		case NUMBER_AVERAGE_DURATION_AFTERDOT:

--- a/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
+++ b/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
@@ -85,13 +85,13 @@ public class SkinGaugeGraphObject extends SkinObject {
 			Pixmap shape = new Pixmap((int) graph.width, (int) graph.height, Pixmap.Format.RGBA8888);
 			// ゲージグラフ描画
 			color = typetable[resource.getGrooveGauge().getType()];
-			gauge = resource.getGauge();
+			gauge = resource.getGauge()[resource.getGrooveGauge().getType()];
 			IntArray section = new IntArray();
 			if (state instanceof CourseResult) {
 				gauge = new FloatArray();
-				for (FloatArray l : resource.getCourseGauge()) {
-					gauge.addAll(l);
-					section.add((section.size > 0 ? section.get(section.size - 1) : 0) + l.size);
+				for (FloatArray[] l : resource.getCourseGauge()) {
+					gauge.addAll(l[resource.getGrooveGauge().getType()]);
+					section.add((section.size > 0 ? section.get(section.size - 1) : 0) + l[resource.getGrooveGauge().getType()].size);
 				}
 			}
 			shape.setColor(graphcolor[color]);


### PR DESCRIPTION
途中落ち無しオプションがオンで、コースをプレイした場合に、曲間で現在のゲージタイプの残量で全てのゲージタイプの残量が引き継がれてしまっていたので、各ゲージタイプそれぞれ別々に引き継ぐようにしました。