### PR TITLE
SkinProperty: Add OPTION_STATE_PRACTICE

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -954,6 +954,8 @@ public class BMSPlayer extends MainState {
 			return autoplay == PlayMode.PLAY || autoplay == PlayMode.PRACTICE;
 		case OPTION_REPLAY_PLAYING:
 			return autoplay.isReplayMode();
+		case OPTION_STATE_PRACTICE:
+			return state == STATE_PRACTICE;
 		case OPTION_NOW_LOADING:
 			return state == STATE_PRELOAD;
 		case OPTION_LOADED:

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -503,6 +503,7 @@ public class SkinProperty {
 	public static final int OPTION_LEVEL_ANOTHER_EXCEED = 78;
 	public static final int OPTION_LEVEL_INSANE_EXCEED = 79;
 
+	public static final int OPTION_STATE_PRACTICE = 1080;
 	public static final int OPTION_NOW_LOADING = 80;
 	public static final int OPTION_LOADED = 81;
 


### PR DESCRIPTION
DPのWIDEスキンなどBGA表示領域がないスキンでプラクティス設定時のみ設定メニューを表示するためにOPTION_STATE_PRACTICEを追加しました。