### PR TITLE
Modify Key on timer update timing

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -803,6 +803,10 @@ public class BMSPlayer extends MainState {
 		keyinput.input();
 	}
 
+	public KeyInputProccessor getKeyinput() {
+		return keyinput;
+	}
+
 	public int getState() {
 		return state;
 	}

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -468,6 +468,7 @@ public class JudgeManager {
 						}							
 					}
 				}
+				main.getKeyinput().inputKeyOn(lane);
 			} else {
 				// キーが離されたときの処理
 				if (processing[lane] != null) {


### PR DESCRIPTION
判定が出る前にキービームがオンになることがあり、判定連動キービームの場合、前の判定の色でキービームが出た後に判定が反映されて色が変わることがあったので、判定を待ってからキーオンタイマーを更新するようにしました。