### PR TITLE
MusicResult: Make possible to display GrooveGauge

### DIFF
--- a/src/bms/player/beatoraja/play/SkinGauge.java
+++ b/src/bms/player/beatoraja/play/SkinGauge.java
@@ -113,7 +113,7 @@ public class SkinGauge extends SkinObject {
 			value = gaugeTransition.get(gaugeTransition.size - 1);
 			if(time < starttime) {
 				value = gauge.getGauge(type).getProperty().min;
-			} else if(time >= starttime && time <= endtime) {
+			} else if(time >= starttime && time < endtime) {
 				value = Math.min(value, Math.max(max * (time - starttime) / (endtime - starttime), gauge.getGauge(type).getProperty().min));
 			}
 		}

--- a/src/bms/player/beatoraja/result/AbstractResult.java
+++ b/src/bms/player/beatoraja/result/AbstractResult.java
@@ -162,4 +162,8 @@ public abstract class AbstractResult extends MainState {
 	public enum ReplayStatus {
 		EXIST, NOT_EXIST, SAVED;
 	}
+
+	public int getGaugeType() {
+		return gaugeType;
+	}
 }

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -557,11 +557,11 @@ public class MusicResult extends AbstractResult {
 			}
 			return resource.getScoreData().getCombo() - oldscore.getCombo();
 		case NUMBER_GROOVEGAUGE:
-			return (int) resource.getGauge()[resource.getGrooveGauge().getType()]
-					.get(resource.getGauge()[resource.getGrooveGauge().getType()].size - 1);
+			return (int) resource.getGauge()[gaugeType]
+					.get(resource.getGauge()[gaugeType].size - 1);
 		case NUMBER_GROOVEGAUGE_AFTERDOT:
-			float value = resource.getGauge()[resource.getGrooveGauge().getType()]
-					.get(resource.getGauge()[resource.getGrooveGauge().getType()].size - 1) * 10;
+			float value = resource.getGauge()[gaugeType]
+					.get(resource.getGauge()[gaugeType].size - 1) * 10;
 			if(value > 0 && value < 1) value = 1;
 			return ((int) value) % 10;
 		case NUMBER_AVERAGE_DURATION:

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1432,7 +1432,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int range = 3;
 		public int cycle = 33;
 		public int starttime = 0;
-		public int endtime = 1000;
+		public int endtime = 500;
 	}
 
 	public static class HiddenCover {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -681,7 +681,7 @@ public class JSONSkinLoader extends SkinLoader{
 						((PlaySkin) skin).setNoteExpansionRate(sk.note.expansionrate);
 						obj = sn;
 					}
-					// gauge (playskin only)
+					// gauge (playskin or resultskin only)
 					if (sk.gauge != null && dst.id.equals(sk.gauge.id)) {
 						TextureRegion[][] pgaugetex = new TextureRegion[sk.gauge.nodes.length][];
 						for (int i = 0; i < sk.gauge.nodes.length; i++) {
@@ -703,6 +703,9 @@ public class JSONSkinLoader extends SkinLoader{
 						}
 
 						obj = new SkinGauge(gaugetex, 0, 0, sk.gauge.parts, sk.gauge.type, sk.gauge.range, sk.gauge.cycle);
+
+						((SkinGauge)obj).setStarttime(sk.gauge.starttime);
+						((SkinGauge)obj).setEndtime(sk.gauge.endtime);
 					}
 					// hidden cover (playskin only)
 					for (HiddenCover img : sk.hiddenCover) {
@@ -1427,7 +1430,9 @@ public class JSONSkinLoader extends SkinLoader{
 		public int parts = 50;
 		public int type;
 		public int range = 3;
-		public int cycle = 33;;
+		public int cycle = 33;
+		public int starttime = 0;
+		public int endtime = 1000;
 	}
 
 	public static class HiddenCover {

--- a/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
+++ b/src/bms/player/beatoraja/skin/SkinPropertyMapper.java
@@ -11,6 +11,7 @@ import bms.player.beatoraja.play.BMSPlayer;
 import bms.player.beatoraja.play.GrooveGauge.Gauge;
 import bms.player.beatoraja.play.JudgeManager;
 import bms.player.beatoraja.play.LaneRenderer;
+import bms.player.beatoraja.result.AbstractResult;
 import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.select.MusicSelector;
@@ -172,35 +173,46 @@ public class SkinPropertyMapper {
 		final int id = Math.abs(optionid);
 		
 		if(id == OPTION_GAUGE_GROOVE) {
-			result = new DrawConditionProperty(DrawConditionProperty.TYPE_STATIC_ON_RESULT) {
+			result = new DrawConditionProperty(DrawConditionProperty.TYPE_NO_STATIC) {
 				@Override
 				public boolean get(MainState state) {
+					int type = Integer.MIN_VALUE;
 					if(state instanceof BMSPlayer) {
-						return ((BMSPlayer) state).getGauge().getType() <= 2;
+						type = ((BMSPlayer) state).getGauge().getType();
+					} else if(state instanceof AbstractResult) {
+						type = ((AbstractResult) state).getGaugeType();
 					}
+					if(type != Integer.MIN_VALUE) return type <= 2;
 					return false;
 				}
 			};			
 		}
 		if(id == OPTION_GAUGE_HARD) {
-			result = new DrawConditionProperty(DrawConditionProperty.TYPE_STATIC_ON_RESULT) {
+			result = new DrawConditionProperty(DrawConditionProperty.TYPE_NO_STATIC) {
 				@Override
 				public boolean get(MainState state) {
+					int type = Integer.MIN_VALUE;
 					if(state instanceof BMSPlayer) {
-						return ((BMSPlayer) state).getGauge().getType() >= 3;
+						type = ((BMSPlayer) state).getGauge().getType();
+					} else if(state instanceof AbstractResult) {
+						type = ((AbstractResult) state).getGaugeType();
 					}
+					if(type != Integer.MIN_VALUE) return type >= 3;
 					return false;
 				}
 			};			
 		}
 		if(id == OPTION_GAUGE_EX) {
-			result = new DrawConditionProperty(DrawConditionProperty.TYPE_STATIC_ON_RESULT) {
+			result = new DrawConditionProperty(DrawConditionProperty.TYPE_NO_STATIC) {
 				@Override
 				public boolean get(MainState state) {
+					int type = Integer.MIN_VALUE;
 					if(state instanceof BMSPlayer) {
-						final int type = ((BMSPlayer) state).getGauge().getType();
-						return type == 0 || type == 1 || type == 4 || type == 5 || type == 7 || type == 8;
+						type = ((BMSPlayer) state).getGauge().getType();
+					} else if(state instanceof AbstractResult) {
+						type = ((AbstractResult) state).getGaugeType();
 					}
+					if(type != Integer.MIN_VALUE) return type == 0 || type == 1 || type == 4 || type == 5 || type == 7 || type == 8;
 					return false;
 				}
 			};			

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -47,15 +47,11 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 	private SkinSource[] mine = new SkinSource[8];
 	private Rectangle[] laner = new Rectangle[8];
 	private float[] scale = new float[8];
-	private SkinGauge gauger = null;
 	private SkinImage line;
 	private SkinImage[] lines = new SkinImage[8];
 	private String[][] linevalues = new String[2][];
 
 	private SkinJudge[] judge = new SkinJudge[3];
-
-	private int groovex = 0;
-	private int groovey = 0;
 
 	private SkinType type;
 
@@ -637,156 +633,6 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 							values[6] * dsth / srch, values[7], values[8], values[9], values[10], values[11],
 							values[12], values[13], values[14], values[15], values[16], values[17], values[18],
 							values[19], values[20], readOffset(str, 21, new int[]{OFFSET_LIFT}));
-				}
-			}
-		});
-
-		addCommandWord(new CommandWord("SRC_GROOVEGAUGE") {
-			@Override
-			public void execute(String[] str) {
-				gauger = null;
-				int[] values = parseInt(str);
-				if (values[2] < imagelist.size && imagelist.get(values[2]) != null) {
-					int playside = values[1];
-					int divx = values[7];
-					if (divx <= 0) {
-						divx = 1;
-					}
-					int divy = values[8];
-					if (divy <= 0) {
-						divy = 1;
-					}
-					TextureRegion[][] gauge;
-					if(values[14] == 3 && divx * divy % 6 == 0) {
-						//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、発光表赤、発光表緑の順にsrc分割
-						gauge = new TextureRegion[(divx * divy) / 6][12];
-						final int w = values[5];
-						final int h = values[6];
-						for (int x = 0; x < divx; x++) {
-							for (int y = 0; y < divy; y++) {
-								if ((y * divx + x) / 6 < gauge.length) {
-									if((y * divx + x) % 6 < 4) {
-										gauge[(y * divx + x) / 6][(y * divx + x) % 6] = new TextureRegion(
-												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-												values[4] + h * y / divy, w / divx, h / divy);
-										gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 4] = new TextureRegion(
-												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-												values[4] + h * y / divy, w / divx, h / divy);
-									} else {
-										gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 4] = new TextureRegion(
-												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-												values[4] + h * y / divy, w / divx, h / divy);
-										gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 6] = new TextureRegion(
-												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-												values[4] + h * y / divy, w / divx, h / divy);
-									}
-								}
-							}
-						}
-					} else {
-						gauge = new TextureRegion[(divx * divy) / 4][8];
-						final int w = values[5];
-						final int h = values[6];
-						for (int x = 0; x < divx; x++) {
-							for (int y = 0; y < divy; y++) {
-								if ((y * divx + x) / 4 < gauge.length) {
-									gauge[(y * divx + x) / 4][(y * divx + x) % 4] = new TextureRegion(
-											(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-									gauge[(y * divx + x) / 4][(y * divx + x) % 4 + 4] = new TextureRegion(
-											(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-								}
-							}
-						}
-					}
-					groovex = values[11];
-					groovey = values[12];
-					if (gauger == null) {
-						if(values[13] == 0) {
-							gauger = new SkinGauge(gauge, values[10], values[9], mode == Mode.POPN_9K ? 24 : 50, 0, mode == Mode.POPN_9K ? 0 : 3, 33);
-						} else {
-							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
-						}
-
-						skin.add(gauger);
-					}
-				}
-			}
-		});
-		addCommandWord(new CommandWord("SRC_GROOVEGAUGE_EX") {
-			//JSONスキンと同形式版 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑の順にsrc分割
-			@Override
-			public void execute(String[] str) {
-				gauger = null;
-				int[] values = parseInt(str);
-				if (values[2] < imagelist.size && imagelist.get(values[2]) != null) {
-					int playside = values[1];
-					int divx = values[7];
-					if (divx <= 0) {
-						divx = 1;
-					}
-					int divy = values[8];
-					if (divy <= 0) {
-						divy = 1;
-					}
-					TextureRegion[][] gauge;
-					if(values[14] == 3 && divx * divy % 12 == 0) {
-						//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑、発光表赤、発光表緑、発光EX表赤、発光EX表緑の順にsrc分割
-						gauge = new TextureRegion[(divx * divy) / 12][12];
-						final int w = values[5];
-						final int h = values[6];
-						for (int x = 0; x < divx; x++) {
-							for (int y = 0; y < divy; y++) {
-								if ((y * divx + x) / 12 < gauge.length) {
-										gauge[(y * divx + x) / 12][(y * divx + x) % 12] = new TextureRegion(
-												(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-												values[4] + h * y / divy, w / divx, h / divy);
-								}
-							}
-						}
-					} else {
-						gauge = new TextureRegion[(divx * divy) / 8][8];
-						final int w = values[5];
-						final int h = values[6];
-						for (int x = 0; x < divx; x++) {
-							for (int y = 0; y < divy; y++) {
-								if ((y * divx + x) / 8 < gauge.length) {
-									gauge[(y * divx + x) / 8][(y * divx + x) % 8] = new TextureRegion(
-											(Texture) imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-								}
-							}
-						}
-					}
-					groovex = values[11];
-					groovey = values[12];
-					if (gauger == null) {
-						if(values[13] == 0) {
-							gauger = new SkinGauge(gauge, values[10], values[9], mode == Mode.POPN_9K ? 24 : 50, 0, mode == Mode.POPN_9K ? 0 : 3, 33);
-						} else {
-							gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
-						}
-
-						skin.add(gauger);
-					}
-				}
-			}
-		});
-		addCommandWord(new CommandWord("DST_GROOVEGAUGE") {
-			@Override
-			public void execute(String[] str) {
-				if (gauger != null) {
-					float width = (Math.abs(groovex) >= 1) ? (groovex * 50 * dstw / srcw)
-							: (Integer.parseInt(str[5]) * dstw / srcw);
-					float height = (Math.abs(groovey) >= 1) ? (groovey * 50 * dsth / srch)
-							: (Integer.parseInt(str[6]) * dsth / srch);
-					float x = Integer.parseInt(str[3]) * dstw / srcw - (groovex < 0 ? groovex * dstw / srcw : 0);
-					float y = dsth - Integer.parseInt(str[4]) * dsth / srch - height;
-					int[] values = parseInt(str);
-					gauger.setDestination(values[2], x, y, width, height, values[7],
-							values[8], values[9], values[10], values[11], values[12], values[13], values[14],
-							values[15], values[16], values[17], values[18], values[19], values[20], readOffset(str, 21));
 				}
 			}
 		});

--- a/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
@@ -3,17 +3,13 @@ package bms.player.beatoraja.skin.lr2;
 import java.io.File;
 import java.io.IOException;
 
-import com.badlogic.gdx.graphics.Texture;
-import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.IntIntMap;
 import com.badlogic.gdx.utils.ObjectMap;
 
-import bms.model.Mode;
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.Resolution;
-import bms.player.beatoraja.play.SkinGauge;
 import bms.player.beatoraja.result.MusicResultSkin;
 import bms.player.beatoraja.result.SkinGaugeGraphObject;
 import bms.player.beatoraja.skin.SkinBPMGraph;
@@ -33,10 +29,6 @@ public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
 	SkinNoteDistributionGraph noteobj;
 	SkinBPMGraph bpmgraphobj;
 	SkinTimingDistributionGraph timinggraphobj;
-	int groovex = 0;
-	int groovey = 0;
-	SkinGauge gauger = null;
-	Mode mode;
 
 	public LR2ResultSkinLoader(final Resolution src, final Config c) {
 		super(src, c);
@@ -45,7 +37,6 @@ public class LR2ResultSkinLoader extends LR2SkinCSVLoader<MusicResultSkin> {
 
 	public MusicResultSkin loadSkin(File f, MainState state, SkinHeader header, IntIntMap option,
 			ObjectMap property) throws IOException {
-		mode = header.getSkinType().getMode();
 		return this.loadSkin(new MusicResultSkin(src, dst), f, state, header, option, property);
 	}
 
@@ -143,163 +134,6 @@ enum ResultCommand implements LR2SkinLoader.Command<LR2ResultSkinLoader> {
 					values[8], values[9], values[10], values[11], values[12], values[13], values[14],
 					values[15], values[16], values[17], values[18], values[19], values[20], loader.readOffset(str, 21));
 
-		}
-	},
-	SRC_GROOVEGAUGE {
-		//SRC定義,index,gr,x,y,w,h,div_x,div_y,cycle,timer,add_x,add_y,parts,animation_type,animation_range,animation_cycle,starttime,endtime
-		@Override
-		public void execute(LR2ResultSkinLoader loader, String[] str) {
-			loader.gauger = null;
-			int[] values = loader.parseInt(str);
-			if (values[2] < loader.imagelist.size && loader.imagelist.get(values[2]) != null) {
-				int playside = values[1];
-				int divx = values[7];
-				if (divx <= 0) {
-					divx = 1;
-				}
-				int divy = values[8];
-				if (divy <= 0) {
-					divy = 1;
-				}
-				TextureRegion[][] gauge;
-				if(values[14] == 3 && divx * divy % 6 == 0) {
-					//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、発光表赤、発光表緑の順にsrc分割
-					gauge = new TextureRegion[(divx * divy) / 6][12];
-					final int w = values[5];
-					final int h = values[6];
-					for (int x = 0; x < divx; x++) {
-						for (int y = 0; y < divy; y++) {
-							if ((y * divx + x) / 6 < gauge.length) {
-								if((y * divx + x) % 6 < 4) {
-									gauge[(y * divx + x) / 6][(y * divx + x) % 6] = new TextureRegion(
-											(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-									gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 4] = new TextureRegion(
-											(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-								} else {
-									gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 4] = new TextureRegion(
-											(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-									gauge[(y * divx + x) / 6][(y * divx + x) % 6 + 6] = new TextureRegion(
-											(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-								}
-							}
-						}
-					}
-				} else {
-					gauge = new TextureRegion[(divx * divy) / 4][8];
-					final int w = values[5];
-					final int h = values[6];
-					for (int x = 0; x < divx; x++) {
-						for (int y = 0; y < divy; y++) {
-							if ((y * divx + x) / 4 < gauge.length) {
-								gauge[(y * divx + x) / 4][(y * divx + x) % 4] = new TextureRegion(
-										(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-										values[4] + h * y / divy, w / divx, h / divy);
-								gauge[(y * divx + x) / 4][(y * divx + x) % 4 + 4] = new TextureRegion(
-										(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-										values[4] + h * y / divy, w / divx, h / divy);
-							}
-						}
-					}
-				}
-				loader.groovex = values[11];
-				loader.groovey = values[12];
-				if (loader.gauger == null) {
-					if(values[13] == 0) {
-						loader.gauger = new SkinGauge(gauge, values[10], values[9], loader.mode == Mode.POPN_9K ? 24 : 50, 0, loader.mode == Mode.POPN_9K ? 0 : 3, 33);
-					} else {
-						loader.gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
-					}
-
-					loader.skin.add(loader.gauger);
-
-					loader.gauger.setStarttime(values[17]);
-					loader.gauger.setEndtime(values[18]);
-				}
-			}
-		}
-	},
-	SRC_GROOVEGAUGE_EX {
-		//JSONスキンと同形式版 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑の順にsrc分割
-		//SRC定義,index,gr,x,y,w,h,div_x,div_y,cycle,timer,add_x,add_y,parts,animation_type,animation_range,animation_cycle,starttime,endtime
-		@Override
-		public void execute(LR2ResultSkinLoader loader, String[] str) {
-			loader.gauger = null;
-			int[] values = loader.parseInt(str);
-			if (values[2] < loader.imagelist.size && loader.imagelist.get(values[2]) != null) {
-				int playside = values[1];
-				int divx = values[7];
-				if (divx <= 0) {
-					divx = 1;
-				}
-				int divy = values[8];
-				if (divy <= 0) {
-					divy = 1;
-				}
-				TextureRegion[][] gauge;
-				if(values[14] == 3 && divx * divy % 12 == 0) {
-					//アニメーションタイプがPMS用明滅アニメーションの場合 表赤、表緑、裏赤、裏緑、EX表赤、EX表緑、EX裏赤、EX裏緑、発光表赤、発光表緑、発光EX表赤、発光EX表緑の順にsrc分割
-					gauge = new TextureRegion[(divx * divy) / 12][12];
-					final int w = values[5];
-					final int h = values[6];
-					for (int x = 0; x < divx; x++) {
-						for (int y = 0; y < divy; y++) {
-							if ((y * divx + x) / 12 < gauge.length) {
-									gauge[(y * divx + x) / 12][(y * divx + x) % 12] = new TextureRegion(
-											(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-											values[4] + h * y / divy, w / divx, h / divy);
-							}
-						}
-					}
-				} else {
-					gauge = new TextureRegion[(divx * divy) / 8][8];
-					final int w = values[5];
-					final int h = values[6];
-					for (int x = 0; x < divx; x++) {
-						for (int y = 0; y < divy; y++) {
-							if ((y * divx + x) / 8 < gauge.length) {
-								gauge[(y * divx + x) / 8][(y * divx + x) % 8] = new TextureRegion(
-										(Texture) loader.imagelist.get(values[2]), values[3] + w * x / divx,
-										values[4] + h * y / divy, w / divx, h / divy);
-							}
-						}
-					}
-				}
-				loader.groovex = values[11];
-				loader.groovey = values[12];
-				if (loader.gauger == null) {
-					if(values[13] == 0) {
-						loader.gauger = new SkinGauge(gauge, values[10], values[9], loader.mode == Mode.POPN_9K ? 24 : 50, 0, loader.mode == Mode.POPN_9K ? 0 : 3, 33);
-					} else {
-						loader.gauger = new SkinGauge(gauge, values[10], values[9], values[13], values[14], values[15], values[16]);
-					}
-
-					loader.skin.add(loader.gauger);
-
-					loader.gauger.setStarttime(values[17]);
-					loader.gauger.setEndtime(values[18]);
-				}
-			}
-		}
-	},
-	DST_GROOVEGAUGE {
-		@Override
-		public void execute(LR2ResultSkinLoader loader, String[] str) {
-			if (loader.gauger != null) {
-				float width = (Math.abs(loader.groovex) >= 1) ? (loader.groovex * 50 * loader.dst.width / loader.src.width)
-						: (Integer.parseInt(str[5]) * loader.dst.width / loader.src.width);
-				float height = (Math.abs(loader.groovey) >= 1) ? (loader.groovey * 50 * loader.dst.height / loader.src.height)
-						: (Integer.parseInt(str[6]) * loader.dst.height / loader.src.height);
-				float x = Integer.parseInt(str[3]) * loader.dst.width / loader.src.width - (loader.groovex < 0 ? loader.groovex * loader.dst.width / loader.src.width : 0);
-				float y = loader.dst.height - Integer.parseInt(str[4]) * loader.dst.height / loader.src.height - height;
-				int[] values = loader.parseInt(str);
-				loader.gauger.setDestination(values[2], x, y, width, height, values[7],
-						values[8], values[9], values[10], values[11], values[12], values[13], values[14],
-						values[15], values[16], values[17], values[18], values[19], values[20], loader.readOffset(str, 21));
-			}
 		}
 	}
 


### PR DESCRIPTION
- 曲リザルトでゲージを表示出来るようにしました。starttimeとendtimeで指定してゲージが0から曲終了時の値まで増える演出をします。
- リザルトでOPTION_GAUGE_GROOVE = 42、OPTION_GAUGE_HARD = 43、OPTION_GAUGE_EX = 1046を使えるようにしました。

いずれも表示しているゲージ推移と連動します。