### PR TITLE
bug fix: Do not update total notes when updateScore=false

### DIFF
--- a/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -185,7 +185,9 @@ public class PlayDataAccessor {
 			score.setMode(model.containsUndefinedLongNote() ? lnmode : 0);
 		}
 		score.setSha256(hash);
-		score.setNotes(model.getTotalNotes());
+		if (updateScore) {
+			score.setNotes(model.getTotalNotes());
+		}
 
 		if (newscore.getClear() > Failed.id) {
 			score.setClearcount(score.getClearcount() + 1);


### PR DESCRIPTION
Double Battleなどの際トータルノーツが更新されてその後の選曲画面でのスコアレート表示がおかしくなるのを修正