### PR TITLE
Dynamic text with Lua

### DIFF
--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1232,15 +1232,22 @@ public class JSONSkinLoader extends SkinLoader{
 			if (font.id.equals(text.font)) {
 				Path path = skinPath.getParent().resolve(font.path);
 				SkinText skinText;
+				StringProperty property = null;
+				if (text.value != null) {
+					property = lua.loadStringProperty(text.value);
+				}
+				if (property == null) {
+					property = StringPropertyFactory.getStringProperty(text.ref);
+				}
 				if (path.toString().toLowerCase().endsWith(".fnt")) {
 					if (!bitmapSourceMap.containsKey(font.id)) {
 						SkinTextBitmap.SkinTextBitmapSource source = new SkinTextBitmap.SkinTextBitmapSource(path, usecim);
 						source.setType(font.type);
 						bitmapSourceMap.put(font.id, source);
 					}
-					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w), text.ref);
+					skinText = new SkinTextBitmap(bitmapSourceMap.get(font.id), text.size * ((float)dstr.width / sk.w), property);
 				} else {
-					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, text.ref);
+					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, property);
 				}
 				skinText.setAlign(text.align);
 				skinText.setWrapping(text.wrapping);
@@ -1395,6 +1402,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int size;
 		public int align;
 		public int ref;
+		public String value;
 		public boolean wrapping = false;
 		public int overflow = SkinText.OVERFLOW_OVERFLOW;
 		public String outlineColor = "ffffff00";

--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -46,6 +46,10 @@ public abstract class SkinText extends SkinObject {
     	ref = StringPropertyFactory.getStringProperty(id);
     }
 
+    public SkinText(StringProperty property) {
+        ref = property;
+    }
+
     public int getAlign() {
 		return align;
 	}

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -6,6 +6,8 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 
 import bms.player.beatoraja.ShaderManager;
+import bms.player.beatoraja.skin.property.StringProperty;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -31,11 +33,11 @@ public class SkinTextBitmap extends SkinText {
 	private float size;
 
 	public SkinTextBitmap(SkinTextBitmapSource source, float size) {
-		this(source, size, -1);
+		this(source, size, StringPropertyFactory.getStringProperty(-1));
 	}
 
-	public SkinTextBitmap(SkinTextBitmapSource source, float size, int id) {
-		super(id);
+	public SkinTextBitmap(SkinTextBitmapSource source, float size, StringProperty property) {
+		super(property);
 		this.source = source;
 		this.size = size;
 		this.layout =new GlyphLayout();

--- a/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -1,5 +1,7 @@
 package bms.player.beatoraja.skin;
 
+import bms.player.beatoraja.skin.property.StringProperty;
+import bms.player.beatoraja.skin.property.StringPropertyFactory;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
@@ -30,11 +32,11 @@ public class SkinTextFont extends SkinText {
     private String preparedFonts;
 
     public SkinTextFont(String fontpath, int cycle, int size, int shadow) {
-        this(fontpath, cycle, size, shadow, -1);
+        this(fontpath, cycle, size, shadow, StringPropertyFactory.getStringProperty(-1));
     }
 
-    public SkinTextFont(String fontpath, int cycle, int size, int shadow, int id) {
-    	super(id);
+    public SkinTextFont(String fontpath, int cycle, int size, int shadow, StringProperty property) {
+    	super(property);
         generator = new FreeTypeFontGenerator(Gdx.files.internal(fontpath));
         parameter = new FreeTypeFontGenerator.FreeTypeFontParameter();
         parameter.characters = "";

--- a/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -177,7 +177,22 @@ public class SkinLuaAccessor {
 		}
 		return null;
 	}
-	
+
+	public StringProperty loadStringProperty(String script) {
+		try {
+			final LuaValue lv = globals.load("return " + script);
+			return new StringProperty() {
+				@Override
+				public String get(MainState state) {
+					return lv.call().tojstring();
+				}
+			};
+		} catch (RuntimeException e) {
+			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
+		}
+		return null;
+	}
+
 	public Event loadEvent(String script) {
 		try {
 			final LuaValue lv = globals.load(script);


### PR DESCRIPTION
数値系オブジェクトと同様、Textにも `value` に Lua 式を記述できるようにしました。固定テキストをフォントで描画する用途にも使えます。（例： `value="[[example]]"` ）