### PR TITLE
Make possible to define separately for SongBar and FolderBar in SRC_BAR_TITLE

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It works on Windows, Mac OS, and Linux.
 - 11 types of clear lamp (ex. assist, light-assist, ex-hard, perfect, and max)
 - real-time play speed controller (x0.25 - x4.0. auto play mode, replay mode only)
 - Various assist options : legacy note, expand judge, bpm guide, and no mine
-- pms judge (nax 1 miss / 1 notes, combo is reset when miss)
+- pms judge (max 1 miss / 1 notes, combo is reset when miss)
 - support bmson 0.2.1, 1.0.0
 - practice mode
 - import difficulty table folder, create course with various constraint (mirror/random OK, no hispeed, and so on)

--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -21,6 +21,7 @@ import bms.player.beatoraja.*;
 import bms.player.beatoraja.CourseData.TrophyData;
 import bms.player.beatoraja.external.BMSSearchAccessor;
 import bms.player.beatoraja.song.SongData;
+import bms.player.beatoraja.song.FolderData;
 import bms.player.beatoraja.song.SongInformationAccessor;
 
 /**
@@ -416,11 +417,29 @@ public class BarRenderer {
 			if(ba.value == -1) {
 				continue;
 			}
-			// 新規追加曲はテキストを変える
-			int songstatus = 0;
-			if (ba.sd instanceof SongBar) {
-				SongData song = ((SongBar) ba.sd).getSongData();
-				songstatus = song == null || System.currentTimeMillis() / 1000 > song.getAdddate() + 3600 * 24 ? 0 : 1;
+			// Barの種類によってテキストを変える
+			// SongBarかFolderBarの場合は新規かどうかでさらに変える
+			// songstatus最終値 =
+			// 0:通常 1:新規 2:SongBar(通常) 3:SongBar(新規) 4:FolderBar(通常) 5:FolderBar(新規) 6:TableBar or HashBar
+			// 7:GradeBar(曲所持) 8:(SongBar or GradeBar)(曲未所持) 9:CommandBar or ContainerBar 10:SearchWordBar
+			// 3以降で定義されてなければ0か1を用いる
+			int songstatus = ba.value;
+			if(songstatus >= 2) {
+				songstatus += 4;
+				//定義されてなければ0:通常を用いる
+				if(baro.getText()[songstatus] == null) songstatus = 0;
+			} else {
+				if (songstatus == 0) {
+					SongData song = ((SongBar) ba.sd).getSongData();
+					songstatus = song == null || System.currentTimeMillis() / 1000 > song.getAdddate() + 3600 * 24 ? 2 : 3;
+					//定義されてなければ0:通常か1:新規を用いる
+					if(baro.getText()[songstatus] == null) songstatus = songstatus == 3 ? 1 : 0;
+				} else {
+					FolderData data = ((FolderBar) ba.sd).getFolderData();
+					songstatus = data == null || System.currentTimeMillis() / 1000 > data.getAdddate() + 3600 * 24 ? 4 : 5;
+					//定義されてなければ0:通常か1:新規を用いる
+					if(baro.getText()[songstatus] == null) songstatus = songstatus == 5 ? 1 : 0;
+				}
 			}
 			baro.getText()[songstatus].setText(ba.sd.getTitle());
 			baro.getText()[songstatus].draw(sprite, time, select, ba.x, ba.y);

--- a/src/bms/player/beatoraja/select/SkinBar.java
+++ b/src/bms/player/beatoraja/select/SkinBar.java
@@ -23,8 +23,13 @@ public class SkinBar extends SkinObject {
      * トロフィーのSkinImage。描画位置はBarの相対座標
      */
     private SkinImage[] trophy = new SkinImage[3];
-
-    private SkinText[] text = new SkinText[2];
+    /**
+     * BarのSkinText。描画位置はBarの相対座標。
+     * Indexは0:通常 1:新規 2:SongBar(通常) 3:SongBar(新規) 4:FolderBar(通常) 5:FolderBar(新規) 6:TableBar or HashBar
+     * 7:GradeBar(曲所持) 8:(SongBar or GradeBar)(曲未所持) 9:CommandBar or ContainerBar 10:SearchWordBar
+     * 3以降で定義されてなければ0か1を用いる
+     */
+    private SkinText[] text = new SkinText[11];
     /**
      * レベルのSkinNumber。描画位置はBarの相対座標
      */

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -841,8 +841,9 @@ public class JSONSkinLoader extends SkinLoader{
 								}
 							}
 						}
-						barobj.getText()[0] = text[0];
-						barobj.getText()[1] = text[1];
+						for(int i = 0; i < barobj.getText().length && i < text.length; i++) {
+							barobj.getText()[i] = text[i];
+						}
 
 						SkinNumber[] numbers = new SkinNumber[sk.songlist.level.length];
 						for (int i = 0; i < sk.songlist.level.length; i++) {

--- a/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
@@ -478,6 +478,9 @@ public class LR2SelectSkinLoader extends LR2SkinCSVLoader<MusicSelectSkin> {
 		addCommandWord(new CommandWord("SRC_BAR_TITLE") {
 			@Override
 			public void execute(String[] str) {
+				// 拡張Index 0:通常 1:新規 2:SongBar(通常) 3:SongBar(新規) 4:FolderBar(通常) 5:FolderBar(新規) 6:TableBar or HashBar
+				// 7:GradeBar(曲所持) 8:(SongBar or GradeBar)(曲未所持) 9:CommandBar or ContainerBar 10:SearchWordBar
+				// 3以降で定義されてなければ0か1が用いられる
 				int[] values = parseInt(str);
 				SkinText bartext = null;
 				if (values[2] < fontlist.size() && fontlist.get(values[2]) != null) {


### PR DESCRIPTION
SRC_BAR_TITLE・DST_BAR_TITLEを曲バーとフォルダーバーで別々に定義したいという要望があったため、以下のようなIndexで定義出来るようにしました。
0:  通常
1:  新規
2:  SongBar(通常)
3:  SongBar(新規)
4:  FolderBar(通常)
5:  FolderBar(新規)
6:  TableBar or HashBar
7:  GradeBar(曲所持)
8:  (SongBar or GradeBar)(曲未所持)
9:  CommandBar or ContainerBar
10: SearchWordBar
3以降で定義されてなければ従来通り0:通常か1:新規が用いられます。

また、上記と関係ありませんが、README.mdに誤字を見つけたので修正しました。