### PR TITLE
Fix PCM sample check

### DIFF
--- a/src/bms/player/beatoraja/audio/PCM.java
+++ b/src/bms/player/beatoraja/audio/PCM.java
@@ -341,7 +341,7 @@ public abstract class PCM<T> {
 //			if(bytes != orgbytes) {
 //				Logger.getGlobal().info("終端の無音データ除外 - " + p.getFileName().toString() + " : " + (orgbytes - bytes) + " bytes");
 //			}
-			if(bytes <= channels * bitsPerSample / 8) {
+			if(bytes < channels * bitsPerSample / 8) {
 				throw new IOException(p.toString() + " : 0 samples");			
 			}
 			pcm.limit(bytes);


### PR DESCRIPTION
音声再生時、サンプル数1は許可するようにしました。

例）
bytes = 2,
channels = 2
bitsPerSample =16

http://founfain.hatenablog.com/entry/2016/04/09/011651