### PR TITLE
Run-time Lua enhancement

### DIFF
--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -511,14 +511,9 @@ public class JSONSkinLoader extends SkinLoader{
 							} else {
 								Texture tex = getTexture(img.src, p);
 
-								FloatProperty value = null;
 								if(img.value != null) {
-									value = img.value;
-								}
-
-								if(value != null) {
 									obj = new SkinGraph(getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx, img.divy),
-											img.timer, img.cycle, value);
+											img.timer, img.cycle, img.value);
 								} else if(img.isRefNum) {
 									obj = new SkinGraph(getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx, img.divy),
 											img.timer, img.cycle, img.type, img.min, img.max);

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -7,6 +7,7 @@ import java.io.*;
 import java.lang.reflect.Array;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.function.Function;
 
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Texture;
@@ -386,15 +387,10 @@ public class JSONSkinLoader extends SkinLoader{
 									}
 								}
 
-								IntegerProperty val = null;
-								if(value.value != null) {
-									val = lua.loadIntegerProperty(value.value);
-								}
-
 								SkinNumber num = null;
-								if(val != null) {
+								if(value.value != null) {
 									num = new SkinNumber(pn, mn, value.timer, value.cycle, value.digit, 0,
-											val);
+											value.value);
 								} else {
 									num = new SkinNumber(pn, mn, value.timer, value.cycle, value.digit, 0,
 											value.ref);
@@ -423,14 +419,10 @@ public class JSONSkinLoader extends SkinLoader{
 									}
 								}
 
-								IntegerProperty val = null;
-								if(value.value != null) {
-									val = lua.loadIntegerProperty(value.value);
-								}
 								SkinNumber num = null;
-								if(val != null) {
+								if(value.value != null) {
 									num = new SkinNumber(nimages, value.timer, value.cycle, value.digit,
-											d > 10 ? 2 : value.padding, val);
+											d > 10 ? 2 : value.padding, value.value);
 								} else {
 									num = new SkinNumber(nimages, value.timer, value.cycle, value.digit,
 											d > 10 ? 2 : value.padding, value.ref);
@@ -472,20 +464,11 @@ public class JSONSkinLoader extends SkinLoader{
 						if (dst.id.equals(img.id)) {
 							Texture tex = getTexture(img.src, p);
 
-							FloatProperty value = null;
 							if(img.value != null) {
-								value = lua.loadFloatProperty(img.value);
-							}
-							FloatWriter event = null;
-							if(img.event != null) {
-								event = lua.loadFloatWriter(img.event);
-							}
-
-							if(value != null) {
 								obj = new SkinSlider(getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx, img.divy),
 										img.timer, img.cycle, img.angle, (int) ((img.angle == 1 || img.angle == 3
 												? ((float)dstr.width / sk.w) : ((float)dstr.height / sk.h)) * img.range),
-										value, event);
+										img.value, img.event);
 							} else if(img.isRefNum) {
 								obj = new SkinSlider(getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx, img.divy),
 										img.timer, img.cycle, img.angle, (int) ((img.angle == 1 || img.angle == 3
@@ -530,7 +513,7 @@ public class JSONSkinLoader extends SkinLoader{
 
 								FloatProperty value = null;
 								if(img.value != null) {
-									value = lua.loadFloatProperty(img.value);
+									value = img.value;
 								}
 
 								if(value != null) {
@@ -1088,11 +1071,6 @@ public class JSONSkinLoader extends SkinLoader{
 	}
 
 	private void setDestination(Skin skin, SkinObject obj, Destination dst) {
-		BooleanProperty draw = null;
-		if(dst.draw != null) {
-			draw = lua.loadBooleanProperty(dst.draw);
-		}
-
 		Animation prev = null;
 		for (Animation a : dst.dst) {
 			if (prev == null) {
@@ -1120,9 +1098,9 @@ public class JSONSkinLoader extends SkinLoader{
 				a.g = (a.g == Integer.MIN_VALUE ? prev.g : a.g);
 				a.b = (a.b == Integer.MIN_VALUE ? prev.b : a.b);
 			}
-			if(draw != null) {
+			if(dst.draw != null) {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
-						a.angle, dst.center, dst.loop, dst.timer, draw);
+						a.angle, dst.center, dst.loop, dst.timer, dst.draw);
 			} else {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
 						a.angle, dst.center, dst.loop, dst.timer, dst.op);
@@ -1232,10 +1210,7 @@ public class JSONSkinLoader extends SkinLoader{
 			if (font.id.equals(text.font)) {
 				Path path = skinPath.getParent().resolve(font.path);
 				SkinText skinText;
-				StringProperty property = null;
-				if (text.value != null) {
-					property = lua.loadStringProperty(text.value);
-				}
+				StringProperty property = text.value;
 				if (property == null) {
 					property = StringPropertyFactory.getStringProperty(text.ref);
 				}
@@ -1392,7 +1367,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int digit;
 		public int padding;
 		public int ref;
-		public String value;
+		public IntegerProperty value;
 		public Value[] offset;
 	}
 
@@ -1402,7 +1377,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int size;
 		public int align;
 		public int ref;
-		public String value;
+		public StringProperty value;
 		public boolean wrapping = false;
 		public int overflow = SkinText.OVERFLOW_OVERFLOW;
 		public String outlineColor = "ffffff00";
@@ -1427,8 +1402,8 @@ public class JSONSkinLoader extends SkinLoader{
 		public int angle;
 		public int range;
 		public int type;
-		public String value;
-		public String event;
+		public FloatProperty value;
+		public FloatWriter event;
 		public boolean isRefNum = false;
 		public int min = 0;
 		public int max = 0;
@@ -1447,7 +1422,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int cycle;
 		public int angle = 1;
 		public int type;
-		public String value;
+		public FloatProperty value;
 		public boolean isRefNum = false;
 		public int min = 0;
 		public int max = 0;
@@ -1601,7 +1576,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int[] offsets = new int[0];
 		public int stretch = -1;
 		public int[] op = new int[0];
-		public String draw;
+		public BooleanProperty draw;
 		public Animation[] dst = new Animation[0];
 		public Rect mouseRect;
 	}
@@ -1714,6 +1689,13 @@ public class JSONSkinLoader extends SkinLoader{
 		for (Class c : array_classes) {
 			json.setSerializer(c, new ArraySerializer<>(enabledOptions, path));
 		}
+
+		json.setSerializer(BooleanProperty.class, new LuaScriptSerializer<>(s -> lua.loadBooleanProperty(s)));
+		json.setSerializer(IntegerProperty.class, new LuaScriptSerializer<>(s -> lua.loadIntegerProperty(s)));
+		json.setSerializer(FloatProperty.class, new LuaScriptSerializer<>(s -> lua.loadFloatProperty(s)));
+		json.setSerializer(StringProperty.class, new LuaScriptSerializer<>(s -> lua.loadStringProperty(s)));
+		json.setSerializer(FloatWriter.class, new LuaScriptSerializer<>(s -> lua.loadFloatWriter(s)));
+		json.setSerializer(Event.class, new LuaScriptSerializer<>(s -> lua.loadEvent(s)));
 	}
 
 	private abstract class Serializer<T> extends Json.ReadOnlySerializer<T> {
@@ -1893,6 +1875,18 @@ public class JSONSkinLoader extends SkinLoader{
 				} catch (FileNotFoundException e) {
 				}
 			}
+		}
+	}
+
+	private class LuaScriptSerializer<T> extends Json.ReadOnlySerializer<T> {
+		Function<String, T> luaPropertyLoader;
+
+		LuaScriptSerializer(Function<String, T> loader) {
+			luaPropertyLoader = loader;
+		}
+
+		public T read(Json json, JsonValue jsonValue, Class cls) {
+			return luaPropertyLoader.apply(jsonValue.asString());
 		}
 	}
 }

--- a/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
@@ -4,9 +4,11 @@ import bms.player.beatoraja.Config;
 import bms.player.beatoraja.MainState;
 import bms.player.beatoraja.SkinConfig;
 import bms.player.beatoraja.skin.*;
+import bms.player.beatoraja.skin.property.*;
 import com.badlogic.gdx.utils.reflect.ClassReflection;
 import com.badlogic.gdx.utils.reflect.Field;
 import com.badlogic.gdx.utils.reflect.ReflectionException;
+import org.luaj.vm2.LuaFunction;
 import org.luaj.vm2.LuaTable;
 import org.luaj.vm2.LuaValue;
 
@@ -61,28 +63,53 @@ public class LuaSkinLoader extends JSONSkinLoader {
 		return skin;
 	}
 
+	@SuppressWarnings("unchecked")
 	<T> T fromLuaValue(Class<T> cls, LuaValue lv) {
 		if (cls.isArray()) {
 			Class componentClass = cls.getComponentType();
 			if (lv.istable()) {
-				LuaTable table = (LuaTable)lv;
+				LuaTable table = (LuaTable) lv;
 				LuaValue[] keys = table.keys();
 				Object array = Array.newInstance(componentClass, keys.length);
-				for (int i=0; i<keys.length; i++) {
+				for (int i = 0; i < keys.length; i++) {
 					Array.set(array, i, fromLuaValue(componentClass, table.get(keys[i])));
 				}
-				return (T)array;
+				return (T) array;
 			} else {
-				return (T)Array.newInstance(componentClass, 0);
+				return (T) Array.newInstance(componentClass, 0);
 			}
 		} else if (cls == boolean.class || cls == Boolean.class) {
-			return (T)(Boolean)lv.toboolean();
+			return (T) (Boolean) lv.toboolean();
 		} else if (cls == int.class || cls == Integer.class) {
-			return (T)(Integer)lv.toint();
+			return (T) (Integer) lv.toint();
 		} else if (cls == float.class || cls == Float.class) {
-			return (T)(Float)lv.tofloat();
+			return (T) (Float) lv.tofloat();
 		} else if (cls == String.class) {
-			return (T)lv.tojstring();
+			return (T) lv.tojstring();
+		} else if (cls == BooleanProperty.class) {
+			return (T) (lv.isfunction()
+					? lua.loadBooleanProperty((LuaFunction)lv)
+					: lua.loadBooleanProperty(lv.tojstring()));
+		} else if (cls == IntegerProperty.class) {
+			return (T) (lv.isfunction()
+					? lua.loadIntegerProperty((LuaFunction)lv)
+					: lua.loadIntegerProperty(lv.tojstring()));
+		} else if (cls == FloatProperty.class) {
+			return (T) (lv.isfunction()
+					? lua.loadFloatProperty((LuaFunction)lv)
+					: lua.loadFloatProperty(lv.tojstring()));
+		} else if (cls == StringProperty.class) {
+			return (T) (lv.isfunction()
+					? lua.loadStringProperty((LuaFunction)lv)
+					: lua.loadStringProperty(lv.tojstring()));
+		} else if (cls == SkinObject.FloatWriter.class) {
+			return (T) (lv.isfunction()
+					? lua.loadFloatWriter((LuaFunction)lv)
+					: lua.loadFloatWriter(lv.tojstring()));
+		} else if (cls == SkinObject.Event.class) {
+			return (T) (lv.isfunction()
+					? lua.loadEvent((LuaFunction)lv)
+					: lua.loadEvent(lv.tojstring()));
 		} else {
 			try {
 				T instance = (T) ClassReflection.newInstance(cls);

--- a/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -139,7 +139,12 @@ public class SkinLuaAccessor {
 
 				@Override
 				public boolean get(MainState state) {
-					return lv.call().toboolean();
+					try {
+						return lv.call().toboolean();
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+						return false;
+					}
 				}
 			};
 		} catch (RuntimeException e) {
@@ -154,9 +159,14 @@ public class SkinLuaAccessor {
 			return new IntegerProperty() {
 				@Override
 				public int get(MainState state) {
-					return lv.call().toint();
+					try{
+						return lv.call().toint();
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+						return 0;
+					}
 				}
-			};			
+			};
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
@@ -169,9 +179,14 @@ public class SkinLuaAccessor {
 			return new FloatProperty() {
 				@Override
 				public float get(MainState state) {
-					return lv.call().tofloat();
+					try{
+						return lv.call().tofloat();
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+						return 0f;
+					}
 				}
-			};			
+			};
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
@@ -184,7 +199,12 @@ public class SkinLuaAccessor {
 			return new StringProperty() {
 				@Override
 				public String get(MainState state) {
-					return lv.call().tojstring();
+					try {
+						return lv.call().tojstring();
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+						return "";
+					}
 				}
 			};
 		} catch (RuntimeException e) {
@@ -199,9 +219,13 @@ public class SkinLuaAccessor {
 			return new Event() {
 				@Override
 				public void exec(MainState state) {
-					lv.call();
+					try{
+						lv.call();
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					}
 				}
-			};			
+			};
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
@@ -215,10 +239,14 @@ public class SkinLuaAccessor {
 
 				@Override
 				public void set(MainState state, float value) {
-					lv.call(LuaDouble.valueOf(value));
+					try{
+						lv.call(LuaDouble.valueOf(value));
+					} catch (RuntimeException e) {
+						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					}
 				}
 				
-			};			
+			};
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}

--- a/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -67,7 +67,7 @@ public class SkinLuaAccessor {
 				return LuaDouble.valueOf(state.main.getConfig().getSystemvolume());
 			}
 		});
-		globals.set("volume_sys", new OneArgFunction() {
+		globals.set("set_volume_sys", new OneArgFunction() {
 			@Override
 			public LuaValue call(LuaValue value) {
 				state.main.getConfig().setSystemvolume(value.tofloat());
@@ -80,7 +80,7 @@ public class SkinLuaAccessor {
 				return LuaDouble.valueOf(state.main.getConfig().getKeyvolume());
 			}
 		});
-		globals.set("volume_key", new OneArgFunction() {
+		globals.set("set_volume_key", new OneArgFunction() {
 			@Override
 			public LuaValue call(LuaValue value) {
 				state.main.getConfig().setKeyvolume(value.tofloat());
@@ -93,7 +93,7 @@ public class SkinLuaAccessor {
 				return LuaDouble.valueOf(state.main.getConfig().getBgvolume());
 			}
 		});
-		globals.set("volume_bg", new OneArgFunction() {
+		globals.set("set_volume_bg", new OneArgFunction() {
 			@Override
 			public LuaValue call(LuaValue value) {
 				state.main.getConfig().setBgvolume(value.tofloat());

--- a/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -127,130 +127,152 @@ public class SkinLuaAccessor {
 			}
 		});
 	}
-	
+
 	public BooleanProperty loadBooleanProperty(String script) {
 		try {
 			final LuaValue lv = globals.load("return " + script);
-			return new BooleanProperty() {
-				@Override
-				public boolean isStatic(MainState state) {
-					return false;
-				}
-
-				@Override
-				public boolean get(MainState state) {
-					try {
-						return lv.call().toboolean();
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
-						return false;
-					}
-				}
-			};
+			return loadBooleanProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
 	}
-	
+
+	public BooleanProperty loadBooleanProperty(LuaFunction function) {
+		return new BooleanProperty() {
+			@Override
+			public boolean isStatic(MainState state) {
+				return false;
+			}
+
+			@Override
+			public boolean get(MainState state) {
+				try {
+					return function.call().toboolean();
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					return false;
+				}
+			}
+		};
+	}
+
 	public IntegerProperty loadIntegerProperty(String script) {
 		try {
 			final LuaValue lv = globals.load("return " + script);
-			return new IntegerProperty() {
-				@Override
-				public int get(MainState state) {
-					try{
-						return lv.call().toint();
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
-						return 0;
-					}
-				}
-			};
+			return loadIntegerProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
 	}
-	
+
+	public IntegerProperty loadIntegerProperty(LuaFunction function) {
+		return new IntegerProperty() {
+			@Override
+			public int get(MainState state) {
+				try{
+					return function.call().toint();
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					return 0;
+				}
+			}
+		};
+	}
+
 	public FloatProperty loadFloatProperty(String script) {
 		try {
 			final LuaValue lv = globals.load("return " + script);
-			return new FloatProperty() {
-				@Override
-				public float get(MainState state) {
-					try{
-						return lv.call().tofloat();
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
-						return 0f;
-					}
-				}
-			};
+			return loadFloatProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
+	}
+
+	public FloatProperty loadFloatProperty(LuaFunction function) {
+		return new FloatProperty() {
+			@Override
+			public float get(MainState state) {
+				try{
+					return function.call().tofloat();
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外 : " + e.getMessage());
+					return 0f;
+				}
+			}
+		};
 	}
 
 	public StringProperty loadStringProperty(String script) {
 		try {
 			final LuaValue lv = globals.load("return " + script);
-			return new StringProperty() {
-				@Override
-				public String get(MainState state) {
-					try {
-						return lv.call().tojstring();
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
-						return "";
-					}
-				}
-			};
+			return loadStringProperty(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
+	}
+
+	public StringProperty loadStringProperty(LuaFunction function) {
+		return new StringProperty() {
+			@Override
+			public String get(MainState state) {
+				try {
+					return function.call().tojstring();
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+					return "";
+				}
+			}
+		};
 	}
 
 	public Event loadEvent(String script) {
 		try {
 			final LuaValue lv = globals.load(script);
-			return new Event() {
-				@Override
-				public void exec(MainState state) {
-					try{
-						lv.call();
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
-					}
-				}
-			};
+			return loadEvent(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
 	}
 
+	public Event loadEvent(LuaFunction function) {
+		return new Event() {
+			@Override
+			public void exec(MainState state) {
+				try{
+					function.call();
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+				}
+			}
+		};
+	}
+
 	public FloatWriter loadFloatWriter(String script) {
 		try {
 			final LuaValue lv = globals.load(script);
-			return new FloatWriter() {
-
-				@Override
-				public void set(MainState state, float value) {
-					try{
-						lv.call(LuaDouble.valueOf(value));
-					} catch (RuntimeException e) {
-						Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
-					}
-				}
-				
-			};
+			return loadFloatWriter(lv.checkfunction());
 		} catch (RuntimeException e) {
 			Logger.getGlobal().warning("Lua解析時の例外 : " + e.getMessage());
 		}
 		return null;
+	}
+
+	public FloatWriter loadFloatWriter(LuaFunction function) {
+		return new FloatWriter() {
+			@Override
+			public void set(MainState state, float value) {
+				try{
+					function.call(LuaDouble.valueOf(value));
+				} catch (RuntimeException e) {
+					Logger.getGlobal().warning("Lua実行時の例外：" + e.getMessage());
+				}
+			}
+		};
 	}
 
 	public LuaValue exec(String script) {


### PR DESCRIPTION
#370 

* Rename conflicting setter functions for Lua
  * 後で変数をテーブルに入れるなどの対応を行う可能性もありますが、とりあえず名前変更
* Handle run-time Lua exceptions
* Support Lua functions in Lua skin
  * Lua スキンからは文字列でコードを渡すだけでなく、関数を直接渡すことも可能
  * Example:

```lua
  {id = "background", draw = "gauge() >= 75"}
```

```lua
  {id = "background", draw = function()
    return gauge() >= 75
  end}
```