### PR TITLE
Skin: Fix rendering issue #244

### DIFF
--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -369,13 +369,14 @@ public class Skin {
 
 		public void draw(TextureRegion image, float x, float y, float w, float h) {
 			preDraw(image);
-			sprite.draw(image, (int)x, (int)y, (int)w, (int)h);
+			sprite.draw(image, (int)(x + 0.5f), (int)(y + 0.5f), (int)(w + (x + 0.5f) % 1.0f), (int)(h + (y + 0.5f) % 1.0f));
 			postDraw();
 		}
 
 		public void draw(TextureRegion image, float x, float y, float w, float h, float cx, float cy, float angle) {
 			preDraw(image);
-			sprite.draw(image, (int)x, (int)y, cx * w, cy * h, (int)w, (int)h, 1, 1, angle);
+			sprite.draw(image, (int)(x + 0.5f), (int)(y + 0.5f), cx * w, cy * h, (int)(w + (x + 0.5f) % 1.0f),
+					(int)(h + (y + 0.5f) % 1.0f), 1, 1, angle);
 			postDraw();
 		}
 


### PR DESCRIPTION
#244の修正をするためにintへの変換を次のように行いました。
- x,y:四捨五入
- w,h: x,yの四捨五入で切り捨てられた小数点以下とw,hを足した後、切り捨て

他にも色々な方法を試してみましたが、他の方法ではLITONE5 beatoraja 0.8.5 9KEYSのレーン右側に隙間が発生したり、LITONE5 beatoraja 0.8.5 選曲スキンのソート表示の上側に隙間が発生したりしました。
![20180321_160857_music_select](https://user-images.githubusercontent.com/4867425/37764381-eb3e16f8-2e04-11e8-9ee3-5bbcda316cad.png)