### PR TITLE
Fix "no sound" issue when there are leading slashes in #WAV paths

### DIFF
--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -227,6 +227,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				continue;
 			}
 			String name = model.getWavList()[wavid];
+                        name = name.replaceFirst("^[\\\\\\/]+", ""); //trim leading \ at the start
+                        
 			for (Note note : waventry.getValue()) {
 				if (note.getMicroStarttime() == 0 && note.getMicroDuration() == 0) {
 					// 音切りなしのケース


### PR DESCRIPTION
e.g. #WAV01 \20074a\0001.wav was being resolved to "E:\20074a\0001.wav" instead of "E:\beatoraja\songs\neu\20074a\0001.wav"

demo: https://youtu.be/OrHJfT64VRA