### PR TITLE
LR2 skin: add STRETCH command

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinObject.java
+++ b/src/bms/player/beatoraja/skin/SkinObject.java
@@ -266,6 +266,8 @@ public abstract class SkinObject implements Disposable {
 	}
 
 	public void setStretch(int stretch) {
+		if (stretch < 0)
+			return;
 		for (StretchType type : StretchType.values()) {
 			if (type.id == stretch) {
 				this.stretch = type;

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -146,6 +146,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 					skin.setDestination(bga, 0, values[3], srch - values[4] - values[6], values[5], values[6],
 							values[7], values[8], values[9], values[10], values[11], values[12], values[13], values[14],
 							values[15], values[16], values[17], values[18], values[19], values[20], readOffset(str, 21));
+					bga.setStretch(stretch);
 				}
 			}
 		});

--- a/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SkinCSVLoader.java
@@ -224,6 +224,7 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 							values[6] * dsth / srch, values[7], values[8], values[9], values[10], values[11],
 							values[12], values[13], values[14], values[15], values[16], values[17], values[18],
 							values[19], values[20], readOffset(str, 21));
+					part.setStretch(stretch);
 				}
 			}
 		});
@@ -651,7 +652,13 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 				}
 			}
 		});
-
+		addCommandWord(new CommandWord("STRETCH") {
+			@Override
+			public void execute(String[] str) {
+				int[] values = parseInt(str);
+				stretch = values[1];
+			}
+		});
 	}
 
 	protected void loadSkin(Skin skin, File f, MainState state) throws IOException {
@@ -707,6 +714,8 @@ public abstract class LR2SkinCSVLoader<S extends Skin> extends LR2SkinLoader {
 	SkinImage PMcharaPart = null;
 
 	List <Object> imagesetarray = new ArrayList<Object>();
+
+	int stretch = -1;
 
 	protected void loadSkin0(Skin skin, File f, MainState state, Map<Integer, Boolean> option) throws IOException {
 


### PR DESCRIPTION
JSONスキンのDestinationにおける `stretch` フィールド (#177) に相当するLR2スキンの機能追加です。

`DST_*` 系コマンドに引数を追加するのが不可能だったため、別コマンド `#STRETCH` で状態を指定するようにしました。下の例のようにDSTより前で目的の値に設定し、DSTより後でデフォルトの-1に戻します。

```
...
#STRETCH,7
#SRC_IMAGE,0,102,0,0,-1,-1,1,1,0,0,0,0,0
#DST_IMAGE,0,0,815,234,150,40,2,255,255,255,255,0,1,0,0,300,11,0,0,0
#DST_IMAGE,0,300,740,214,300,80,2,255,255,255,255,0,1,0,0
#STRETCH,-1
...
```

今のところ使用頻度の高いであろう `#DST_IMAGE` と `#DST_BGA` のみに影響します。