### PR TITLE
Improve rendering speed of SkinNoteDistributionGraph when play

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -1375,6 +1375,10 @@ public class BMSPlayer extends MainState {
 		return notes == main.getPlayerResource().getSongdata().getNotes();
 	}
 
+	public int getPastNotes() {
+		return notes;
+	}
+
 	public void setPastNotes(int notes) {
 		this.notes = notes;
 	}

--- a/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -250,6 +250,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 		if (shapetex != null && !(state instanceof BMSPlayer)) {
 			shapetex.getTexture().dispose();
 			backtex.getTexture().dispose();
+			shape.dispose();
 		}
 
 		if( shape == null || (shape != null && !(state instanceof BMSPlayer)) ) {
@@ -334,6 +335,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 			shapetex.getTexture().dispose();
 			startcursor.getTexture().dispose();
 			endcursor.getTexture().dispose();
+			shape.dispose();
 			shapetex = null;
 		}
 	}


### PR DESCRIPTION
プレイ中、SkinNoteDistributionGraphを表示すると非常に重くなってしまっていたので以下の変更をしました。
- 処理済みノート数に変化があった時だけ判定分布を更新
- SkinTimingVisualizerのようにnewやdisposeはせずに透明色で埋めることで画像データをリセット