### PR TITLE
BMSPlayer: Add input.setEnable(true) in STATE_PRACTICE_FINISHED

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -633,6 +633,8 @@ public class BMSPlayer extends MainState {
 		// practice終了
 		case STATE_PRACTICE_FINISHED:
 			if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
+				input.setEnable(true);
+				input.setStartTime(0);
 				main.changeState(MainController.STATE_SELECTMUSIC);
 			}
 			break;


### PR DESCRIPTION
オートプレイ時に、STATE_PRACTICE_FINISHEDを介して選曲画面に戻るとキー操作が出来なくなってしまっていたので修正しました。