### PR TITLE
Fix crash when rival changed

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -558,6 +558,10 @@ public class MainController extends ApplicationAdapter {
             	this.updateSong(download.getDownloadpath());
             	download.setDownloadpath(null);
             }
+			if (updateSong != null && !updateSong.isAlive()) {
+				selector.getBarRender().updateBar();
+				updateSong = null;
+			}
         }
 	}
 

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -193,7 +193,7 @@ public class MusicSelector extends MainState {
 
 	public void setRival(PlayerInformation rival) {
 		this.rival = rival;
-		rivalcache = rivalcaches.get(rival);
+		rivalcache = rival != null ? rivalcaches.get(rival) : null;
 		bar.updateBar();
 
 		Logger.getGlobal().info("Rival変更:" + (rival != null ? rival.getName() : "なし"));

--- a/src/bms/player/beatoraja/select/bar/DirectoryBar.java
+++ b/src/bms/player/beatoraja/select/bar/DirectoryBar.java
@@ -3,17 +3,14 @@ package bms.player.beatoraja.select.bar;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
-
 import bms.model.Mode;
-import bms.player.beatoraja.IRScoreData;
 import bms.player.beatoraja.ScoreDatabaseAccessor.ScoreDataCollector;
 import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.song.SongData;
 
 /**
  * ディレクトリの抽象バー。
- * 
+ *
  * @author exch
  */
 public abstract class DirectoryBar extends Bar {
@@ -78,7 +75,7 @@ public abstract class DirectoryBar extends Bar {
 
 	/**
 	 * ディレクトリ内のバーを返す
-	 * 
+	 *
 	 * @return ディレクトリ内のバー
 	 */
 	public abstract Bar[] getChildren();
@@ -116,15 +113,16 @@ public abstract class DirectoryBar extends Bar {
 		final ScoreDataCollector collector = (song, score) -> {
 			if(score != null) {
 				lamps[score.getClear()]++;
-				
+
 				if (score.getNotes() != 0) {
-					ranks[(score.getExscore() * 27 / (score.getNotes() * 2))]++;
+					int rank = score.getExscore() * 27 / (score.getNotes() * 2);
+					ranks[rank < 28 ? rank : 27]++;
 				} else {
 					ranks[0]++;
 				}
 			} else {
 				lamps[0]++;
-				ranks[0]++;				
+				ranks[0]++;
 			}
 		};
 


### PR DESCRIPTION
- ライバル選択を無しにするとクラッシュする問題を修正

これに加え、次の修正を行いました
- DirectoryBar: プレイヤーのランクの計算がおかしい時、配列を超えないように修正
- MainController: updateSong thread終了時バーを更新するように