### PR TITLE
improve audio resampling quality

### DIFF
--- a/src/bms/player/beatoraja/audio/FloatPCM.java
+++ b/src/bms/player/beatoraja/audio/FloatPCM.java
@@ -85,15 +85,15 @@ public class FloatPCM extends PCM<float[]> {
 		float[] samples = new float[(int) (((long) this.sample.length / channels) * sample / sampleRate) * channels];
 
 		for (long i = 0; i < samples.length / channels; i++) {
+			long position = i * sampleRate / sample;
+			long mod = (i * sampleRate) % sample;
 			for (int j = 0; j < channels; j++) {
-				if ((i * sampleRate) % sample != 0
-						&& (int) ((i * sampleRate / sample + 1) * channels + j) < this.sample.length) {
-					samples[(int) (i * channels
-							+ j)] = (short) (this.sample[(int) ((i * sampleRate / sample) * channels + j)] / 2
-									+ this.sample[(int) ((i * sampleRate / sample + 1) * channels + j)] / 2);
+				if (mod != 0 && (int) ((position + 1) * channels + j) < this.sample.length) {
+					float sample1 = this.sample[(int) (position * channels + j)];
+					float sample2 = this.sample[(int) ((position + 1) * channels + j)];
+					samples[(int) (i * channels + j)] = (sample1 * (sample - mod) + sample2 * mod) / sample;
 				} else {
-					samples[(int) (i * channels + j)] = this.sample[(int) ((i * sampleRate / sample) * channels
-							+ j)];
+					samples[(int) (i * channels + j)] = this.sample[(int) (position * channels + j)];
 				}
 			}
 		}

--- a/src/bms/player/beatoraja/audio/ShortDirectPCM.java
+++ b/src/bms/player/beatoraja/audio/ShortDirectPCM.java
@@ -89,14 +89,15 @@ public class ShortDirectPCM extends PCM<ByteBuffer> {
 		ByteBuffer samples = getDirectByteBuffer((int) (((long) this.sample.limit() / 2 / channels) * sample / sampleRate) * channels * 2);
 
 		for (long i = 0; i < samples.limit() / 2 / channels; i++) {
+			long position = i * sampleRate / sample;
+			long mod = (i * sampleRate) % sample;
 			for (int j = 0; j < channels; j++) {
-				if ((i * sampleRate) % sample != 0
-						&& (int) ((i * sampleRate / sample + 1) * channels + j) < this.sample.limit() / 2) {
-					samples.putShort((int) (i * channels + j) * 2, (short) (this.sample.getShort((int) ((i * sampleRate / sample) * channels + j) * 2) / 2
-									+ this.sample.get((int) ((i * sampleRate / sample + 1) * channels + j) * 2) / 2));
+				if (mod != 0 && (int) ((position + 1) * channels + j) < this.sample.limit() / 2) {
+					short sample1 = this.sample.getShort((int) (position * channels + j) * 2);
+					short sample2 = this.sample.getShort((int) ((position + 1) * channels + j) * 2);
+					samples.putShort((int) (i * channels + j) * 2,  (short)(((long)sample1 * (sample - mod) + (long)sample2 * mod) / sample));
 				} else {
-					samples.putShort((int) (i * channels + j) * 2, this.sample.getShort((int) ((i * sampleRate / sample) * channels
-							+ j) * 2));
+					samples.putShort((int) (i * channels + j) * 2, this.sample.getShort((int) (position * channels+ j) * 2));
 				}
 			}
 		}

--- a/src/bms/player/beatoraja/audio/ShortPCM.java
+++ b/src/bms/player/beatoraja/audio/ShortPCM.java
@@ -86,15 +86,15 @@ public class ShortPCM extends PCM<short[]> {
 		short[] samples = new short[(int) (((long) this.sample.length / channels) * sample / sampleRate) * channels];
 
 		for (long i = 0; i < samples.length / channels; i++) {
+			long position = i * sampleRate / sample;
+			long mod = (i * sampleRate) % sample;
 			for (int j = 0; j < channels; j++) {
-				if ((i * sampleRate) % sample != 0
-						&& (int) ((i * sampleRate / sample + 1) * channels + j) < this.sample.length) {
-					samples[(int) (i * channels
-							+ j)] = (short) (this.sample[(int) ((i * sampleRate / sample) * channels + j)] / 2
-									+ this.sample[(int) ((i * sampleRate / sample + 1) * channels + j)] / 2);
+				if (mod  != 0 && (int) ((position + 1) * channels + j) < this.sample.length) {
+					short sample1 = this.sample[(int) (position * channels + j)];
+					short sample2 = this.sample[(int) ((position + 1) * channels + j)];
+					samples[(int) (i * channels + j)] = (short) (((long)sample1 * (sample - mod) + (long)sample2 * mod) / sample);
 				} else {
-					samples[(int) (i * channels + j)] = this.sample[(int) ((i * sampleRate / sample) * channels
-							+ j)];
+					samples[(int) (i * channels + j)] = this.sample[(int) (position * channels + j)];
 				}
 			}
 		}


### PR DESCRIPTION
サンプリングレート変換の際、ノイズが目立つことがある（48kHz → 44.1kHz などの場合）ので線形補間するようにしました