### PR TITLE
Ant target for release

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,9 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <project default="create_run_jar" name="Create Runnable Jar for Project beatoraja">
 
+	<property environment="env" />
 	<property name="build.src" value="src" />
 	<property name="build.dest" value="build" />
 	<property name="app.version" value="0.5.4"/>
+	<property name="dir.release" value="release" />
+	<property name="dir.release.windows" value="${dir.release}/windows" />
+	<property name="dir.release.linux" value="${dir.release}/linux" />
+
+	<!-- zip file name -->
+	<property name="zipname" value="beatoraja_${app.version}" />
 
 	<!-- launch4j setting -->
 	<property name="launch4j.dir" location="launch4j" />
@@ -13,12 +20,16 @@
 	        :${launch4j.dir}/lib/xstream.jar" />
 
 	<path id="build.lib">
-	   <fileset dir="lib" includes="*.jar" />
+		<fileset dir="lib" includes="*.jar" />
 	</path>
 
 	<target name="clean">
-	   <delete dir="${build.dest}" />
-	   <mkdir dir="${build.dest}" />
+		<delete dir="${build.dest}" />
+		<mkdir dir="${build.dest}" />
+		<delete dir="${dir.release}" />
+		<mkdir dir="${dir.release}" />
+		<mkdir dir="${dir.release}/windows" />
+		<mkdir dir="${dir.release}/linux" />
 	</target>
 
 	<target name="compile" depends="clean">
@@ -26,7 +37,7 @@
 	</target>
 
 	<target name="create_run_jar" depends="compile">
-		<jar destfile="./beatoraja.jar" filesetmanifest="mergewithoutmain" duplicate="preserve">
+		<jar destfile="./${build.dest}/beatoraja.jar" filesetmanifest="mergewithoutmain" duplicate="preserve">
 			<manifest>
 				<attribute name="Main-Class" value="bms.player.beatoraja.MainLoader" />
 				<attribute name="Bundle-NativeCode" value="jasiohost32.dll;jasiohost64.dll" />
@@ -68,5 +79,47 @@
 		</copy>
 		<launch4j configFile="launch4j.xml.tmp" />
 		<delete file="launch4j.xml.tmp"/>
+	</target>
+
+	<target name="filecopy">
+		<copy todir="${dir.release.windows}">
+			<fileset dir="./">
+				<include name="folder/**" />
+				<include name="manual/**" />
+				<include name="natives/**" />
+				<include name="skin/default/**" />
+				<include name="skin/default/bg.jpg" />
+			</fileset>
+		</copy>
+		<copy todir="${dir.release.linux}">
+			<fileset dir="./">
+				<include name="folder/**" />
+				<include name="manual/**" />
+				<include name="natives/**" />
+				<include name="skin/default/**" />
+				<include name="skin/default/bg.jpg" />
+				<include name="beatoraja-config.command" />
+			</fileset>
+			<fileset dir="./${build.dest}">
+				<include name="beatoraja.jar" />
+			</fileset>
+		</copy>
+	</target>
+
+	<target name="make_zip">
+		<zip destfile="${dir.release.windows}/${zipname}_windows.zip" basedir="${dir.release.windows}" />
+		<zip destfile="${dir.release.linux}/${zipname}_linux.zip" basedir="${dir.release.linux}" />
+	</target>
+
+	<target name="release">
+		<antcall target="create_run_jar" />
+		<antcall target="make_exe_file" />
+		<copy todir="${dir.release.windows}">
+			<fileset dir="./${build.dest}">
+				<include name="beatoraja.exe" />
+			</fileset>
+		</copy>
+		<antcall target="filecopy" />
+		<antcall target="make_zip" />
 	</target>
 </project>

--- a/launch4j/launch4j.xml
+++ b/launch4j/launch4j.xml
@@ -1,7 +1,7 @@
 <launch4jConfig>
   <headerType>gui</headerType>
-  <jar>beatoraja.jar</jar>
-  <outfile>beatoraja.exe</outfile>
+  <jar>build/beatoraja.jar</jar>
+  <outfile>build/beatoraja.exe</outfile>
   <errTitle>beatoraja</errTitle>
   <chdir>.</chdir>
   <!-- <icon>beatoraja.ico</icon> -->
@@ -9,10 +9,4 @@
     <minVersion>1.8.0</minVersion>
     <runtimeBits>64/32</runtimeBits>
   </jre>
-  <!-- <splash>
-    <file>splash.bmp</file>
-    <waitForWindow>true</waitForWindow>
-    <timeout>60</timeout>
-    <timeoutErr>true</timeoutErr>
-  </splash> -->
 </launch4jConfig>


### PR DESCRIPTION
* リリース作業用に`release`Antターゲットを作成しました。 
  * releaseフォルダ内に各OSごとのzipができます。 
    * Windows：exe +その他のフォルダ
    * linux：jar +コマンドファイル（Mac）+その他のフォルダ
* (jarがrootに出力されるのが微妙かなと思ったので) Jarファイルの出力先を変更しました。 
* zip解凍後、起動まで確認しました (windows)  。 
* 作業フォルダ等の構造に問題がある場合は、お手数ですが修正してください。

***

* Created Ant target for release.
  * It is zipped for each OS.
    * Windows : exe + other folders
    * linux: jar+ command file(Mac) + other folders
* Changed the output destination of the Jar file.
* I confirmed until starting (windows).
* Please correct it if there is a problem with the folder structure.