### PR TITLE
Config: Modify default number of simulataneous audio sources

### DIFF
--- a/src/bms/player/beatoraja/Config.java
+++ b/src/bms/player/beatoraja/Config.java
@@ -53,7 +53,7 @@ public class Config {
 	/**
 	 * オーディオ同時発音数
 	 */
-	private int audioDeviceSimultaneousSources = 64;
+	private int audioDeviceSimultaneousSources = 128;
 
 	/**
 	 * オーディオ再生速度変化の処理:なし


### PR DESCRIPTION
In some general BMS, some sounds do not sound when the simultaneous audio sources number is 64, so I changed the initial value of it to 128.
e.g. 桜シロガネ妖狐伝説
http://manbow.nothing.sh/event/event.cgi?action=More_def&num=96&event=115