### PR TITLE
Change mouse wheel direction

### DIFF
--- a/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -187,7 +187,7 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 	}
 
 	public boolean scrolled(int amount) {
-		this.bmsPlayerInputProcessor.scroll += amount;
+		this.bmsPlayerInputProcessor.scroll -= amount;
 		return false;
 	}
 


### PR DESCRIPTION
マウスホイールで動く方向をLR2と合わせました。
DAOコンにはSTART+SCでマウスホイールを用いたアナログSC機能があるので、LR2と同じ方向ですと有り難いです。