### PR TITLE
Bitmap font (distance field or other prerendered fonts generated with Hiero) support

### DIFF
--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1241,6 +1241,8 @@ public class JSONSkinLoader extends SkinLoader{
 					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, text.ref);
 				}
 				skinText.setAlign(text.align);
+				skinText.setWrapping(text.wrapping);
+				skinText.setOverflow(text.overflow);
 				return skinText;
 			}
 		}
@@ -1378,6 +1380,8 @@ public class JSONSkinLoader extends SkinLoader{
 		public int size;
 		public int align;
 		public int ref;
+		public boolean wrapping = false;
+		public int overflow = SkinText.OVERFLOW_OVERFLOW;
 	}
 
 	public static class Slider {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1235,7 +1235,7 @@ public class JSONSkinLoader extends SkinLoader{
 				if (path.toString().toLowerCase().endsWith(".fnt")) {
 					if (!bitmapSourceMap.containsKey(font.id)) {
 						SkinTextBitmap.SkinTextBitmapSource source = new SkinTextBitmap.SkinTextBitmapSource(path, usecim);
-						source.setDistanceField(font.distanceField);
+						source.setType(font.type);
 						bitmapSourceMap.put(font.id, source);
 					}
 					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w));
@@ -1342,7 +1342,7 @@ public class JSONSkinLoader extends SkinLoader{
 	public static class Font {
 		public String id;
 		public String path;
-		public boolean distanceField;
+		public int type;
 	}
 
 	public static class Image {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1238,7 +1238,7 @@ public class JSONSkinLoader extends SkinLoader{
 						source.setDistanceField(font.distanceField);
 						bitmapSourceMap.put(font.id, source);
 					}
-					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size);
+					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w));
 				} else {
 					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, text.ref);
 				}

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -12,6 +12,7 @@ import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.reflect.*;
 
@@ -1244,16 +1245,23 @@ public class JSONSkinLoader extends SkinLoader{
 				skinText.setAlign(text.align);
 				skinText.setWrapping(text.wrapping);
 				skinText.setOverflow(text.overflow);
-				try {
-					skinText.setOutlineColor(Color.valueOf(text.outlineColor));
-				} catch (Exception e) {
-					skinText.setOutlineColor(Color.WHITE);
-				}
+				skinText.setOutlineColor(parseHexColor(text.outlineColor, Color.WHITE));
 				skinText.setOutlineWidth(text.outlineWidth);
+				skinText.setShadowColor(parseHexColor(text.shadowColor, Color.WHITE));
+				skinText.setShadowOffset(new Vector2(text.shadowOffsetX, text.shadowOffsetY));
+				skinText.setShadowSmoothness(text.shadowSmoothness);
 				return skinText;
 			}
 		}
 		return null;
+	}
+
+	Color parseHexColor(String hex, Color fallbackColor) {
+		try {
+			return Color.valueOf(hex);
+		} catch (Exception e) {
+			return fallbackColor;
+		}
 	}
 
 	public static class JsonSkin {
@@ -1391,6 +1399,10 @@ public class JSONSkinLoader extends SkinLoader{
 		public int overflow = SkinText.OVERFLOW_OVERFLOW;
 		public String outlineColor = "ffffff00";
 		public float outlineWidth = 0;
+		public String shadowColor = "ffffff00";
+		public float shadowOffsetX = 0;
+		public float shadowOffsetY = 0;
+		public float shadowSmoothness = 0;
 	}
 
 	public static class Slider {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1232,7 +1232,9 @@ public class JSONSkinLoader extends SkinLoader{
 				SkinText skinText;
 				if (path.toString().toLowerCase().endsWith(".fnt")) {
 					if (!bitmapSourceMap.containsKey(font.id)) {
-						bitmapSourceMap.put(font.id, new SkinTextBitmap.SkinTextBitmapSource(path, usecim));
+						SkinTextBitmap.SkinTextBitmapSource source = new SkinTextBitmap.SkinTextBitmapSource(path, usecim);
+						source.setDistanceField(font.distanceField);
+						bitmapSourceMap.put(font.id, source);
 					}
 					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size);
 				} else {
@@ -1323,6 +1325,7 @@ public class JSONSkinLoader extends SkinLoader{
 	public static class Font {
 		public String id;
 		public String path;
+		public boolean distanceField;
 	}
 
 	public static class Image {

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1238,7 +1238,7 @@ public class JSONSkinLoader extends SkinLoader{
 						source.setType(font.type);
 						bitmapSourceMap.put(font.id, source);
 					}
-					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w));
+					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w), text.ref);
 				} else {
 					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, text.ref);
 				}

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -8,6 +8,7 @@ import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.*;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
@@ -1243,6 +1244,12 @@ public class JSONSkinLoader extends SkinLoader{
 				skinText.setAlign(text.align);
 				skinText.setWrapping(text.wrapping);
 				skinText.setOverflow(text.overflow);
+				try {
+					skinText.setOutlineColor(Color.valueOf(text.outlineColor));
+				} catch (Exception e) {
+					skinText.setOutlineColor(Color.WHITE);
+				}
+				skinText.setOutlineWidth(text.outlineWidth);
 				return skinText;
 			}
 		}
@@ -1382,6 +1389,8 @@ public class JSONSkinLoader extends SkinLoader{
 		public int ref;
 		public boolean wrapping = false;
 		public int overflow = SkinText.OVERFLOW_OVERFLOW;
+		public String outlineColor = "ffffff00";
+		public float outlineWidth = 0;
 	}
 
 	public static class Slider {

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -328,43 +328,58 @@ public class Skin {
 		}
 
 		public void draw(BitmapFont font, String s, float x, float y, Color c) {
-			preDraw(font.getRegion());
+			for (TextureRegion region : font.getRegions()) {
+				setFilter(region);
+			}
+			preDraw();
 			font.setColor(c);
 			font.draw(sprite, s, x, y);
 			postDraw();
 		}
 
 		public void draw(BitmapFont font, GlyphLayout layout, float x, float y) {
-			preDraw(font.getRegion());
+			for (TextureRegion region : font.getRegions()) {
+				setFilter(region);
+			}
+			preDraw();
 			font.draw(sprite, layout, x, y);
 			postDraw();
 		}
 
 		public void draw(Texture image, float x, float y, float w, float h) {
-			preDraw(image);
+			setFilter(image);
+			preDraw();
 			sprite.draw(image, x, y, w, h);
 			postDraw();
 		}
 
 		public void draw(TextureRegion image, float x, float y, float w, float h) {
-			preDraw(image);
+			setFilter(image);
+			preDraw();
 			// x,yが*.5の際に(Windowsのみ)TextureRegionがずれるため、暫定対処
 			sprite.draw(image,  x + 0.01f, y + 0.01f, w, h);
 			postDraw();
 		}
 
 		public void draw(TextureRegion image, float x, float y, float w, float h, float cx, float cy, float angle) {
-			preDraw(image);
+			setFilter(image);
+			preDraw();
 			// x,yが*.5の際に(Windowsのみ)TextureRegionがずれるため、暫定対処
 			sprite.draw(image, x + 0.01f, y + 0.01f, cx * w, cy * h, w, h, 1, 1, angle);
 			postDraw();
 		}
 
-		private void preDraw(TextureRegion image) {
-			preDraw(image.getTexture());
+		private void setFilter(TextureRegion image) {
+			setFilter(image.getTexture());
+		}
+
+		private void setFilter(Texture image) {
+			if(type == TYPE_LINEAR || type == TYPE_FFMPEG || type == TYPE_DISTANCE_FIELD) {
+				image.setFilter(TextureFilter.Linear, TextureFilter.Linear);
+			}
 		}
 		
-		private void preDraw(Texture image) {
+		private void preDraw() {
 			if(shaders[current] != shaders[type]) {
 				sprite.setShader(shaders[type]);
 				current = type;
@@ -386,10 +401,6 @@ public class Skin {
 			case 9:
 				sprite.setBlendFunction(GL11.GL_ONE_MINUS_DST_COLOR, GL11.GL_ZERO);
 				break;
-			}
-			
-			if(type == TYPE_LINEAR || type == TYPE_FFMPEG || type == TYPE_DISTANCE_FIELD) {
-				image.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 			}
 
 			if(color != null) {

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -297,7 +297,7 @@ public class Skin {
 		
 		private final SpriteBatch sprite;
 		
-		private ShaderProgram[] shaders = new ShaderProgram[5];
+		private ShaderProgram[] shaders = new ShaderProgram[6];
 		
 		private int current;
 		
@@ -310,6 +310,7 @@ public class Skin {
 		public static final int TYPE_BILINEAR = 2;
 		public static final int TYPE_FFMPEG = 3;
 		public static final int TYPE_LAYER = 4;
+		public static final int TYPE_DISTANCE_FIELD = 5;
 		
 		private Color color;
 		
@@ -320,6 +321,7 @@ public class Skin {
 			shaders[TYPE_BILINEAR] = ShaderManager.getShader("bilinear");
 			shaders[TYPE_FFMPEG] = ShaderManager.getShader("ffmpeg");
 			shaders[TYPE_LAYER] = ShaderManager.getShader("layer");
+			shaders[TYPE_DISTANCE_FIELD] = ShaderManager.getShader("distance_field");
 
 			sprite.setShader(shaders[current]);
 			sprite.setColor(Color.WHITE);
@@ -386,8 +388,8 @@ public class Skin {
 				break;
 			}
 			
-			if(type == TYPE_LINEAR || type == TYPE_FFMPEG) {
-				image.setFilter(TextureFilter.Linear, TextureFilter.Linear);				
+			if(type == TYPE_LINEAR || type == TYPE_FFMPEG || type == TYPE_DISTANCE_FIELD) {
+				image.setFilter(TextureFilter.Linear, TextureFilter.Linear);
 			}
 
 			if(color != null) {

--- a/src/bms/player/beatoraja/skin/SkinLoader.java
+++ b/src/bms/player/beatoraja/skin/SkinLoader.java
@@ -114,20 +114,24 @@ public abstract class SkinLoader {
     }
 
     protected static Texture getTexture(String path, boolean usecim) {
+        return getTexture(path, usecim, false);
+    }
+
+    protected static Texture getTexture(String path, boolean usecim, boolean useMipMaps) {
     	final PixmapResourcePool resource = SkinLoader.getResource();
         if(resource.exists(path)) {
-            return new Texture(resource.get(path));
+            return new Texture(resource.get(path), useMipMaps);
         }
         try {
             long modifiedtime = Files.getLastModifiedTime(Paths.get(path)).toMillis() / 1000;
             String cim = path.substring(0, path.lastIndexOf('.')) + "__" + modifiedtime + ".cim";
             if(resource.exists(cim)) {
-                return new Texture(resource.get(cim));
+                return new Texture(resource.get(cim), useMipMaps);
             }
 
             if (Files.exists(Paths.get(cim))) {
                 Pixmap pixmap = resource.get(cim);
-                return new Texture(pixmap);
+                return new Texture(pixmap, useMipMaps);
             } else if(usecim){
                 Pixmap pixmap = resource.get(path);
 
@@ -144,11 +148,11 @@ public abstract class SkinLoader {
                 }
                 PixmapIO.writeCIM(Gdx.files.local(cim), pixmap);
 
-                Texture tex = new Texture(pixmap);
+                Texture tex = new Texture(pixmap, useMipMaps);
                 return tex;
             } else {
                 Pixmap pixmap = resource.get(path);
-                return new Texture(pixmap);
+                return new Texture(pixmap, useMipMaps);
             }
         } catch (Throwable e) {
             e.printStackTrace();

--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.StringProperty;
 import bms.player.beatoraja.skin.property.StringPropertyFactory;
 
+import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.Align;
 
@@ -34,6 +35,8 @@ public abstract class SkinText extends SkinObject {
 
     private boolean wrapping;
     private int overflow;
+    private Color outlineColor;
+    private float outlineWidth;
     
     public SkinText(int id) {
     	ref = StringPropertyFactory.getStringProperty(id);
@@ -101,5 +104,21 @@ public abstract class SkinText extends SkinObject {
 
     public void setOverflow(int value) {
         overflow = value;
+    }
+
+    public Color getOutlineColor() {
+        return outlineColor;
+    }
+
+    public void setOutlineColor(Color color) {
+        outlineColor = color;
+    }
+
+    public float getOutlineWidth() {
+        return outlineWidth;
+    }
+
+    public void setOutlineWidth(float value) {
+        outlineWidth = value;
     }
 }

--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -7,6 +7,7 @@ import bms.player.beatoraja.skin.property.StringPropertyFactory;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.math.Vector2;
 import com.badlogic.gdx.utils.Align;
 
 /**
@@ -37,6 +38,9 @@ public abstract class SkinText extends SkinObject {
     private int overflow;
     private Color outlineColor;
     private float outlineWidth;
+    private Color shadowColor;
+    private Vector2 shadowOffset;
+    private float shadowSmoothness;
     
     public SkinText(int id) {
     	ref = StringPropertyFactory.getStringProperty(id);
@@ -120,5 +124,29 @@ public abstract class SkinText extends SkinObject {
 
     public void setOutlineWidth(float value) {
         outlineWidth = value;
+    }
+
+    public Color getShadowColor() {
+        return shadowColor;
+    }
+
+    public void setShadowColor(Color color) {
+        shadowColor = color;
+    }
+
+    public Vector2 getShadowOffset() {
+        return shadowOffset;
+    }
+
+    public void setShadowOffset(Vector2 offset) {
+        shadowOffset = offset;
+    }
+
+    public float getShadowSmoothness() {
+        return shadowSmoothness;
+    }
+
+    public void setShadowSmoothness(float value) {
+        shadowSmoothness = value;
     }
 }

--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -19,6 +19,10 @@ public abstract class SkinText extends SkinObject {
 	public static final int ALIGN_LEFT = 0;
     public static final int ALIGN_CENTER = 1;
     public static final int ALIGN_RIGHT = 2;
+
+    public static final int OVERFLOW_OVERFLOW = 0;
+    public static final int OVERFLOW_SHRINK = 1;
+    public static final int OVERFLOW_TRUNCATE = 2;
     
     public static final int[] ALIGN = {Align.left, Align.center, Align.right};
 
@@ -27,6 +31,9 @@ public abstract class SkinText extends SkinObject {
     private String text = "";
 
     private boolean editable;
+
+    private boolean wrapping;
+    private int overflow;
     
     public SkinText(int id) {
     	ref = StringPropertyFactory.getStringProperty(id);
@@ -78,5 +85,21 @@ public abstract class SkinText extends SkinObject {
 
     public void setEditable(boolean editable) {
         this.editable = editable;
+    }
+
+    public boolean isWrapping() {
+        return wrapping;
+    }
+
+    public void setWrapping(boolean value) {
+        wrapping = value;
+    }
+
+    public int getOverflow() {
+        return overflow;
+    }
+
+    public void setOverflow(int value) {
+        overflow = value;
     }
 }

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -1,0 +1,133 @@
+package bms.player.beatoraja.skin;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.math.Rectangle;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Disposable;
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
+
+
+public class SkinTextBitmap extends SkinText {
+
+	SkinTextBitmapSource source;
+	private BitmapFont font;
+	private GlyphLayout layout;
+	private int size;
+
+	public SkinTextBitmap(SkinTextBitmapSource source, int size) {
+		this(source, size, -1);
+	}
+
+	public SkinTextBitmap(SkinTextBitmapSource source, int size, int id) {
+		super(id);
+		this.source = source;
+		this.size = size;
+		this.layout =new GlyphLayout();
+	}
+
+	@Override
+	public void prepareFont(String text) {
+		font = source.getFont();
+	}
+
+	@Override
+	protected void prepareText(String text) {
+		font = source.getFont();
+	}
+
+	public void draw(SkinObjectRenderer sprite, long time, MainState state, int offsetX, int offsetY) {
+		if (font == null)
+			return;
+
+		Rectangle r = this.getDestination(time, state);
+		if (r != null) {
+			float scale = this.size / source.getOriginalSize();
+			font.getData().setScale(scale);
+			final Color c = getColor();
+			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
+			layout.setText(font, getText(), c, r.getWidth(),ALIGN[getAlign()], false);
+			sprite.setType(SkinObjectRenderer.TYPE_DISTANCE_FIELD);
+			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
+			font.getData().setScale(1);
+		}
+	}
+
+	public void dispose() {
+		source.dispose();
+	}
+
+	public static class SkinTextBitmapSource implements Disposable {
+
+		boolean usecim;
+		boolean useMipMaps;
+		Path fontPath;
+		BitmapFont.BitmapFontData fontData;
+		Array<TextureRegion> regions;
+		BitmapFont font;
+		float originalSize;
+
+		public SkinTextBitmapSource(Path fontPath, boolean usecim) {
+			this(fontPath, usecim, true);
+		}
+
+		public SkinTextBitmapSource(Path fontPath, boolean usecim, boolean useMipMaps) {
+			this.usecim = usecim;
+			this.useMipMaps = useMipMaps;
+			this.fontPath = fontPath;
+		}
+
+		public void load() {
+			// TODO: 画像の cim 対応
+			try {
+				fontData = new BitmapFont.BitmapFontData(new FileHandle(fontPath.toFile()), false);
+
+				regions = new Array<>(fontData.imagePaths.length);
+				for (int i = 0; i < fontData.imagePaths.length; ++i) {
+					FileHandle file = new FileHandle(new File(fontData.imagePaths[i]));
+					this.regions.add(new TextureRegion(new Texture(file, useMipMaps)));
+				}
+
+				font = new BitmapFont(fontData, regions, true);
+
+				// size が BitmapFont から取得できないので、独自に取得する
+				try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileHandle(fontPath.toFile()).read()), 512)) {
+					String line = reader.readLine();
+					originalSize = (float) Integer.parseInt(line.substring(line.indexOf("size=") + 5).split(" ")[0]);
+				} catch (Exception e) {
+					originalSize = fontData.lineHeight;
+				}
+			} catch (Exception e) {
+				font = null;
+			}
+		}
+
+		public BitmapFont getFont() {
+			if (font == null) {
+				load();
+			}
+			return font;
+		}
+
+		public float getOriginalSize() {
+			return originalSize;
+		}
+
+		@Override
+		public void dispose() {
+			if (font != null) {
+				font.dispose();
+				font = null;
+			}
+		}
+	}
+}

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -134,14 +134,12 @@ public class SkinTextBitmap extends SkinText {
 		}
 
 		public void load() {
-			// TODO: 画像の cim 対応
 			try {
 				fontData = new BitmapFont.BitmapFontData(new FileHandle(fontPath.toFile()), false);
 
 				regions = new Array<>(fontData.imagePaths.length);
 				for (int i = 0; i < fontData.imagePaths.length; ++i) {
-					FileHandle file = new FileHandle(new File(fontData.imagePaths[i]));
-					this.regions.add(new TextureRegion(new Texture(file, useMipMaps)));
+					this.regions.add(new TextureRegion(SkinLoader.getTexture(fontData.imagePaths[i], usecim)));
 				}
 
 				font = new BitmapFont(fontData, regions, true);

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -57,10 +57,33 @@ public class SkinTextBitmap extends SkinText {
 			font.getData().setScale(scale);
 			final Color c = getColor();
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
-			layout.setText(font, getText(), c, r.getWidth(),ALIGN[getAlign()], false);
+			setLayout(c, r);
 			sprite.setType(source.isDistanceField() ? SkinObjectRenderer.TYPE_DISTANCE_FIELD : SkinObjectRenderer.TYPE_BILINEAR);
 			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			font.getData().setScale(1);
+		}
+	}
+
+	private void setLayout(Color c, Rectangle r) {
+		if (isWrapping()) {
+			layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], true);
+		} else {
+			switch (getOverflow()) {
+			case OVERFLOW_OVERFLOW:
+				layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+				break;
+			case OVERFLOW_SHRINK:
+				layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+				float actualWidth = layout.width;
+				if (actualWidth > r.getWidth()) {
+					font.getData().setScale(font.getData().scaleX * r.getWidth() / actualWidth, font.getData().scaleY);
+					layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+				}
+				break;
+			case OVERFLOW_TRUNCATE:
+				layout.setText(font, getText(), 0, getText().length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
+				break;
+			}
 		}
 	}
 

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -61,7 +61,8 @@ public class SkinTextBitmap extends SkinText {
 			font.getData().setScale(scale);
 			final Color c = getColor();
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
-			if (source.isDistanceField()) {
+			if (source.getType() == SkinTextBitmapSource.TYPE_DISTANCE_FIELD ||
+					source.getType() == SkinTextBitmapSource.TYPE_COLORED_DISTANCE_FIELD) {
 				ShaderProgram shader = ShaderManager.getShader("distance_field");
 				shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
 				shader.setUniformf("u_outlineColor", getOutlineColor());
@@ -112,6 +113,10 @@ public class SkinTextBitmap extends SkinText {
 
 	public static class SkinTextBitmapSource implements Disposable {
 
+		public static final int TYPE_STANDARD = 0;
+		public static final int TYPE_DISTANCE_FIELD = 1;
+		public static final int TYPE_COLORED_DISTANCE_FIELD = 2;
+
 		private boolean usecim;
 		private boolean useMipMaps;
 		private Path fontPath;
@@ -119,7 +124,7 @@ public class SkinTextBitmap extends SkinText {
 		private Array<TextureRegion> regions;
 		private BitmapFont font;
 		private float originalSize;
-		private boolean distanceField;
+		private int type;
 		private float pageWidth;
 		private float pageHeight;
 
@@ -174,12 +179,12 @@ public class SkinTextBitmap extends SkinText {
 			return originalSize;
 		}
 
-		public boolean isDistanceField() {
-			return distanceField;
+		public int getType() {
+			return type;
 		}
 
-		public void setDistanceField(boolean value) {
-			distanceField = value;
+		public void setType(int type) {
+			this.type = type;
 		}
 
 		public float getPageWidth() {

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -19,7 +19,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 
 public class SkinTextBitmap extends SkinText {
 
-	SkinTextBitmapSource source;
+	private SkinTextBitmapSource source;
 	private BitmapFont font;
 	private GlyphLayout layout;
 	private int size;
@@ -56,7 +56,7 @@ public class SkinTextBitmap extends SkinText {
 			final Color c = getColor();
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
 			layout.setText(font, getText(), c, r.getWidth(),ALIGN[getAlign()], false);
-			sprite.setType(SkinObjectRenderer.TYPE_DISTANCE_FIELD);
+			sprite.setType(source.isDistanceField() ? SkinObjectRenderer.TYPE_DISTANCE_FIELD : SkinObjectRenderer.TYPE_BILINEAR);
 			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			font.getData().setScale(1);
 		}
@@ -68,13 +68,14 @@ public class SkinTextBitmap extends SkinText {
 
 	public static class SkinTextBitmapSource implements Disposable {
 
-		boolean usecim;
-		boolean useMipMaps;
-		Path fontPath;
-		BitmapFont.BitmapFontData fontData;
-		Array<TextureRegion> regions;
-		BitmapFont font;
-		float originalSize;
+		private boolean usecim;
+		private boolean useMipMaps;
+		private Path fontPath;
+		private BitmapFont.BitmapFontData fontData;
+		private Array<TextureRegion> regions;
+		private BitmapFont font;
+		private float originalSize;
+		private boolean distanceField;
 
 		public SkinTextBitmapSource(Path fontPath, boolean usecim) {
 			this(fontPath, usecim, true);
@@ -120,6 +121,14 @@ public class SkinTextBitmap extends SkinText {
 
 		public float getOriginalSize() {
 			return originalSize;
+		}
+
+		public boolean isDistanceField() {
+			return distanceField;
+		}
+
+		public void setDistanceField(boolean value) {
+			distanceField = value;
 		}
 
 		@Override

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -28,13 +28,13 @@ public class SkinTextBitmap extends SkinText {
 	private SkinTextBitmapSource source;
 	private BitmapFont font;
 	private GlyphLayout layout;
-	private int size;
+	private float size;
 
-	public SkinTextBitmap(SkinTextBitmapSource source, int size) {
+	public SkinTextBitmap(SkinTextBitmapSource source, float size) {
 		this(source, size, -1);
 	}
 
-	public SkinTextBitmap(SkinTextBitmapSource source, int size, int id) {
+	public SkinTextBitmap(SkinTextBitmapSource source, float size, int id) {
 		super(id);
 		this.source = source;
 		this.size = size;

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -63,23 +63,25 @@ public class SkinTextBitmap extends SkinText {
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
 			if (source.getType() == SkinTextBitmapSource.TYPE_DISTANCE_FIELD ||
 					source.getType() == SkinTextBitmapSource.TYPE_COLORED_DISTANCE_FIELD) {
-				ShaderProgram shader = ShaderManager.getShader("distance_field");
-				shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
-				shader.setUniformf("u_outlineColor", getOutlineColor());
-				shader.setUniformf("u_shadowColor", getShadowColor());
-				shader.setUniformf("u_shadowSmoothing", getShadowSmoothness() / 2f);
-				shader.setUniformf("u_shadowOffset",
-						new Vector2(getShadowOffset().x / source.getPageWidth(), getShadowOffset().y / source.getPageHeight()));
 				sprite.setType(SkinObjectRenderer.TYPE_DISTANCE_FIELD);
+				setLayout(c, r);
+				sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight(), shader -> {
+					shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
+					shader.setUniformf("u_outlineColor", getOutlineColor());
+					shader.setUniformf("u_shadowColor", getShadowColor());
+					shader.setUniformf("u_shadowSmoothing", getShadowSmoothness() / 2f);
+					shader.setUniformf("u_shadowOffset",
+							new Vector2(getShadowOffset().x / source.getPageWidth(), getShadowOffset().y / source.getPageHeight()));
+				});
 			} else {
 				sprite.setType(SkinObjectRenderer.TYPE_BILINEAR);
 				if (!getShadowOffset().isZero()) {
 					setLayout(new Color(c.r / 2, c.g / 2, c.b / 2, c.a), r);
 					sprite.draw(font, layout, x + getShadowOffset().x + offsetX, r.y - getShadowOffset().y + offsetY + r.getHeight());
 				}
+				setLayout(c, r);
+				sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			}
-			setLayout(c, r);
-			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			font.getData().setScale(1);
 		}
 	}

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -4,12 +4,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.InputStreamReader;
 import java.nio.file.Path;
+
+import bms.player.beatoraja.ShaderManager;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+import com.badlogic.gdx.graphics.glutils.ShaderProgram;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
@@ -58,6 +61,9 @@ public class SkinTextBitmap extends SkinText {
 			final Color c = getColor();
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
 			setLayout(c, r);
+			ShaderProgram shader = ShaderManager.getShader("distance_field");
+			shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
+			shader.setUniformf("u_outlineColor", getOutlineColor());
 			sprite.setType(source.isDistanceField() ? SkinObjectRenderer.TYPE_DISTANCE_FIELD : SkinObjectRenderer.TYPE_BILINEAR);
 			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			font.getData().setScale(1);

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -139,7 +139,7 @@ public class SkinTextBitmap extends SkinText {
 
 				regions = new Array<>(fontData.imagePaths.length);
 				for (int i = 0; i < fontData.imagePaths.length; ++i) {
-					this.regions.add(new TextureRegion(SkinLoader.getTexture(fontData.imagePaths[i], usecim)));
+					this.regions.add(new TextureRegion(SkinLoader.getTexture(fontData.imagePaths[i], usecim, useMipMaps)));
 				}
 
 				font = new BitmapFont(fontData, regions, true);

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -16,7 +16,9 @@ import com.badlogic.gdx.utils.Disposable;
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 
-
+/**
+ * .fnt ファイルをソースとして持つスキン用テキスト
+ */
 public class SkinTextBitmap extends SkinText {
 
 	private SkinTextBitmapSource source;

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -61,15 +61,23 @@ public class SkinTextBitmap extends SkinText {
 			font.getData().setScale(scale);
 			final Color c = getColor();
 			final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
+			if (source.isDistanceField()) {
+				ShaderProgram shader = ShaderManager.getShader("distance_field");
+				shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
+				shader.setUniformf("u_outlineColor", getOutlineColor());
+				shader.setUniformf("u_shadowColor", getShadowColor());
+				shader.setUniformf("u_shadowSmoothing", getShadowSmoothness() / 2f);
+				shader.setUniformf("u_shadowOffset",
+						new Vector2(getShadowOffset().x / source.getPageWidth(), getShadowOffset().y / source.getPageHeight()));
+				sprite.setType(SkinObjectRenderer.TYPE_DISTANCE_FIELD);
+			} else {
+				sprite.setType(SkinObjectRenderer.TYPE_BILINEAR);
+				if (!getShadowOffset().isZero()) {
+					setLayout(new Color(c.r / 2, c.g / 2, c.b / 2, c.a), r);
+					sprite.draw(font, layout, x + getShadowOffset().x + offsetX, r.y - getShadowOffset().y + offsetY + r.getHeight());
+				}
+			}
 			setLayout(c, r);
-			ShaderProgram shader = ShaderManager.getShader("distance_field");
-			shader.setUniformf("u_outlineDistance", Math.max(0.1f, 0.5f - getOutlineWidth()/2f));
-			shader.setUniformf("u_outlineColor", getOutlineColor());
-			shader.setUniformf("u_shadowColor", getShadowColor());
-			shader.setUniformf("u_shadowSmoothing", getShadowSmoothness() / 2f);
-			shader.setUniformf("u_shadowOffset",
-					new Vector2(getShadowOffset().x / source.getPageWidth(), getShadowOffset().y / source.getPageHeight()));
-			sprite.setType(source.isDistanceField() ? SkinObjectRenderer.TYPE_DISTANCE_FIELD : SkinObjectRenderer.TYPE_BILINEAR);
 			sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
 			font.getData().setScale(1);
 		}

--- a/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.math.Rectangle;
 
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
+import com.badlogic.gdx.math.Vector2;
 
 /**
  * フォントデータをソースとして持つスキン用テキスト
@@ -24,8 +25,6 @@ public class SkinTextFont extends SkinText {
 
     private GlyphLayout layout;
 
-    private int shadow = 0;
-    
     private FreeTypeFontGenerator generator;
     private FreeTypeFontGenerator.FreeTypeFontParameter parameter;
     private String preparedFonts;
@@ -41,7 +40,7 @@ public class SkinTextFont extends SkinText {
         parameter.characters = "";
 //        this.setCycle(cycle);
         parameter.size = size;
-        this.shadow = shadow;
+        setShadowOffset(new Vector2(shadow, shadow));
     }
 
     public void prepareFont(String text) {
@@ -80,9 +79,9 @@ public class SkinTextFont extends SkinText {
                 sprite.setType(getFilter() != 0 ? SkinObjectRenderer.TYPE_LINEAR : SkinObjectRenderer.TYPE_NORMAL);
 
                 final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
-                if(shadow > 0) {
+                if(!getShadowOffset().isZero()) {
                     setLayout(new Color(c.r / 2, c.g / 2, c.b / 2, c.a), r);
-                    sprite.draw(font, layout, x + shadow + offsetX, r.y - shadow + offsetY + r.getHeight());
+                    sprite.draw(font, layout, x + getShadowOffset().x + offsetX, r.y - getShadowOffset().y + offsetY + r.getHeight());
                 }
                 setLayout(c, r);
                 sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());

--- a/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -81,16 +81,38 @@ public class SkinTextFont extends SkinText {
 
                 final float x = (getAlign() == 2 ? r.x - r.width : (getAlign() == 1 ? r.x - r.width / 2 : r.x));
                 if(shadow > 0) {
-                    layout.setText(font, getText(), new Color(c.r / 2, c.g / 2, c.b / 2, c.a), r.getWidth(),ALIGN[getAlign()], false);
+                    setLayout(new Color(c.r / 2, c.g / 2, c.b / 2, c.a), r);
                     sprite.draw(font, layout, x + shadow + offsetX, r.y - shadow + offsetY + r.getHeight());
                 }
-                layout.setText(font, getText(), c, r.getWidth(),ALIGN[getAlign()], false);
-
+                setLayout(c, r);
                 sprite.draw(font, layout, x + offsetX, r.y + offsetY + r.getHeight());
             }
         }
     }
-	
+
+    private void setLayout(Color c, Rectangle r) {
+        if (isWrapping()) {
+            layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], true);
+        } else {
+            switch (getOverflow()) {
+            case OVERFLOW_OVERFLOW:
+                layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+                break;
+            case OVERFLOW_SHRINK:
+                layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+                float actualWidth = layout.width;
+                if (actualWidth > r.getWidth()) {
+                    font.getData().setScale(font.getData().scaleX * r.getWidth() / actualWidth, font.getData().scaleY);
+                    layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+                }
+                break;
+            case OVERFLOW_TRUNCATE:
+                layout.setText(font, getText(), 0, getText().length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
+                break;
+            }
+        }
+    }
+
     public void dispose() {
         if(generator != null) {
         	generator.dispose();

--- a/src/glsl/distance_field.frag
+++ b/src/glsl/distance_field.frag
@@ -1,0 +1,16 @@
+#ifdef GL_ES
+precision mediump float;
+#endif
+
+uniform sampler2D u_texture;
+
+varying vec4 v_color;
+varying vec2 v_texCoord;
+
+const float smoothing = 1.0/16.0;
+
+void main() {
+    float distance = texture2D(u_texture, v_texCoord).a;
+    float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
+    gl_FragColor = vec4(v_color.rgb, v_color.a * alpha);
+}

--- a/src/glsl/distance_field.frag
+++ b/src/glsl/distance_field.frag
@@ -5,6 +5,9 @@ precision mediump float;
 uniform sampler2D u_texture;
 uniform float u_outlineDistance; // Between 0 and 0.5, 0 = thick outline, 0.5 = no outline
 uniform vec4 u_outlineColor;
+uniform vec2 u_shadowOffset; // Between 0 and spread / textureSize
+uniform float u_shadowSmoothing; // Between 0 and 0.5
+uniform vec4 u_shadowColor;
 
 varying vec4 v_color;
 varying vec2 v_texCoord;
@@ -16,5 +19,11 @@ void main() {
     float outlineFactor = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
     vec4 color = mix(u_outlineColor, v_color, outlineFactor);
     float alpha = smoothstep(u_outlineDistance - smoothing, u_outlineDistance + smoothing, distance);
-    gl_FragColor = vec4(color.rgb, color.a * alpha);
+    vec4 mainColor = vec4(color.rgb, color.a * alpha);
+
+    float shadowDistance = texture2D(u_texture, v_texCoord - u_shadowOffset).a;
+    float shadowAlpha = smoothstep(0.5 - u_shadowSmoothing, 0.5 + u_shadowSmoothing, shadowDistance);
+    vec4 shadow = vec4(u_shadowColor.rgb, u_shadowColor.a * shadowAlpha);
+
+    gl_FragColor = mix(shadow, mainColor, mainColor.a);
 }

--- a/src/glsl/distance_field.frag
+++ b/src/glsl/distance_field.frag
@@ -3,6 +3,8 @@ precision mediump float;
 #endif
 
 uniform sampler2D u_texture;
+uniform float u_outlineDistance; // Between 0 and 0.5, 0 = thick outline, 0.5 = no outline
+uniform vec4 u_outlineColor;
 
 varying vec4 v_color;
 varying vec2 v_texCoord;
@@ -11,6 +13,8 @@ const float smoothing = 1.0/16.0;
 
 void main() {
     float distance = texture2D(u_texture, v_texCoord).a;
-    float alpha = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
-    gl_FragColor = vec4(v_color.rgb, v_color.a * alpha);
+    float outlineFactor = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance);
+    vec4 color = mix(u_outlineColor, v_color, outlineFactor);
+    float alpha = smoothstep(u_outlineDistance - smoothing, u_outlineDistance + smoothing, distance);
+    gl_FragColor = vec4(color.rgb, color.a * alpha);
 }

--- a/src/glsl/distance_field.vert
+++ b/src/glsl/distance_field.vert
@@ -1,0 +1,14 @@
+uniform mat4 u_projTrans;
+
+attribute vec4 a_position;
+attribute vec2 a_texCoord0;
+attribute vec4 a_color;
+
+varying vec4 v_color;
+varying vec2 v_texCoord;
+
+void main() {
+    gl_Position = u_projTrans * a_position;
+    v_texCoord = a_texCoord0;
+    v_color = a_color;
+}


### PR DESCRIPTION
Hiero で作成した `.fnt` 形式のビットマップフォント対応

参考：[Distance field fonts · libgdx/libgdx Wiki](https://github.com/libgdx/libgdx/wiki/Distance-field-fonts)
距離フィールドは拡大してもエッジが比較的きれいで、しかもプログラムで後からアウトラインを付けたりすることもできるため、フォントテクスチャの容量削減に役立ちます。Hieroでグラデーションを使うとLR2フォントよりいい感じの結果が得られますが、距離フィールドとの併用はできないようです。

* JSON/Lua スキンのみ
* `Font` の `type` フィールドで距離フィールドフォントかどうかを設定（0:通常、1:距離フィールド）
* `Text` では以下の項目を追加で指定可能
  * `wrapping` テキストの折り返し
  * `overflow` 表示領域幅から溢れる場合の挙動（0:そのまま、1:縮小、2:切り詰め）
  * `outlineColor`, `outlineWidth` アウトラインの色と幅（距離フィールドフォントのみ）
  * `shadowColor`, `shadowOffsetX`, `shadowOffsetY`, `shadowSmoothness` シャドウ（オフセット以外は距離フィールドのみ）
* 以上のうち、 `wrapping`, `overflow`, `shadowOffsetX`, `shadowOffsetY` は従来のダイナミックフォント（`SkinTextFont`）でも使用可能になります