### PR TITLE
Enable default custom option value if the given property does not contain the option

### DIFF
--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -142,10 +142,15 @@ public class JSONSkinLoader extends SkinLoader{
 			json.setIgnoreUnknownFields(true);
 
 			HashSet<Integer> enabledOptions = new HashSet<>();
-			if (property != null) {
-				for (SkinConfig.Option op : property.getOption()) {
-					enabledOptions.add(op.value);
+			for (SkinHeader.CustomOption customOption : header.getCustomOptions()) {
+				int op = customOption.getDefaultOption();
+				for (SkinConfig.Option option : property.getOption()) {
+					if (option.name.equals(customOption.name)) {
+						op = option.value;
+						break;
+					}
 				}
+				enabledOptions.add(op);
 			}
 			setSerializers(json, enabledOptions, p);
 

--- a/src/bms/player/beatoraja/skin/SkinHeader.java
+++ b/src/bms/player/beatoraja/skin/SkinHeader.java
@@ -122,6 +122,14 @@ public class SkinHeader {
 			this.contents = contents;
 			this.def = def;
 		}
+
+		public int getDefaultOption() {
+			for (int i = 0; i < option.length; i++) {
+				if (contents[i].equals(def))
+					return option[i];
+			}
+			return option[0];
+		}
 	}
 
 	public static class CustomFile {


### PR DESCRIPTION
スキン未設定またはスキン読み込み失敗によりデフォルトスキンが読み込まれたときなどに、PropertyにCustomOptionが存在しないため正常に動作しない場合があるのを修正

※LR2スキンでも同様の対応が必要ですが、対応が少々面倒なのとデフォルトスキンとして読み込まれることはなく重要度は低いためとりあえず省略しています。（CustomOptionを後で追加・削除した場合を考えるとあった方がいいです）