### PR TITLE
MusicSelectInputProcessor: Fix about DURATION_UP cannot use when press numkey5

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
+++ b/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
@@ -91,7 +91,8 @@ public class MusicSelectInputProcessor {
         
         final MusicSelectKeyProperty property = MusicSelectKeyProperty.values()[config.getMusicselectinput()];
 
-        if (numberstate[4] && numtime[4] != 0 || (!input.startPressed() && !input.isSelectPressed() && property.isPressed(keystate, keytime, NEXT_REPLAY, true))) {
+        if (numberstate[4] && numtime[4] != 0
+                || (!input.startPressed() && !input.isSelectPressed() && !input.getNumberState()[5] && property.isPressed(keystate, keytime, NEXT_REPLAY, true))) {
             // change replay
             numtime[4] = 0;
             select.execute(MusicSelectCommand.NEXT_REPLAY);


### PR DESCRIPTION
数字キー5で詳細オプションを出した時にDURATION_UPが使えずリプレイ切り替えとなってしまっていたので修正しました。