### PR TITLE
Improve duration change UI

### DIFF
--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -308,7 +308,7 @@
                                          <Label text="%GVALUE" GridPane.columnIndex="2" />
                                          <NumericSpinner fx:id="gvalue" editable="true" GridPane.columnIndex="3">
                                              <valueFactory>
-                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="1" initialValue="300" max="2000" min="1" />
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="1" initialValue="500" max="5000" min="1" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          <CheckBox fx:id="enableLanecover" mnemonicParsing="false" text="%ENABLE_LANECOVER" GridPane.rowIndex="1" />

--- a/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -459,6 +459,38 @@ public enum MusicSelectCommand {
             }
 		}
     },
+    DURATION_UP_LARGE {
+        @Override
+        public void execute(MusicSelector selector) {
+            Bar current = selector.getBarRender().getSelected();
+            PlayConfig pc = null;
+            if (current instanceof SongBar && ((SongBar)current).existsSong()) {
+                SongBar song = (SongBar) current;
+                pc = selector.main.getPlayerConfig().getPlayConfig(song.getSongData().getMode()).getPlayconfig();
+            }
+            if (pc != null && pc.getDuration() < 5000) {
+                int duration = pc.getDuration() + 10;
+                pc.setDuration(duration - duration % 10);
+                selector.play(SOUND_CHANGEOPTION);
+            }
+        }
+    },
+    DURATION_DOWN_LARGE {
+        @Override
+        public void execute(MusicSelector selector) {
+            Bar current = selector.getBarRender().getSelected();
+            PlayConfig pc = null;
+            if (current instanceof SongBar && ((SongBar)current).existsSong()) {
+                SongBar song = (SongBar) current;
+                pc = selector.main.getPlayerConfig().getPlayConfig(song.getSongData().getMode()).getPlayconfig();
+            }
+            if (pc != null && pc.getDuration() > 10) {
+                int duration = pc.getDuration() - 10;
+                pc.setDuration(duration - duration % 10);
+                selector.play(SOUND_CHANGEOPTION);
+            }
+        }
+    },
     NEXT_BGA_SHOW {
 		@Override
 		public void execute(MusicSelector selector) {

--- a/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -438,7 +438,7 @@ public enum MusicSelectCommand {
                 SongBar song = (SongBar) current;
                 pc = selector.main.getPlayerConfig().getPlayConfig(song.getSongData().getMode()).getPlayconfig();
             }
-            if (pc != null && pc.getDuration() < 2000) {
+            if (pc != null && pc.getDuration() < 5000) {
                 pc.setDuration(pc.getDuration() + 1);
                 selector.play(SOUND_CHANGEOPTION);
             }

--- a/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
+++ b/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
@@ -34,6 +34,10 @@ public class MusicSelectInputProcessor {
     private final int durationlow = 300;
     private final int durationhigh = 50;
 
+    // ノーツ表示時間変更のカウンタ
+    private long timeChangeDuration;
+    private int countChangeDuration;
+
     private final MusicSelector select;
 
     public MusicSelectInputProcessor(MusicSelector select) {
@@ -221,14 +225,32 @@ public class MusicSelectInputProcessor {
             if (property.isPressed(keystate, keytime, BGA_DOWN, true)) {
                 select.execute(MusicSelectCommand.NEXT_BGA_SHOW);
             }
-            if (property.isPressed(keystate, keytime, DURATION_DOWN, true)) {
-                select.execute(MusicSelectCommand.DURATION_DOWN);
-            }
             if (property.isPressed(keystate, keytime, JUDGETIMING_DOWN, true)) {
                 select.execute(MusicSelectCommand.JUDGETIMING_DOWN);
             }
-            if (property.isPressed(keystate, keytime, DURATION_UP, true)) {
-                select.execute(MusicSelectCommand.DURATION_UP);
+            if (property.isPressed(keystate, keytime, DURATION_DOWN, false)) {
+                long l = System.currentTimeMillis();
+                if (timeChangeDuration == 0) {
+                    timeChangeDuration = l + durationlow;
+                    select.execute(MusicSelectCommand.DURATION_DOWN);
+                } else if (l > timeChangeDuration) {
+                    countChangeDuration++;
+                    timeChangeDuration = l + durationhigh;
+                    select.execute(countChangeDuration > 50 ? MusicSelectCommand.DURATION_DOWN_LARGE : MusicSelectCommand.DURATION_DOWN);
+                }
+            } else if (property.isPressed(keystate, keytime, DURATION_UP, false)) {
+                long l = System.currentTimeMillis();
+                if (timeChangeDuration == 0) {
+                    timeChangeDuration = l + durationlow;
+                    select.execute(MusicSelectCommand.DURATION_UP);
+                } else if (l > timeChangeDuration) {
+                    countChangeDuration++;
+                    timeChangeDuration = l + durationhigh;
+                    select.execute(countChangeDuration > 50 ? MusicSelectCommand.DURATION_UP_LARGE : MusicSelectCommand.DURATION_UP);
+                }
+            } else {
+                timeChangeDuration = 0;
+                countChangeDuration = 0;
             }
             if (property.isPressed(keystate, keytime, JUDGETIMING_UP, true)) {
                 select.execute(MusicSelectCommand.JUDGETIMING_UP);


### PR DESCRIPTION
* duration の上限を5000に変更（初心者用＆24鍵モード・トリッキーなギミック譜面をプレイしやすくするため）
* 選曲画面での duration 変更をキー押しっぱなしで可能にする
  * 変更間隔はとりあえず選曲バーのスクロールと同じに
  * それでも大きく変更するには時間がかかるので、しばらく押し続けると10単位で変化するようにする