### PR TITLE
SkinGauge: Move 7to9 gauge parts changing from BMSPlayer

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -331,22 +331,6 @@ public class BMSPlayer extends MainState {
 
 		loadSkin(getSkinType());
 
-		if(BMSPlayerRule.isSevenToNine()) {
-			//7to9 ボーダーが丁度割り切れるゲージ粒数に変更
-			Skin skin = getSkin();
-			int setParts = skin.getGaugeParts();
-			for(int type = 0; type < gauge.getGaugeTypeLength(); type++) {
-				final GaugeElementProperty element = gauge.getGauge(type).getProperty();
-				for(int i = skin.getGaugeParts(); i <= element.max; i++) {
-					if(element.border % (element.max / i) == 0) {
-						setParts = Math.max(setParts, i);
-						break;
-					}
-				}
-			}
-			skin.setGaugeParts(setParts);
-		}
-
 		setSound(SOUND_READY, "playready.wav", SoundType.SOUND, false);
 		setSound(SOUND_PLAYSTOP, "playstop.wav", SoundType.SOUND, false);
 		setSound(SOUND_GUIDE_SE_PG, "guide-pg.wav", SoundType.SOUND, false);

--- a/src/bms/player/beatoraja/play/SkinGauge.java
+++ b/src/bms/player/beatoraja/play/SkinGauge.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.play;
 
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.PlayerResource;
+import bms.player.beatoraja.play.GaugeProperty.GaugeElementProperty;
 import bms.player.beatoraja.result.AbstractResult;
 import bms.player.beatoraja.result.MusicResult;
 
@@ -59,6 +60,11 @@ public class SkinGauge extends SkinObject {
 	 */
 	private int endtime = 500;
 
+	/**
+	 * 7to9時にボーダーが丁度割り切れるゲージ粒数になっているかがチェック済みかどうか
+	 */
+	private boolean isCheckedSevenToNine = false;
+
 	public SkinGauge(TextureRegion[][] image, int timer, int cycle, int parts, int type, int range, int duration) {
 		this.image = new SkinSourceImage(image, timer, cycle);
 		this.parts = parts;
@@ -96,6 +102,22 @@ public class SkinGauge extends SkinObject {
 				break;
 			}
 			atime = time + duration;
+		}
+
+		if(!isCheckedSevenToNine && BMSPlayerRule.isSevenToNine()) {
+			//7to9 ボーダーが丁度割り切れるゲージ粒数に変更
+			int setParts = parts;
+			for(int type = 0; type < gauge.getGaugeTypeLength(); type++) {
+				final GaugeElementProperty element = gauge.getGauge(type).getProperty();
+				for(int i = parts; i <= element.max; i++) {
+					if(element.border % (element.max / i) == 0) {
+						setParts = Math.max(setParts, i);
+						break;
+					}
+				}
+			}
+			parts = setParts;
+			isCheckedSevenToNine = true;
 		}
 
 		float value = gauge.getValue();

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -492,15 +492,6 @@ public class Skin {
 		}
 	}
 
-	public int getGaugeParts() {
-		for(SkinObject obj: objects) {
-			if(obj instanceof SkinGauge) {
-				return ((SkinGauge)obj).getParts();
-			}
-		}
-		return 0;
-	}
-
 	/*
 	 * 白数字が0の時のレーンカバーのy座標
 	 */
@@ -515,14 +506,6 @@ public class Skin {
 			}
 		}
 		return -1;
-	}
-
-	public void setGaugeParts(int parts) {
-		for(SkinObject obj: objects) {
-			if(obj instanceof SkinGauge) {
-				((SkinGauge)obj).setParts(parts);
-			}
-		}
 	}
 
 	public SkinOffset getOffsetAll(MainState state) {


### PR DESCRIPTION
7to9時のゲージ粒数変更処理をリザルトでも行うためにBMSPlayerからSkinGaugeに移しました。
これは24粒ゲージだと80/100が丁度割り切れないために表示上はボーダーにのっていないにも関わらず実際には80%超えとなる場合があるので粒数を変更してます。