### PR TITLE
Fix dst2 default value

### DIFF
--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1476,7 +1476,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public String[] hidden = new String[0];
 		public String[] processed = new String[0];
 		public Animation[] dst = new Animation[0];
-		public int dst2 = Integer.MIN_VALUE;
+		public int dst2 = Integer.MAX_VALUE;
 		public int[] expansionrate = {100,100};
 		public float[] size = new float[0];
 		public Destination[] group = new Destination[0];


### PR DESCRIPTION
While Integer.MIN_VALUE for dst2 works for 1280x720 skins, removing missed notes instantly, at 1920x1080 skin resolution, this value ceases to work and causes the notes to play the drop off animation after being missed. 

Changing it to Integer.MAX_VALUE should make sure the default value results in missed notes being removed instantly for any resolution.