### PR TITLE
Add SRC_LN_BODY_ACTIVE for LR2SKIN and Signed number zeropadding

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinNumber.java
+++ b/src/bms/player/beatoraja/skin/SkinNumber.java
@@ -127,11 +127,21 @@ public class SkinNumber extends SkinObject {
 			shiftbase = 0;
 			value = Math.abs(value);
 			for (int j = values.length - 1; j >= 0; j--) {
-				if (value > 0 || j == values.length - 1) {
-					values[j] = value % 10;
+				if(mimage != null && zeropadding > 0) {
+					if(j == 0) {
+						values[j] = 11;
+					} else if(value > 0 || j == values.length - 1) {
+						values[j] = value % 10;
+					} else {
+						values[j] = zeropadding == 2 ? 10 : 0;
+					}
 				} else {
-					values[j] = (zeropadding == 2 ? 10 : (zeropadding == 1 ? 0 : (mimage != null
-							&& (values[j + 1] != 11 && values[j + 1] != -1) ? 11 : -1)));
+					if (value > 0 || j == values.length - 1) {
+						values[j] = value % 10;
+					} else {
+						values[j] = (zeropadding == 2 ? 10 : (zeropadding == 1 ? 0 : (mimage != null
+								&& (values[j + 1] != 11 && values[j + 1] != -1) ? 11 : -1)));
+					}
 				}
 				if(values[j] == -1) {
 					shiftbase++;

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -193,6 +193,18 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 				addNote(str, lnbodya, true);
 			}
 		});
+		addCommandWord(new CommandWord("SRC_LN_BODY_INACTIVE") {
+			@Override
+			public void execute(String[] str) {
+				addNote(str, lnbody, true);
+			}
+		});
+		addCommandWord(new CommandWord("SRC_LN_BODY_ACTIVE") {
+			@Override
+			public void execute(String[] str) {
+				addNote(str, lnbodya, true);
+			}
+		});
 		addCommandWord(new CommandWord("SRC_HCN_END") {
 			@Override
 			public void execute(String[] str) {
@@ -209,6 +221,18 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			@Override
 			public void execute(String[] str) {
 				addNote(str, hcnbody, false);
+				addNote(str, hcnbodya, true);
+			}
+		});
+		addCommandWord(new CommandWord("SRC_HCN_BODY_INACTIVE") {
+			@Override
+			public void execute(String[] str) {
+				addNote(str, hcnbody, true);
+			}
+		});
+		addCommandWord(new CommandWord("SRC_HCN_BODY_ACTIVE") {
+			@Override
+			public void execute(String[] str) {
 				addNote(str, hcnbodya, true);
 			}
 		});

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -228,6 +228,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 		});
 
 		addCommandWord(new CommandWord("SRC_NUMBER") {
+			//#SRC_NUMBER,(NULL),gr,x,y,w,h,div_x,div_y,cycle,timer,num,align,keta,zeropadding
 			@Override
 			public void execute(String[] str) {
 				num = null;
@@ -258,7 +259,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 								}
 							}
 
-							num = new SkinNumber(pn, mn, values[10], values[9], values[13] + 1, 0, values[11]);
+							num = new SkinNumber(pn, mn, values[10], values[9], values[13] + 1, str[14].length() > 0 ? values[14] : 2, values[11]);
 							num.setAlign(values[12]);
 						} else {
 							int d = images.length % 10 == 0 ? 10 : 11;


### PR DESCRIPTION
- LR2スキンでもLNアクティブと非アクティブを別々に定義出来るように「#SRC_LN_BODY_INACTIVE」「#SRC_LN_BODY_ACTIVE」「#SRC_HCN_BODY_INACTIVE」「#SRC_HCN_BODY_ACTIVE」を追加しました。
- 符号付き数字でも裏0を表示出来るようにしました。LR2スキンでは「#SRC_NUMBER」の14個目をzeropaddingとし、記述無しもしくは2でLR2同様裏0あり、0で裏0なしとしました。