### PR TITLE
Add Exception Handling in send IR

### DIFF
--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -203,45 +203,49 @@ public class CourseResult extends AbstractResult {
 
 					@Override
 					public void run() {
-						main.switchTimer(TIMER_IR_CONNECT_SUCCESS, true);
-						Logger.getGlobal().info("IRへスコア送信");
-						int lnmode = 0;
-						for(BMSModel model : resource.getCourseBMSModels()) {
-							if(model.containsUndefinedLongNote()) {
-								lnmode = config.getLnmode();
-								break;
-							}
-						}
-						IRResponse<Object> send = ir.sendCoursePlayData(resource.getCourseData(), lnmode, resource.getCourseScoreData());
-						if(send.isSuccessed()) {
+						try {
 							main.switchTimer(TIMER_IR_CONNECT_SUCCESS, true);
-							Logger.getGlobal().info("IRスコア送信完了");							
-						} else {
-							main.switchTimer(TIMER_IR_CONNECT_FAIL, true);
-							Logger.getGlobal().warning("IRスコア送信失敗 : " + send.getMessage());							
-						}
-						IRResponse<IRScoreData[]> response = ir.getCoursePlayData(null, resource.getCourseData(), lnmode);
-						if(response.isSuccessed()) {
-							IRScoreData[] scores = response.getData();
-							irtotal = scores.length;
-
-							for(int i = 0;i < scores.length;i++) {
-								if(irrank == 0 && scores[i].getExscore() <= resource.getScoreData().getExscore() ) {
-									irrank = i + 1;
+							Logger.getGlobal().info("IRへスコア送信");
+							int lnmode = 0;
+							for(BMSModel model : resource.getCourseBMSModels()) {
+								if(model.containsUndefinedLongNote()) {
+									lnmode = config.getLnmode();
+									break;
 								}
-								if(irprevrank == 0 && scores[i].getExscore() <= oldscore.getExscore() ) {
-									irprevrank = i + 1;
-									if(irrank == 0) {
-										irrank = irprevrank;
+							}
+							IRResponse<Object> send = ir.sendCoursePlayData(resource.getCourseData(), lnmode, resource.getCourseScoreData());
+							if(send.isSuccessed()) {
+								main.switchTimer(TIMER_IR_CONNECT_SUCCESS, true);
+								Logger.getGlobal().info("IRスコア送信完了");							
+							} else {
+								main.switchTimer(TIMER_IR_CONNECT_FAIL, true);
+								Logger.getGlobal().warning("IRスコア送信失敗 : " + send.getMessage());							
+							}
+							IRResponse<IRScoreData[]> response = ir.getCoursePlayData(null, resource.getCourseData(), lnmode);
+							if(response.isSuccessed()) {
+								IRScoreData[] scores = response.getData();
+								irtotal = scores.length;
+	
+								for(int i = 0;i < scores.length;i++) {
+									if(irrank == 0 && scores[i].getExscore() <= resource.getScoreData().getExscore() ) {
+										irrank = i + 1;
+									}
+									if(irprevrank == 0 && scores[i].getExscore() <= oldscore.getExscore() ) {
+										irprevrank = i + 1;
+										if(irrank == 0) {
+											irrank = irprevrank;
+										}
 									}
 								}
+								Logger.getGlobal().warning("IRからのスコア取得成功 : " + response.getMessage());
+							} else {
+								Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
 							}
-							Logger.getGlobal().warning("IRからのスコア取得成功 : " + response.getMessage());
-						} else {
-							Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+						} catch (Exception e) {
+							Logger.getGlobal().severe(e.getMessage());
+						} finally {
+							state = STATE_IR_FINISHED;
 						}
-
-						state = STATE_IR_FINISHED;
 					}
 				};
 				irprocess.start();					

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -413,31 +413,35 @@ public class MusicResult extends AbstractResult {
 
 						@Override
 						public void run() {
-							ir.sendPlayData(resource.getBMSModel(), resource.getScoreData());
-							IRResponse<IRScoreData[]> response = ir.getPlayData(null, resource.getBMSModel());
-							if(response.isSuccessed()) {
-								IRScoreData[] scores = response.getData();
-								irtotal = scores.length;
-
-								for(int i = 0;i < scores.length;i++) {
-									if(irrank == 0 && scores[i].getExscore() <= resource.getScoreData().getExscore() ) {
-										irrank = i + 1;
-									}
-									if(irprevrank == 0 && scores[i].getExscore() <= oldscore.getExscore() ) {
-										irprevrank = i + 1;
-										if(irrank == 0) {
-											irrank = irprevrank;
+							try {
+								ir.sendPlayData(resource.getBMSModel(), resource.getScoreData());
+								IRResponse<IRScoreData[]> response = ir.getPlayData(null, resource.getBMSModel());
+								if(response.isSuccessed()) {
+									IRScoreData[] scores = response.getData();
+									irtotal = scores.length;
+	
+									for(int i = 0;i < scores.length;i++) {
+										if(irrank == 0 && scores[i].getExscore() <= resource.getScoreData().getExscore() ) {
+											irrank = i + 1;
+										}
+										if(irprevrank == 0 && scores[i].getExscore() <= oldscore.getExscore() ) {
+											irprevrank = i + 1;
+											if(irrank == 0) {
+												irrank = irprevrank;
+											}
 										}
 									}
+									main.switchTimer(TIMER_IR_CONNECT_SUCCESS, true);
+									Logger.getGlobal().info("IRへスコア送信完了");
+								} else {
+									main.switchTimer(TIMER_IR_CONNECT_FAIL, true);
+									Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
 								}
-								main.switchTimer(TIMER_IR_CONNECT_SUCCESS, true);
-								Logger.getGlobal().info("IRへスコア送信完了");
-							} else {
-								main.switchTimer(TIMER_IR_CONNECT_FAIL, true);
-								Logger.getGlobal().warning("IRからのスコア取得失敗 : " + response.getMessage());
+							} catch (Exception e) {
+								Logger.getGlobal().severe(e.getMessage());
+							} finally {
+								state = STATE_IR_FINISHED;
 							}
-
-							state = STATE_IR_FINISHED;
 						}
 					};
 					irprocess.start();


### PR DESCRIPTION
各自実装した`bms.player.beatoraja.ir.IRConnection`でのExceptionや、そもそも該当メソッドが実装されていない場合にエラーとなり、`state = STATE_IR_FINISHED;` に移行しなかったのを修正しました。

![unknown](https://user-images.githubusercontent.com/20876249/39192788-f60a3b1e-4814-11e8-9665-51ec5eafe6ce.png)

***
自分の環境だと何故か例外を確認できなかったので検証いただきたいです。
