### PR TITLE
MusicSelector: Modify condition of reading bms information

### DIFF
--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -740,6 +740,8 @@ public class BarRenderer {
 			}
 			dirString = str.toString();
 
+			select.selectedBarMoved();
+
 			return true;
 		}
 

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -74,7 +74,7 @@ public class MusicSelector extends MainState {
 	/**
 	 * 楽曲が選択されてからbmsを読み込むまでの時間(ms)
 	 */
-	private final int notesGraphDuration = 1000;
+	private final int notesGraphDuration = 350;
 	/**
 	 * 楽曲が選択されてからプレビュー曲を再生するまでの時間(ms)
 	 */
@@ -221,6 +221,7 @@ public class MusicSelector extends MainState {
 		setSound(SOUND_CHANGEOPTION, "o-change.wav", SoundType.SOUND,false);
 
 		play = null;
+		showNoteGraph = false;
 		playerdata = main.getPlayDataAccessor().readPlayerData();
 		if (bar.getSelected() != null && bar.getSelected() instanceof SongBar) {
 			scorecache.update(((SongBar) bar.getSelected()).getSongData(), config.getLnmode());
@@ -260,6 +261,9 @@ public class MusicSelector extends MainState {
         if(main.getNowTime() > getSkin().getInput()){
         	main.switchTimer(TIMER_STARTINPUT, true);
         }
+		if(main.getNowTime(TIMER_SONGBAR_CHANGE) < 0) {
+			main.setTimerOn(TIMER_SONGBAR_CHANGE);
+		}
 		// draw song information
 		resource.setSongdata(current instanceof SongBar ? ((SongBar) current).getSongData() : null);
 


### PR DESCRIPTION
選曲画面において、フォルダを開いた直後やモードフィルタ・ソート変更直後、リザルトから戻ってきた直後にPlayerResourceにBMSModelがセットされていなかったので、セットするようにしました。
また、楽曲が選択されてからbmsを読み込むまでの時間はもう少し短い方が有り難いです。