### PR TITLE
Add timing distribution thing

### DIFF
--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -145,7 +145,7 @@ public class JudgeManager {
 	/**
 	 * 直近100ノーツの判定差時間
 	 */
-	private long[] recenJudges = new long[100];
+	private long[] recentJudges = new long[100];
 	/**
 	 * 判定差時間のヘッド
 	 */
@@ -204,16 +204,18 @@ public class JudgeManager {
 				constraint = 1;
 			}
 		}
-		njudge = rule.getNoteJudge(judgerank, judgeWindowRate, constraint, model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
-		cnendjudge = rule.getLongNoteEndJudge(judgerank, judgeWindowRate, constraint, model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
+		njudge = rule.getNoteJudge(judgerank, judgeWindowRate, constraint,
+				model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
+		cnendjudge = rule.getLongNoteEndJudge(judgerank, judgeWindowRate, constraint,
+				model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
 		sjudge = rule.getScratchJudge(judgerank, judgeWindowRate, constraint);
 		scnendjudge = rule.getLongScratchEndJudge(judgerank, judgeWindowRate, constraint);
 		judgestart = judgeend = 0;
-		for(int[] i : njudge) {
+		for (int[] i : njudge) {
 			judgestart = Math.min(judgestart, i[0]);
 			judgeend = Math.max(judgeend, i[1]);
 		}
-		for(int[] i : sjudge) {
+		for (int[] i : sjudge) {
 			judgestart = Math.min(judgestart, i[0]);
 			judgeend = Math.max(judgeend, i[1]);
 		}
@@ -226,7 +228,7 @@ public class JudgeManager {
 			setCourseMaxcombo(resource.getMaxcombo());
 		}
 
-		Arrays.fill(recenJudges, Long.MIN_VALUE);
+		Arrays.fill(recentJudges, Long.MIN_VALUE);
 		this.recentJudgesIndex = 0;
 	}
 
@@ -251,8 +253,8 @@ public class JudgeManager {
 					break;
 				}
 			}
-			for(Note note = lanemodel.getNote();note != null && note.getTime() <= time;note = lanemodel.getNote()) {
-				if(note.getTime() <= prevtime) {
+			for (Note note = lanemodel.getNote(); note != null && note.getTime() <= time; note = lanemodel.getNote()) {
+				if (note.getTime() <= prevtime) {
 					continue;
 				}
 				if (note instanceof LongNote) {
@@ -280,7 +282,7 @@ public class JudgeManager {
 						auto_presstime[laneassign[lane][0]] = now;
 						main.play(note, config.getKeyvolume(), 0);
 						this.update(lane, note, time, 0, 0);
-						if(playerConfig.isGuideSE()) {
+						if (playerConfig.isGuideSE()) {
 							main.play(main.SOUND_GUIDE_SE_PG);
 						}
 					}
@@ -298,7 +300,7 @@ public class JudgeManager {
 								this.update(lane, ln, time, 0, 0);
 							}
 							processing[lane] = ln.getPair();
-							if(playerConfig.isGuideSE()) {
+							if (playerConfig.isGuideSE()) {
 								main.play(main.SOUND_GUIDE_SE_PG);
 							}
 						}
@@ -313,7 +315,7 @@ public class JudgeManager {
 								this.update(lane, ln, time, 0, 0);
 								main.play(processing[lane], config.getKeyvolume(), 0);
 								processing[lane] = null;
-								if(playerConfig.isGuideSE() && sckeyassign[lane] != -1) {
+								if (playerConfig.isGuideSE() && sckeyassign[lane] != -1) {
 									main.play(main.SOUND_GUIDE_SE_PG);
 								}
 							}
@@ -322,13 +324,16 @@ public class JudgeManager {
 				}
 			}
 			// HCNゲージ増減判定
-			if (passing[lane] != null && (pressed || (passing[lane].getPair().getState() > 0 && passing[lane].getPair().getState() <= 3) || autoplay)) {
+			if (passing[lane] != null
+					&& (pressed || (passing[lane].getPair().getState() > 0 && passing[lane].getPair().getState() <= 3)
+							|| autoplay)) {
 				next_inclease[lane] = true;
 			}
 
 			if (autoplay) {
 				for (int key : laneassign[lane]) {
-					if (auto_presstime[key] != Long.MIN_VALUE && now - auto_presstime[key] > auto_minduration && processing[lane] == null) {
+					if (auto_presstime[key] != Long.MIN_VALUE && now - auto_presstime[key] > auto_minduration
+							&& processing[lane] == null) {
 						auto_presstime[key] = Long.MIN_VALUE;
 					}
 				}
@@ -341,9 +346,10 @@ public class JudgeManager {
 
 		for (int lane = 0; lane < passing.length; lane++) {
 			final int offset = main.getLaneProperty().getLaneSkinOffset()[lane];
-			final int timerActive = SkinPropertyMapper.hcnActiveTimerId(main.getLaneProperty().getLanePlayer()[lane], offset);
-			final int timerDamage = SkinPropertyMapper.hcnDamageTimerId(main.getLaneProperty().getLanePlayer()[lane], offset);
-
+			final int timerActive = SkinPropertyMapper.hcnActiveTimerId(main.getLaneProperty().getLanePlayer()[lane],
+					offset);
+			final int timerDamage = SkinPropertyMapper.hcnDamageTimerId(main.getLaneProperty().getLanePlayer()[lane],
+					offset);
 
 			if (passing[lane] == null || passing[lane].getState() == 0) {
 				mc.setTimerOff(timerActive);
@@ -396,17 +402,21 @@ public class JudgeManager {
 						final int[][] judge = scnendjudge;
 						final int dtime = (int) (processing[lane].getTime() - ptime);
 						int j = 0;
-						for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++);
+						for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++)
+							;
 
 						this.update(lane, processing[lane], time, j, dtime);
-//						 System.out.println("BSS終端判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane].hashCode());
+						//						 System.out.println("BSS終端判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane].hashCode());
 						main.play(processing[lane], config.getKeyvolume(), 0);
 						processing[lane] = null;
 						sckey[sc] = 0;
-						if(playerConfig.isGuideSE()) {
-							if(j == 0) main.play(main.SOUND_GUIDE_SE_PG);
-							else if(j == 1) main.play(main.SOUND_GUIDE_SE_GR);
-							else if(j == 2) main.play(main.SOUND_GUIDE_SE_GD);
+						if (playerConfig.isGuideSE()) {
+							if (j == 0)
+								main.play(main.SOUND_GUIDE_SE_PG);
+							else if (j == 1)
+								main.play(main.SOUND_GUIDE_SE_GR);
+							else if (j == 2)
+								main.play(main.SOUND_GUIDE_SE_GD);
 						}
 					} else {
 						// ここに来るのはマルチキーアサイン以外ありえないはず
@@ -417,7 +427,7 @@ public class JudgeManager {
 					lanemodel.reset();
 					Note tnote = null;
 					int j = 0;
-					for (Note judgenote = lanemodel.getNote();judgenote != null;judgenote = lanemodel.getNote()) {
+					for (Note judgenote = lanemodel.getNote(); judgenote != null; judgenote = lanemodel.getNote()) {
 						final long dtime = judgenote.getTime() - ptime;
 						if (dtime >= judgeend) {
 							break;
@@ -429,17 +439,21 @@ public class JudgeManager {
 								&& ((LongNote) judgenote).isEnd())) {
 							continue;
 						}
-						if (tnote == null || tnote.getState() != 0 || algorithm.compare(tnote, judgenote, ptime, judge)) {
+						if (tnote == null || tnote.getState() != 0
+								|| algorithm.compare(tnote, judgenote, ptime, judge)) {
 							if (!(miss == MissCondition.ONE && (judgenote.getState() != 0
-									|| (judgenote.getState() == 0 && judgenote.getPlayTime() != 0 && (dtime > judge[2][1] || dtime < judge[2][0]))))) {
+									|| (judgenote.getState() == 0 && judgenote.getPlayTime() != 0
+											&& (dtime > judge[2][1] || dtime < judge[2][0]))))) {
 								if (judgenote.getState() != 0) {
 									j = (dtime >= judge[4][0] && dtime <= judge[4][1]) ? 5 : 6;
 								} else {
-									for (j = 0; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++) {
+									for (j = 0; j < judge.length
+											&& !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++) {
 									}
 									j = (j >= 4 ? j + 1 : j);
 								}
-								if(j < 6 && (j < 4 || tnote == null || Math.abs(tnote.getTime() - ptime) > Math.abs(judgenote.getTime() - ptime))) {
+								if (j < 6 && (j < 4 || tnote == null
+										|| Math.abs(tnote.getTime() - ptime) > Math.abs(judgenote.getTime() - ptime))) {
 									tnote = judgenote;
 								}
 							}
@@ -466,7 +480,7 @@ public class JudgeManager {
 								processing[lane] = ln.getPair();
 								if (sc >= 0) {
 									// BSS処理開始
-//									 System.out.println("BSS開始判定 - Time : " + ptime + " Judge : " + j + " KEY : " + key + " LN : " + ln.getPair().hashCode());
+									//									 System.out.println("BSS開始判定 - Time : " + ptime + " Judge : " + j + " KEY : " + key + " LN : " + ln.getPair().hashCode());
 									sckey[sc] = key;
 								}
 							}
@@ -476,10 +490,13 @@ public class JudgeManager {
 							final int dtime = (int) (tnote.getTime() - ptime);
 							this.update(lane, tnote, time, j, dtime);
 						}
-						if(playerConfig.isGuideSE()) {
-							if(j == 0) main.play(main.SOUND_GUIDE_SE_PG);
-							else if(j == 1) main.play(main.SOUND_GUIDE_SE_GR);
-							else if(j == 2) main.play(main.SOUND_GUIDE_SE_GD);
+						if (playerConfig.isGuideSE()) {
+							if (j == 0)
+								main.play(main.SOUND_GUIDE_SE_PG);
+							else if (j == 1)
+								main.play(main.SOUND_GUIDE_SE_GR);
+							else if (j == 2)
+								main.play(main.SOUND_GUIDE_SE_GD);
 						}
 					} else {
 						// 空POOR判定がないときのレーザー色変更処理
@@ -488,15 +505,15 @@ public class JudgeManager {
 						// 空POOR判定がないときのキー音処理
 						final Note[] notes = lanemodel.getNotes();
 						Note n = notes.length > 0 ? notes[0] : null;
-						for(Note note : lanemodel.getHiddens()) {
-							if(note.getTime() >= ptime) {
+						for (Note note : lanemodel.getHiddens()) {
+							if (note.getTime() >= ptime) {
 								break;
 							}
 							n = note;
 						}
 
-						for(Note note : notes) {
-							if(note.getTime() >= ptime) {
+						for (Note note : notes) {
+							if (note.getTime() >= ptime) {
 								break;
 							}
 							if ((n == null || n.getTime() <= note.getTime())
@@ -517,7 +534,8 @@ public class JudgeManager {
 					final int[][] judge = sc >= 0 ? scnendjudge : cnendjudge;
 					int dtime = (int) (processing[lane].getTime() - ptime);
 					int j = 0;
-					for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++);
+					for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++)
+						;
 
 					if ((lntype != BMSModel.LNTYPE_LONGNOTE
 							&& processing[lane].getType() == LongNote.TYPE_UNDEFINED)
@@ -529,11 +547,11 @@ public class JudgeManager {
 							if (j != 4 || key != sckey[sc]) {
 								release = false;
 							} else {
-//								 System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);
+								//								 System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);
 								sckey[sc] = 0;
 							}
 						}
-						if(release) {
+						if (release) {
 							if (j >= 3) {
 								main.stop(processing[lane].getPair());
 							}
@@ -545,7 +563,8 @@ public class JudgeManager {
 						// LN離し処理
 						if (Math.abs(passingcount[lane]) > Math.abs(dtime)) {
 							dtime = passingcount[lane];
-							for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++);
+							for (; j < judge.length && !(dtime >= judge[j][0] && dtime <= judge[j][1]); j++)
+								;
 						}
 						if (j >= 3) {
 							main.stop(processing[lane].getPair());
@@ -581,7 +600,8 @@ public class JudgeManager {
 			// 見逃しPOOR判定
 			final Lane lanemodel = lanes[lane];
 			lanemodel.reset();
-			for (Note note = lanemodel.getNote(); note != null && note.getTime() < time + judge[3][0]; note = lanemodel.getNote()) {
+			for (Note note = lanemodel.getNote(); note != null
+					&& note.getTime() < time + judge[3][0]; note = lanemodel.getNote()) {
 				final long jud = note.getTime() - time;
 				if (note instanceof NormalNote && note.getState() == 0) {
 					this.update(lane, note, time, 4, jud);
@@ -630,19 +650,21 @@ public class JudgeManager {
 			n.setState(judge + 1);
 			pastNotes++;
 		}
-		if(miss == MissCondition.ONE && judge == 4 && n.getPlayTime() != 0) {
+		if (miss == MissCondition.ONE && judge == 4 && n.getPlayTime() != 0) {
 			main.setPastNotes(pastNotes);
 			return;
 		}
 		n.setPlayTime(fast);
 		score.addJudgeCount(judge, fast >= 0, 1);
 
-		if (recentJudgesIndex == recenJudges.length - 1) {
-			recentJudgesIndex = 0;
-		} else {
-			recentJudgesIndex++;
+		if (judge < 4) {
+			if (recentJudgesIndex == recentJudges.length - 1) {
+				recentJudgesIndex = 0;
+			} else {
+				recentJudgesIndex++;
+			}
+			recentJudges[recentJudgesIndex] = fast;
 		}
-		recenJudges[recentJudgesIndex] = fast;
 
 		if (combocond[judge] && judge < 5) {
 			combo++;
@@ -655,8 +677,9 @@ public class JudgeManager {
 			coursecombo = 0;
 		}
 
-		if (judge != 4) this.judge[player[lane]][offset[lane]] = judge == 0 ? 1 : judge * 2 + (fast > 0 ? 0 : 1);
-		if (judge <= ((PlaySkin)main.getSkin()).getJudgetimer()) {
+		if (judge != 4)
+			this.judge[player[lane]][offset[lane]] = judge == 0 ? 1 : judge * 2 + (fast > 0 ? 0 : 1);
+		if (judge <= ((PlaySkin) main.getSkin()).getJudgetimer()) {
 			main.main.setTimerOn(SkinPropertyMapper.bombTimerId(player[lane], offset[lane]));
 		}
 		PMcharaJudge = judge + 1;
@@ -664,9 +687,10 @@ public class JudgeManager {
 		final int lanelength = sckeyassign.length;
 		if (judgenow.length > 0) {
 			main.main.setTimerOn(JUDGE_TIMER[lane / (lanelength / judgenow.length)]);
-			if(judgenow.length >= 3) {
-				for(int i = 0 ; i < COMBO_TIMER.length ; i++) {
-					if(i != lane / (lanelength / judgenow.length)) main.main.setTimerOff(COMBO_TIMER[i]);
+			if (judgenow.length >= 3) {
+				for (int i = 0; i < COMBO_TIMER.length; i++) {
+					if (i != lane / (lanelength / judgenow.length))
+						main.main.setTimerOff(COMBO_TIMER[i]);
 				}
 			}
 			main.main.setTimerOn(COMBO_TIMER[lane / (lanelength / judgenow.length)]);
@@ -678,7 +702,7 @@ public class JudgeManager {
 	}
 
 	public long[] getRecentJudges() {
-		return recenJudges;
+		return recentJudges;
 	}
 
 	public int getRecentJudgesIndex() {

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -500,8 +500,8 @@ public class MusicResult extends MainState {
 		super.dispose();
 	}
 
-	public int[] getTimingDistribution() {
-		return timingDistribution.getTimingDistribution();
+	public TimingDistribution getTimingDistribution() {
+		return timingDistribution;
 	}
 
 	public int getTotalNotes() {
@@ -835,6 +835,10 @@ public class MusicResult extends MainState {
 
 		public float getStdDev() {
 			return stdDev;
+		}
+
+		public int getArrayCenter() {
+			return arrayCenter;
 		}
 
 	}

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -593,7 +593,16 @@ public class MusicResult extends MainState {
 				return irtotal;
 			}
 			return Integer.MIN_VALUE;
+		case NUMBER_AVERAGE_TIMING:
+			return (int) timingDistribution.getAverage();
+		case NUMBER_AVERAGE_TIMING_AFTERDOT:
+			return (int) (timingDistribution.getAverage() * 100) % 100;
+		case NUMBER_STDDEV_TIMING:
+			return (int) timingDistribution.getStdDev();
+		case NUMBER_STDDEV_TIMING_AFTERDOT:
+			return (int) (timingDistribution.getStdDev() * 100) % 100;
 		}
+
 		return super.getNumberValue(id);
 	}
 

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -49,7 +49,7 @@ public class MusicResult extends MainState {
 	/**
 	 * タイミング分布レンジ
 	 */
-	final int distRange = 200;
+	final int distRange = 150;
 
 	/**
 	 * 状態

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -596,7 +596,11 @@ public class MusicResult extends MainState {
 		case NUMBER_AVERAGE_TIMING:
 			return (int) timingDistribution.getAverage();
 		case NUMBER_AVERAGE_TIMING_AFTERDOT:
-			return (int) (timingDistribution.getAverage() * 100) % 100;
+			if (timingDistribution.getAverage() >= 0.0) {
+				return (int) (timingDistribution.getAverage() * 100) % 100;
+			} else {
+				return (int) ( -1 * ((Math.abs(timingDistribution.getAverage()) * 100) % 100));
+			}
 		case NUMBER_STDDEV_TIMING:
 			return (int) timingDistribution.getStdDev();
 		case NUMBER_STDDEV_TIMING_AFTERDOT:
@@ -813,7 +817,7 @@ public class MusicResult extends MainState {
 				return;
 			}
 
-			average = sum / count;
+			average = sum * 1.0f / count;
 
 			for (int i = 0; i < dist.length; i++) {
 				sumf += dist[i] * (i - arrayCenter - average) * (i - arrayCenter - average);

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -127,7 +127,7 @@ public class SkinProperty {
 	public static final int TIMER_RESULTGRAPH_BEGIN = 150;
 	public static final int TIMER_RESULTGRAPH_END = 151;
 	public static final int TIMER_RESULT_UPDATESCORE = 152;
-	
+
 	public static final int TIMER_IR_CONNECT_BEGIN = 172;
 	public static final int TIMER_IR_CONNECT_SUCCESS = 173;
 	public static final int TIMER_IR_CONNECT_FAIL = 174;
@@ -286,6 +286,10 @@ public class SkinProperty {
 	public static final int NUMBER_TARGET_CLEAR = 371;
 	public static final int NUMBER_AVERAGE_DURATION = 372;
 	public static final int NUMBER_AVERAGE_DURATION_AFTERDOT = 373;
+	public static final int NUMBER_AVERAGE_TIMING = 374;
+	public static final int NUMBER_AVERAGE_TIMING_AFTERDOT = 375;
+	public static final int NUMBER_STDDEV_TIMING = 376;
+	public static final int NUMBER_STDDEV_TIMING_AFTERDOT = 377;
 	public static final int NUMBER_SCORE = 71;
 	public static final int NUMBER_MAXSCORE = 72;
 	public static final int NUMBER_TOTALNOTES = 74;
@@ -736,7 +740,7 @@ public class SkinProperty {
 	// 廃止予定
 	public static final int OFFSET_LIFT_OBSOLETE = 50;
 	public static final int OFFSET_LANECOVER_OBSOLETE = 51;
-	
+
 	public static final int OFFSET_MAX = 199;
 
 	public static final int BUTTON_MODE = 11;

--- a/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
@@ -1,5 +1,7 @@
 package bms.player.beatoraja.skin;
 
+import java.util.Optional;
+
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -24,72 +26,80 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
  */
 public class SkinTimingDistributionGraph extends SkinObject {
 
-	private TextureRegion backtex;
-	private TextureRegion graphtex;
+	private TextureRegion tex = null;
+	private Pixmap shape = null;
+
+	private final boolean drawAverage;
 
 	private int max = 10;
 
 	private static final Color[] JColor = new Color[] {
-					Color.valueOf("000088"),
-					Color.valueOf("008800"),
-					Color.valueOf("666600"),
-					Color.valueOf("880000"),
-					Color.valueOf("000000")};
+			Color.valueOf("000088"),
+			Color.valueOf("008800"),
+			Color.valueOf("666600"),
+			Color.valueOf("880000"),
+			Color.valueOf("000000") };
+
+	public SkinTimingDistributionGraph() {
+		this(1);
+	}
+
+	public SkinTimingDistributionGraph(int drawAverage) {
+		this.drawAverage = drawAverage == 1 ? true : false;
+	}
 
 	@Override
 	public void draw(SkinObjectRenderer sprite, long time, MainState state) {
 
 		if (state instanceof MusicResult) {
-			draw(sprite, time, (MusicResult)state, getDestination(time, state));
+			draw(sprite, time, (MusicResult) state, getDestination(time, state));
 		}
 
 	}
 
 	private void draw(SkinObjectRenderer sprite, long time, MusicResult state, Rectangle r) {
-		if (backtex != null) {
-			backtex.getTexture().dispose();
-		}
-		if (graphtex != null) {
-			graphtex.getTexture().dispose();
-		}
-
 		if (r == null) {
 			return;
 		}
 
-		TimingDistribution td = state.getTimingDistribution();
-		int[] dist = td.getTimingDistribution();
-		final int center = td.getArrayCenter();
-		int[][] judgeArea = getJudgeArea(state.main.getPlayerResource());
+		// Texture生成は一度だけ
+		if (tex == null) {
+			TimingDistribution td = state.getTimingDistribution();
+			int[] dist = td.getTimingDistribution();
+			final int center = td.getArrayCenter();
+			int[][] judgeArea = getJudgeArea(state.main.getPlayerResource());
 
-		for (int d : dist) {
-			if (max < d) {
-				max = (d / 10) * 10 + 10;
+			for (int d : dist) {
+				if (max < d) {
+					max = (d / 10) * 10 + 10;
+				}
 			}
+
+			Pixmap shape = new Pixmap(dist.length, max, Pixmap.Format.RGBA8888);
+			for (int i = JColor.length - 1; i >= 0; i--) {
+				shape.setColor(JColor[i]);
+				int x = center + Math.max(-center, Math.min(judgeArea[i][0], center));
+				int width = Math.min(dist.length - x, Math.abs(judgeArea[i][0]) + Math.abs(judgeArea[i][1]) + 1);
+				shape.fillRectangle(x, 0, width, max);
+			}
+
+			for (int i = 0; i < dist.length; i++) {
+				shape.setColor(Color.valueOf("dddddd"));
+				shape.drawLine(i, max - dist[i], i, max);
+			}
+
+			if (drawAverage && td.getAverage() != Float.MAX_VALUE) {
+				int avg = Math.round(td.getAverage());
+				shape.setColor(Color.RED);
+				shape.drawLine(center + avg, 0, center + avg, max);
+			}
+
+			tex = new TextureRegion(new Texture(shape));
+			shape.dispose();
 		}
 
-		Pixmap shape = new Pixmap(dist.length , 1, Pixmap.Format.RGBA8888);
-		for (int i = JColor.length - 1; i >= 0; i--) {
-			shape.setColor(JColor[i]);
-			int x = center + Math.max(-center, Math.min(judgeArea[i][0], center));
-			int width = Math.min(dist.length - x, Math.abs(judgeArea[i][0]) + Math.abs(judgeArea[i][1]));
-			shape.fillRectangle(x, 0, width, 1);
-		}
+		draw(sprite, tex, r.x, r.y, r.width, r.height);
 
-		backtex = new TextureRegion(new Texture(shape));
-		shape.dispose();
-
-		shape = new Pixmap(dist.length, max, Pixmap.Format.RGBA8888);
-		for (int i = 0; i < dist.length; i++) {
-			shape.setColor(Color.valueOf("dddddd"));
-			shape.fillRectangle(i, max - dist[i], 1, dist[i]);
-		}
-
-		graphtex = new TextureRegion(new Texture(shape));
-		shape.dispose();
-
-		draw(sprite, backtex, r.x, r.y, r.width, r.height);
-		draw(sprite, graphtex, r.x, r.y, r.width, r.height);
 	}
 
 	private int[][] getJudgeArea(PlayerResource resource) {
@@ -107,17 +117,14 @@ public class SkinTimingDistributionGraph extends SkinObject {
 			}
 		}
 
-		return rule.getNoteJudge(judgerank, judgeWindowRate, constraint, model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
+		return rule.getNoteJudge(judgerank, judgeWindowRate, constraint,
+				model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
 	}
 
 	@Override
 	public void dispose() {
-		if (graphtex != null) {
-			graphtex.getTexture().dispose();
-			backtex.getTexture().dispose();
-			graphtex = null;
-		}
-
+		Optional.ofNullable(tex.getTexture()).ifPresent(Texture::dispose);
+		Optional.ofNullable(shape).ifPresent(Pixmap::dispose);
 	}
 
 }

--- a/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
@@ -78,13 +78,13 @@ public class SkinTimingDistributionGraph extends SkinObject {
 
 		backtex = new TextureRegion(new Texture(shape));
 		shape.dispose();
-		
+
 		shape = new Pixmap(dist.length, max, Pixmap.Format.RGBA8888);
 		for (int i = 0; i < dist.length; i++) {
 			shape.setColor(Color.valueOf("dddddd"));
 			shape.fillRectangle(i, max - dist[i], 1, dist[i]);
 		}
-		
+
 		graphtex = new TextureRegion(new Texture(shape));
 		shape.dispose();
 
@@ -112,7 +112,11 @@ public class SkinTimingDistributionGraph extends SkinObject {
 
 	@Override
 	public void dispose() {
-		// TODO 自動生成されたメソッド・スタブ
+		if (graphtex != null) {
+			graphtex.getTexture().dispose();
+			backtex.getTexture().dispose();
+			graphtex = null;
+		}
 
 	}
 

--- a/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
@@ -1,0 +1,119 @@
+package bms.player.beatoraja.skin;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Rectangle;
+
+import bms.model.BMSModel;
+import bms.model.Mode;
+import bms.player.beatoraja.CourseData;
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.PlayerResource;
+import bms.player.beatoraja.play.BMSPlayerRule;
+import bms.player.beatoraja.play.JudgeProperty;
+import bms.player.beatoraja.result.MusicResult;
+import bms.player.beatoraja.result.MusicResult.TimingDistribution;
+import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
+
+/**
+ * 判定タイミング分布のグラフ
+ *
+ * @author keh
+ */
+public class SkinTimingDistributionGraph extends SkinObject {
+
+	private TextureRegion backtex;
+	private TextureRegion graphtex;
+
+	private int max = 10;
+
+	private static final Color[] JColor = new Color[] {
+					Color.valueOf("000088"),
+					Color.valueOf("008800"),
+					Color.valueOf("666600"),
+					Color.valueOf("880000"),
+					Color.valueOf("000000")};
+
+	@Override
+	public void draw(SkinObjectRenderer sprite, long time, MainState state) {
+
+		if (state instanceof MusicResult) {
+			draw(sprite, time, (MusicResult)state, getDestination(time, state));
+		}
+
+	}
+
+	private void draw(SkinObjectRenderer sprite, long time, MusicResult state, Rectangle r) {
+		if (backtex != null) {
+			backtex.getTexture().dispose();
+		}
+		if (graphtex != null) {
+			graphtex.getTexture().dispose();
+		}
+
+		if (r == null) {
+			return;
+		}
+
+		TimingDistribution td = state.getTimingDistribution();
+		int[] dist = td.getTimingDistribution();
+		final int center = td.getArrayCenter();
+		int[][] judgeArea = getJudgeArea(state.main.getPlayerResource());
+
+		for (int d : dist) {
+			if (max < d) {
+				max = (d / 10) * 10 + 10;
+			}
+		}
+
+		Pixmap shape = new Pixmap(dist.length , 1, Pixmap.Format.RGBA8888);
+		for (int i = JColor.length - 1; i >= 0; i--) {
+			shape.setColor(JColor[i]);
+			int x = center + Math.max(-center, Math.min(judgeArea[i][0], center));
+			int width = Math.min(dist.length - x, Math.abs(judgeArea[i][0]) + Math.abs(judgeArea[i][1]));
+			shape.fillRectangle(x, 0, width, 1);
+		}
+
+		backtex = new TextureRegion(new Texture(shape));
+		shape.dispose();
+		
+		shape = new Pixmap(dist.length, max, Pixmap.Format.RGBA8888);
+		for (int i = 0; i < dist.length; i++) {
+			shape.setColor(Color.valueOf("dddddd"));
+			shape.fillRectangle(i, max - dist[i], 1, dist[i]);
+		}
+		
+		graphtex = new TextureRegion(new Texture(shape));
+		shape.dispose();
+
+		draw(sprite, backtex, r.x, r.y, r.width, r.height);
+		draw(sprite, graphtex, r.x, r.y, r.width, r.height);
+	}
+
+	private int[][] getJudgeArea(PlayerResource resource) {
+		BMSModel model = resource.getBMSModel();
+		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(model.getMode()).judge;
+
+		final int judgerank = model.getJudgerank();
+		final int judgeWindowRate = resource.getPlayerConfig().getJudgewindowrate();
+		int constraint = 2;
+		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
+			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+				constraint = 0;
+			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+				constraint = 1;
+			}
+		}
+
+		return rule.getNoteJudge(judgerank, judgeWindowRate, constraint, model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
+	}
+
+	@Override
+	public void dispose() {
+		// TODO 自動生成されたメソッド・スタブ
+
+	}
+
+}

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -1,0 +1,124 @@
+package bms.player.beatoraja.skin;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Rectangle;
+
+import bms.model.BMSModel;
+import bms.model.Mode;
+import bms.player.beatoraja.CourseData;
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.PlayerResource;
+import bms.player.beatoraja.play.BMSPlayer;
+import bms.player.beatoraja.play.BMSPlayerRule;
+import bms.player.beatoraja.play.JudgeProperty;
+import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
+
+/**
+ * 判定タイミングの可視化
+ *
+ * @author keh
+ */
+public class SkinTimingVisualizer extends SkinObject {
+
+	private TextureRegion backtex;
+	private TextureRegion shapetex;
+
+	private static final Color[] JColor = new Color[] {
+			Color.valueOf("000088"),
+			Color.valueOf("008800"),
+			Color.valueOf("666600"),
+			Color.valueOf("880000"),
+			Color.valueOf("000000") };
+
+	private final int center = 200;
+	private final int range = center * 2 + 1;
+
+	@Override
+	public void draw(SkinObjectRenderer sprite, long time, MainState state) {
+		if (state instanceof BMSPlayer) {
+			draw(sprite, time, (BMSPlayer) state, getDestination(time, state));
+		}
+
+	}
+
+	private void draw(SkinObjectRenderer sprite, long time, BMSPlayer state, Rectangle r) {
+		if (backtex != null) {
+			backtex.getTexture().dispose();
+		}
+		if (shapetex != null) {
+			shapetex.getTexture().dispose();
+		}
+
+		if (r == null) {
+			return;
+		}
+
+		PlayerResource resource = state.main.getPlayerResource();
+		int index = state.getJudgeManager().getRecentJudgesIndex();
+		long[] recent = state.getJudgeManager().getRecentJudges();
+		int[][] judgeArea = getJudgeArea(resource);
+
+		Pixmap shape = new Pixmap(range, 200, Pixmap.Format.RGBA8888);
+		for (int i = JColor.length - 1; i >= 0; i--) {
+			shape.setColor(JColor[i]);
+			int x = center + Math.max(-center, Math.min(judgeArea[i][0], center));
+			int width = Math.min(range - x, Math.abs(judgeArea[i][0]) + Math.abs(judgeArea[i][1]) + 1);
+			shape.fillRectangle(x, 0, width, 200);
+		}
+		shape.setColor(Color.valueOf("FFFFFF"));
+		shape.fillRectangle(0, 100, range, 1);
+		shape.fillRectangle(center, 0, 2, 200);
+
+		backtex = new TextureRegion(new Texture(shape));
+		shape.dispose();
+
+		shape = new Pixmap(range, 200, Pixmap.Format.RGBA8888);
+		for (int i = 0; i < recent.length; i++) {
+			int j = index + 1;
+			if (recent[(i + j) % recent.length] == Long.MIN_VALUE) {
+				continue;
+			}
+			shape.setColor(Color.rgba8888(0.0f, 1.0f, 0, (i / (1.0f * recent.length))));
+			int x = center + Math.max(-center, Math.min((int) recent[(i + j) % recent.length], center));
+			shape.fillRectangle(x, recent.length - i, 1, i * 2);
+		}
+
+		shapetex = new TextureRegion(new Texture(shape));
+		shape.dispose();
+
+		draw(sprite, backtex, r.x, r.y, r.width, r.height);
+		draw(sprite, shapetex, r.x, r.y, r.width, r.height);
+	}
+
+	private int[][] getJudgeArea(PlayerResource resource) {
+		BMSModel model = resource.getBMSModel();
+		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(model.getMode()).judge;
+
+		final int judgerank = model.getJudgerank();
+		final int judgeWindowRate = resource.getPlayerConfig().getJudgewindowrate();
+		int constraint = 2;
+		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
+			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+				constraint = 0;
+			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+				constraint = 1;
+			}
+		}
+
+		return rule.getNoteJudge(judgerank, judgeWindowRate, constraint,
+				model.getMode() == Mode.POPN_9K && !BMSPlayerRule.isSevenToNine());
+	}
+
+	@Override
+	public void dispose() {
+		if (shapetex != null) {
+			shapetex.getTexture().dispose();
+			backtex.getTexture().dispose();
+			shapetex = null;
+		}
+	}
+
+}

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -86,7 +86,7 @@ public class SkinTimingVisualizer extends SkinObject {
 			}
 			if (drawCenter) {
 				shape.setColor(Color.WHITE);
-				shape.drawPixel(center, 0);
+				shape.fillRectangle(center, 0, Math.min(range, 2), 1);
 			}
 
 			backtex = new TextureRegion(new Texture(shape));
@@ -113,7 +113,7 @@ public class SkinTimingVisualizer extends SkinObject {
 			if (drawDecay) {
 				shape.drawLine(x, recent.length - i, x, recent.length + i);
 			} else {
-				shape.drawLine(x, 0, x, recent.length);
+				shape.drawLine(x, 0, x, recent.length * 2);
 			}
 		}
 

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -1,22 +1,38 @@
 package bms.player.beatoraja.skin.lr2;
 
-import java.io.*;
-import java.util.*;
+import static bms.player.beatoraja.skin.SkinProperty.*;
 
-import bms.model.Mode;
-import bms.player.beatoraja.*;
-import bms.player.beatoraja.play.*;
-import bms.player.beatoraja.skin.*;
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
 
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
-import static bms.player.beatoraja.skin.SkinProperty.*;
+import bms.model.Mode;
+import bms.player.beatoraja.Config;
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.Resolution;
+import bms.player.beatoraja.play.PlaySkin;
+import bms.player.beatoraja.play.SkinBGA;
+import bms.player.beatoraja.play.SkinGauge;
+import bms.player.beatoraja.play.SkinJudge;
+import bms.player.beatoraja.play.SkinNote;
+import bms.player.beatoraja.skin.Skin;
+import bms.player.beatoraja.skin.SkinBPMGraph;
+import bms.player.beatoraja.skin.SkinHeader;
+import bms.player.beatoraja.skin.SkinImage;
+import bms.player.beatoraja.skin.SkinNoteDistributionGraph;
+import bms.player.beatoraja.skin.SkinNumber;
+import bms.player.beatoraja.skin.SkinSource;
+import bms.player.beatoraja.skin.SkinSourceImage;
+import bms.player.beatoraja.skin.SkinTimingVisualizer;
+import bms.player.beatoraja.skin.SkinType;
 
 /**
  * LR2プレイスキンローダー
- * 
+ *
  * @author exch
  */
 public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
@@ -28,7 +44,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	private Rectangle[] playerr;
 
 	private Mode mode;
-	
+
 	private SkinSource[] note = new SkinSource[8];
 	private SkinSource[] lnstart = new SkinSource[8];
 	private SkinSource[] lnend = new SkinSource[8];
@@ -54,7 +70,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	private int groovey = 0;
 
 	private SkinType type;
-	
+
 	final float srcw;
 	final float srch;
 	final float dstw;
@@ -64,6 +80,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	private Rectangle gauge = new Rectangle();
 	private SkinNoteDistributionGraph noteobj;
 	private SkinBPMGraph bpmgraphobj;
+	private SkinTimingVisualizer timingobj;
 
 	public LR2PlaySkinLoader(final SkinType type, final Resolution src, final Config c) {
 		super(src, c);
@@ -162,7 +179,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 					if(playerr[values[1] % 2] != null) {
 						playerr[values[1] % 2] = new Rectangle(values[3] * dstw / srcw,
 								dsth - (values[4] + values[6]) * dsth / srch, values[5] * dstw / srcw,
-								(values[4] + values[6]) * dsth / srch);						
+								(values[4] + values[6]) * dsth / srch);
 					}
 					linevalues[values[1] % 2] = values;
 				}
@@ -397,7 +414,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 								values[6] * dsth / srch, values[7], values[8], values[9], values[10], values[11],
 								values[12], values[13], values[14], values[15], values[16], values[17], values[18],
 								values[19], values[20], new int[]{OFFSET_JUDGE_2P, values[21]});
-						
+
 						if (!detail) {
 							detail = true;
 							addJudgeDetail(skin, values, srcw, dstw, srch, dsth, 1);
@@ -734,7 +751,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 						} else {
 							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
 						}
-						
+
 						skin.add(gauger);
 					}
 				}
@@ -800,8 +817,29 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 						values[16], values[17], values[18], values[19], values[20], values[21]);
 			}
 		});
+		addCommandWord(new CommandWord("SRC_TIMING_1P") {
+			//#SRC_NOTECHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,field_h,(start),(end),delay,backTexOff,orderReverse,noGap
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				timingobj = new SkinTimingVisualizer();
+				gauge = new Rectangle(0, 0, values[11], values[12]);
+				skin.add(timingobj);
+			}
+		});
+		addCommandWord(new CommandWord("DST_TIMING_1P") {
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				gauge.x = values[3];
+				gauge.y = src.height - values[4];
+				skin.setDestination(timingobj, values[2], gauge.x, gauge.y, gauge.width, gauge.height, values[7], values[8],
+						values[9], values[10], values[11], values[12], values[13], values[14], values[15],
+						values[16], values[17], values[18], values[19], values[20], values[21]);
+			}
+		});
 	}
-	
+
 	private void setDstNowCombo(int index, String[] str, int offsetid) {
 		final SkinJudge sj = judge[index];
 		if (sj != null && sj.getJudgeCount()[Integer.parseInt(str[1]) <= 5 ? (5 - Integer.parseInt(str[1])) : Integer.parseInt(str[1])] != null) {
@@ -914,16 +952,16 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 		mine = new SkinSource[mode.key];
 		laner = new Rectangle[mode.key];
 		scale = new float[mode.key];
-		
+
 		playerr = new Rectangle[mode.player];
 		for(int i = 0;i < playerr.length;i++) {
 			playerr[i] = new Rectangle();
 		}
-		
+
 		this.loadSkin(new PlaySkin(src, dst), f, player, header, option, property);
 
 		lanerender.setLaneRegion(laner, scale, skin);
-		
+
 		SkinImage[] skinline = new SkinImage[lines[0] != null ? (lines[1] != null ? 2 : 1) : 0];
 		for(int i = 0;i < skinline.length;i++) {
 			skinline[i] = lines[i];
@@ -932,12 +970,12 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 		SkinImage[] skintime = new SkinImage[skinline.length];
 		for(int i = 0;i < skintime.length;i++) {
 			if(lines[i + 6] == null && lines[i] != null) {
-				makeDefaultLines(i + 6, 1, 64, 192, 192);				
+				makeDefaultLines(i + 6, 1, 64, 192, 192);
 			}
 			skintime[i] = lines[i + 6];
 		}
 		skin.setTimeLine(skintime);
-		
+
 		SkinImage[] skinbpm = new SkinImage[skinline.length];
 		for(int i = 0;i < skinbpm.length;i++) {
 			if(lines[i + 2] == null && lines[i] != null) {
@@ -945,8 +983,8 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			}
 			skinbpm[i] = lines[i + 2];
 		}
-		skin.setBPMLine(skinbpm);		
-		
+		skin.setBPMLine(skinbpm);
+
 		SkinImage[] skinstop = new SkinImage[skinline.length];
 		for(int i = 0;i < skinstop.length;i++) {
 			if(lines[i + 4] == null && lines[i] != null) {
@@ -955,7 +993,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			skinstop[i] = lines[i + 4];
 		}
 		skin.setStopLine(skinstop);
-		
+
 		int judge_reg = 1;
 		for(int i = 1 ; i < judge.length ; i++) {
 			if(judge[i] != null) judge_reg++;
@@ -967,7 +1005,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 
 		return skin;
 	}
-	
+
 	private void makeDefaultLines(int index, int h, int r, int g, int b) {
 		Texture tex = new Texture("skin/default/system.png");
 		int[] values = linevalues[index % 2];
@@ -978,5 +1016,5 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 				values[5] * dstw / srcw, values[6] * dsth / srch * h, values[7], 255, r, g,
 				b, values[12], values[13], values[14], values[15], values[16],
 				values[17], values[18], values[19], values[20], values[21]);
-	}	
+	}
 }

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -818,11 +818,11 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			}
 		});
 		addCommandWord(new CommandWord("SRC_TIMING_1P") {
-			//#SRC_NOTECHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,field_h,(start),(end),delay,backTexOff,orderReverse,noGap
+			//#SRC_NOTECHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,(field_h),(start),(end),drawCenter,drawDecay,(),()
 			@Override
 			public void execute(String[] str) {
 				int[] values = parseInt(str);
-				timingobj = new SkinTimingVisualizer();
+				timingobj = new SkinTimingVisualizer(values[11], values[15], values[16]);
 				gauge = new Rectangle(0, 0, values[11], values[12]);
 				skin.add(timingobj);
 			}

--- a/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
@@ -105,11 +105,11 @@ public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
 			}
 		});
 		addCommandWord(new CommandWord("SRC_TIMINGCHART_1P") {
-			//#SRC_TIMINGCHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,field_h,(start),(end),delay,backTexOff,orderReverse,noGap
+			//#SRC_TIMINGCHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,field_h,(start),(end),drawAverage
 			@Override
 			public void execute(String[] str) {
 				int[] values = parseInt(str);
-				timinggraphobj = new SkinTimingDistributionGraph();
+				timinggraphobj = new SkinTimingDistributionGraph(values[15]);
 				gauge = new Rectangle(0, 0, values[11], values[12]);
 				skin.add(timinggraphobj);
 			}

--- a/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
@@ -4,20 +4,21 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Map;
 
+import com.badlogic.gdx.math.Rectangle;
+
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.Resolution;
-import com.badlogic.gdx.math.Rectangle;
-
 import bms.player.beatoraja.result.MusicResultSkin;
 import bms.player.beatoraja.result.SkinGaugeGraphObject;
 import bms.player.beatoraja.skin.SkinBPMGraph;
 import bms.player.beatoraja.skin.SkinHeader;
 import bms.player.beatoraja.skin.SkinNoteDistributionGraph;
+import bms.player.beatoraja.skin.SkinTimingDistributionGraph;
 
 /**
  * LR2リザルトスキン読み込み用クラス
- * 
+ *
  * @author exch
  */
 public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
@@ -26,6 +27,7 @@ public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
 	private SkinGaugeGraphObject gaugeobj;
 	private SkinNoteDistributionGraph noteobj;
 	private SkinBPMGraph bpmgraphobj;
+	private SkinTimingDistributionGraph timinggraphobj;
 
 	public LR2ResultSkinLoader(final Resolution src, final Config c) {
 		super(src, c);
@@ -100,6 +102,29 @@ public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
 				skin.setDestination(bpmgraphobj, values[2], gauge.x, gauge.y, gauge.width, gauge.height, values[7], values[8],
 						values[9], values[10], values[11], values[12], values[13], values[14], values[15],
 						values[16], values[17], values[18], values[19], values[20], values[21]);
+			}
+		});
+		addCommandWord(new CommandWord("SRC_TIMINGCHART_1P") {
+			//#SRC_TIMINGCHART_1P,(index),(gr),(x),(y),(w),(h),(div_x),(div_y),(cycle),(timer),field_w,field_h,(start),(end),delay,backTexOff,orderReverse,noGap
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				timinggraphobj = new SkinTimingDistributionGraph();
+				gauge = new Rectangle(0, 0, values[11], values[12]);
+				skin.add(timinggraphobj);
+			}
+		});
+		addCommandWord(new CommandWord("DST_TIMINGCHART_1P") {
+
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				gauge.x = values[3];
+				gauge.y = src.height - values[4];
+				skin.setDestination(timinggraphobj, values[2], gauge.x, gauge.y, gauge.width, gauge.height, values[7], values[8],
+						values[9], values[10], values[11], values[12], values[13], values[14], values[15],
+						values[16], values[17], values[18], values[19], values[20], values[21]);
+
 			}
 		});
 	}


### PR DESCRIPTION
判定タイミングの可視化グラフを追加しました。
Playスキン #SRC_TIMING_1P, #DST_TIMING_1P で直近100ノーツのタイミング、
Resultスキン #SRC_TIMINGCHART_1P, #SRC_TIMINGCHART_1P で判定タイミングの分布を表示します
それに伴い、ResultスキンにNUMBERを追加しました。
374, 375 : 平均判定タイミングズレ(整数部、小数部)
376, 377 : ズレ偏差(整数部、小数部)