### PR TITLE
bug-fix :SkinTimingVisualizer#dispose

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingDistributionGraph.java
@@ -2,19 +2,13 @@ package bms.player.beatoraja.skin;
 
 import java.util.Optional;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.Pixmap;
-import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
-import bms.model.BMSModel;
-import bms.model.Mode;
-import bms.player.beatoraja.CourseData;
-import bms.player.beatoraja.MainState;
-import bms.player.beatoraja.PlayerResource;
-import bms.player.beatoraja.play.BMSPlayerRule;
-import bms.player.beatoraja.play.JudgeProperty;
+import bms.model.*;
+import bms.player.beatoraja.*;
+import bms.player.beatoraja.play.*;
 import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.result.MusicResult.TimingDistribution;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
@@ -123,7 +117,7 @@ public class SkinTimingDistributionGraph extends SkinObject {
 
 	@Override
 	public void dispose() {
-		Optional.ofNullable(tex.getTexture()).ifPresent(Texture::dispose);
+		Optional.ofNullable(tex).ifPresent(t -> t.getTexture().dispose());
 		Optional.ofNullable(shape).ifPresent(Pixmap::dispose);
 	}
 

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -166,8 +166,8 @@ public class SkinTimingVisualizer extends SkinObject {
 
 	@Override
 	public void dispose() {
-		Optional.ofNullable(backtex.getTexture()).ifPresent(Texture::dispose);
-		Optional.ofNullable(shapetex.getTexture()).ifPresent(Texture::dispose);
+		Optional.ofNullable(backtex).ifPresent(t -> t.getTexture().dispose());
+		Optional.ofNullable(shapetex).ifPresent(t -> t.getTexture().dispose());
 		Optional.ofNullable(shape).ifPresent(Pixmap::dispose);
 	}
 


### PR DESCRIPTION
dispose処理のnullチェックに問題があったため修正しました。
プレイスキンで曲読み込み中、もしくはプラクティスで曲再生前にEscで抜けるとNullPointerExceptionがスローされる問題を修正しました。