### PR TITLE
MusicResult: Fix oldscore when played the first time

### DIFF
--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -180,6 +180,8 @@ public class CourseResult extends MainState {
 				config.getLnmode(), random, resource.getConstraint());
 		if (score != null) {
 			oldscore = score;
+		}else{
+			oldscore = new IRScoreData();
 		}
 
 		getScoreDataProperty().setTargetScore(oldscore.getExscore(), resource.getRivalScoreData(), resource.getBMSModel().getTotalNotes());

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -267,6 +267,8 @@ public class MusicResult extends MainState {
 				resource.getPlayerConfig().getLnmode());
 		if (oldsc != null) {
 			oldscore = oldsc;
+		}else{
+			oldscore = new IRScoreData();
 		}
 
 		getScoreDataProperty().setTargetScore(oldscore.getExscore(), resource.getRivalScoreData(), resource.getBMSModel().getTotalNotes());


### PR DESCRIPTION
ある曲を初めて演奏した時、前にプレイした別の楽曲のoldscoreが表示される問題を修正しました。