### PR TITLE
LR2SkinLoader: Modify LaneRegion.height

### DIFF
--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -6,6 +6,7 @@ import bms.player.beatoraja.ShaderManager;
 import bms.player.beatoraja.SkinConfig.Offset;
 import bms.player.beatoraja.play.SkinGauge;
 import bms.player.beatoraja.skin.SkinObject.BooleanProperty;
+import bms.player.beatoraja.skin.SkinObject.SkinObjectDestination;
 import bms.player.beatoraja.skin.SkinObject.SkinOffset;
 import bms.player.beatoraja.play.BMSPlayer;
 
@@ -503,6 +504,22 @@ public class Skin {
 			}
 		}
 		return 0;
+	}
+
+	/*
+	 * 白数字が0の時のレーンカバーのy座標
+	 */
+	public float getLaneCoverPosition() {
+		for(SkinObject obj: objects) {
+			if(obj instanceof SkinSlider) {
+				SkinSlider slider = (SkinSlider) obj;
+				if(slider.getType() == SLIDER_LANECOVER) {
+					SkinObjectDestination[] dst = slider.getAllDestination();
+					return dst[dst.length - 1].region.y;
+				}
+			}
+		}
+		return -1;
 	}
 
 	public void setGaugeParts(int parts) {

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -1028,6 +1028,13 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 
 		this.loadSkin(new PlaySkin(src, dst), f, player, header, option, property);
 
+		//白数字が0の時のレーンカバーのy座標の分だけレーンの高さを減らす
+		float laneCoverPosition = skin.getLaneCoverPosition();
+		if(laneCoverPosition > 0) {
+			for(int i = 0; i < laner.length; i++) {
+				laner[i].height = laner[i].height - (dsth - laneCoverPosition);
+			}
+		}
 		lanerender.setLaneRegion(laner, scale, skin);
 
 		SkinImage[] skinline = new SkinImage[lines[0] != null ? (lines[1] != null ? 2 : 1) : 0];


### PR DESCRIPTION
LR2スキンにおいて、レーン上端と画面上端が一致しないスキンで、LaneRegion.heightが正しくならないので、レーンカバーのy座標の分だけ減らすようにしました。
SkinSliderのtypeは将来廃止予定とのことですが、廃止する際は変更お願い致します。