### PR TITLE
MusicSelect: move to search result after search

### DIFF
--- a/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/src/bms/player/beatoraja/select/SearchTextField.java
@@ -62,10 +62,12 @@ public class SearchTextField extends Stage {
 						if (count > 0) {
 							selector.getBarRender().addSearch(swb);
 							selector.getBarRender().updateBar(null);
+							selector.getBarRender().setSelected(swb);
 							textField.setText("");
 							textField.setMessageText(count + " song(s) found");
 							textFieldStyle.messageFontColor = Color.valueOf("00c0c0");
 						} else {
+							selector.main.getInputProcessor().setEnterPressed(false);
 							textField.setText("");
 							textField.setMessageText("no song found");
 							textFieldStyle.messageFontColor = Color.DARK_GRAY;


### PR DESCRIPTION
曲選択画面で、曲検索後に検索結果を表示するようにしました。
また、検索結果が無い場合は、エンターキーを誤爆しないようにしました。