### PR TITLE
Lua timer definition support

### DIFF
--- a/src/bms/player/beatoraja/play/SkinHidden.java
+++ b/src/bms/player/beatoraja/play/SkinHidden.java
@@ -7,6 +7,8 @@ import bms.player.beatoraja.skin.SkinObject;
 import bms.player.beatoraja.skin.SkinSource;
 import bms.player.beatoraja.skin.SkinSourceImage;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
+import bms.player.beatoraja.skin.property.TimerPropertyFactory;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -40,10 +42,20 @@ public class SkinHidden extends SkinObject {
 	private float previousY = Float.MIN_VALUE;
 	private float previousLift = Float.MIN_VALUE;
 
-	private int timer;
+	private TimerProperty timer;
 	private int cycle;
 
 	public SkinHidden(TextureRegion[] image, int timer, int cycle) {
+		this.timer = timer > 0 ? TimerPropertyFactory.getTimerProperty(timer) : null;
+		this.cycle = cycle;
+		originalImages = image;
+		trimmedImages = new TextureRegion[originalImages.length];
+		for(int i = 0; i < trimmedImages.length; i++) {
+			trimmedImages[i] = new TextureRegion(originalImages[i]);
+		}
+	}
+
+	public SkinHidden(TextureRegion[] image, TimerProperty timer, int cycle) {
 		this.timer = timer;
 		this.cycle = cycle;
 		originalImages = image;
@@ -108,11 +120,11 @@ public class SkinHidden extends SkinObject {
 			return 0;
 		}
 
-		if (timer != 0 && timer < MainController.timerCount) {
-			if (!state.main.isTimerOn(timer)) {
+		if (timer != null) {
+			if (timer.isOff(state)) {
 				return 0;
 			}
-			time -= state.main.getTimer(timer);
+			time -= timer.get(state);
 		}
 		if (time < 0) {
 			return 0;

--- a/src/bms/player/beatoraja/select/SkinDistributionGraph.java
+++ b/src/bms/player/beatoraja/select/SkinDistributionGraph.java
@@ -6,6 +6,7 @@ import bms.player.beatoraja.select.bar.DirectoryBar;
 import bms.player.beatoraja.skin.*;
 import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
@@ -64,6 +65,21 @@ public class SkinDistributionGraph extends SkinObject {
     }
 
     public SkinDistributionGraph(int type, TextureRegion[][] image, int timer, int cycle) {
+        this.type = type;
+        if(type == 0) {
+            lampimage = new SkinSource[11];
+            for(int i = 0;i < lampimage.length;i++) {
+                lampimage[i] = new SkinSourceImage(image[i],timer,cycle);
+            }
+        } else {
+            lampimage = new SkinSource[28];
+            for(int i = 0;i < lampimage.length;i++) {
+                lampimage[i] = new SkinSourceImage(image[i],timer,cycle);
+            }
+        }
+    }
+
+    public SkinDistributionGraph(int type, TextureRegion[][] image, TimerProperty timer, int cycle) {
         this.type = type;
         if(type == 0) {
             lampimage = new SkinSource[11];

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1690,13 +1690,14 @@ public class JSONSkinLoader extends SkinLoader{
 			json.setSerializer(c, new ArraySerializer<>(enabledOptions, path));
 		}
 
-		json.setSerializer(BooleanProperty.class, new LuaScriptSerializer<>(s -> lua.loadBooleanProperty(s)));
-		json.setSerializer(IntegerProperty.class, new LuaScriptSerializer<>(s -> lua.loadIntegerProperty(s)));
-		json.setSerializer(FloatProperty.class, new LuaScriptSerializer<>(s -> lua.loadFloatProperty(s)));
-		json.setSerializer(StringProperty.class, new LuaScriptSerializer<>(s -> lua.loadStringProperty(s)));
-		json.setSerializer(TimerProperty.class, new LuaScriptSerializer<>(s -> lua.loadTimerProperty(s)));
-		json.setSerializer(FloatWriter.class, new LuaScriptSerializer<>(s -> lua.loadFloatWriter(s)));
-		json.setSerializer(Event.class, new LuaScriptSerializer<>(s -> lua.loadEvent(s)));
+		// method reference (lua::load*Property) is not possible because lua may be null
+		json.setSerializer(BooleanProperty.class, new LuaScriptSerializer<>(s -> lua.loadBooleanProperty(s), BooleanPropertyFactory::getBooleanProperty));
+		json.setSerializer(IntegerProperty.class, new LuaScriptSerializer<>(s -> lua.loadIntegerProperty(s), IntegerPropertyFactory::getIntegerProperty));
+		json.setSerializer(FloatProperty.class, new LuaScriptSerializer<>(s -> lua.loadFloatProperty(s), FloatPropertyFactory::getFloatProperty));
+		json.setSerializer(StringProperty.class, new LuaScriptSerializer<>(s -> lua.loadStringProperty(s), StringPropertyFactory::getStringProperty));
+		json.setSerializer(TimerProperty.class, new LuaScriptSerializer<>(s -> lua.loadTimerProperty(s), TimerPropertyFactory::getTimerProperty));
+		json.setSerializer(FloatWriter.class, new LuaScriptSerializer<>(s -> lua.loadFloatWriter(s), FloatPropertyFactory::getFloatWriter));
+		json.setSerializer(Event.class, new LuaScriptSerializer<>(s -> lua.loadEvent(s), null));
 	}
 
 	private abstract class Serializer<T> extends Json.ReadOnlySerializer<T> {
@@ -1881,13 +1882,21 @@ public class JSONSkinLoader extends SkinLoader{
 
 	private class LuaScriptSerializer<T> extends Json.ReadOnlySerializer<T> {
 		Function<String, T> luaPropertyLoader;
+		Function<Integer, T> idPropertyLoader;
 
-		LuaScriptSerializer(Function<String, T> loader) {
+		LuaScriptSerializer(Function<String, T> loader, Function<Integer, T> byId) {
 			luaPropertyLoader = loader;
+			idPropertyLoader = byId;
 		}
 
 		public T read(Json json, JsonValue jsonValue, Class cls) {
-			return luaPropertyLoader.apply(jsonValue.asString());
+			if (jsonValue.isString() && luaPropertyLoader != null) {
+				return luaPropertyLoader.apply(jsonValue.asString());
+			} else if (jsonValue.isNumber() && idPropertyLoader != null) {
+				return idPropertyLoader.apply(jsonValue.asInt());
+			} else {
+				return null;
+			}
 		}
 	}
 }

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -340,14 +340,14 @@ public class JSONSkinLoader extends SkinLoader{
 					for (ImageSet imgs : sk.imageset) {
 						if (dst.id.equals(imgs.id)) {
 							TextureRegion[][] tr = new TextureRegion[imgs.images.length][];
-							int timer = -1;
+							TimerProperty timer = null;
 							int cycle = -1;
 							for (int i = 0; i < imgs.images.length; i++) {
 								for (Image img : sk.image) {
 									if (img.id.equals(imgs.images[i])) {
 										Texture tex = getTexture(img.src, p);
 										tr[i] = getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx, img.divy);
-										if (timer == -1) {
+										if (timer == null) {
 											timer = img.timer;
 										}
 										if (cycle == -1) {
@@ -808,7 +808,7 @@ public class JSONSkinLoader extends SkinLoader{
 							for (ImageSet imgs : sk.imageset) {
 								if (sk.songlist.liston[i].id.equals(imgs.id)) {
 									TextureRegion[][] tr = new TextureRegion[imgs.images.length][];
-									int timer = -1;
+									TimerProperty timer = null;
 									int cycle = -1;
 									for (int j = 0; j < imgs.images.length; j++) {
 										for (Image img : sk.image) {
@@ -816,7 +816,7 @@ public class JSONSkinLoader extends SkinLoader{
 												Texture tex = getTexture(img.src, p);
 												tr[j] = getSourceImage(tex, img.x, img.y, img.w, img.h, img.divx,
 														img.divy);
-												if (timer == -1) {
+												if (timer == null) {
 													timer = img.timer;
 												}
 												if (cycle == -1) {
@@ -1066,10 +1066,6 @@ public class JSONSkinLoader extends SkinLoader{
 	}
 
 	private void setDestination(Skin skin, SkinObject obj, Destination dst) {
-		TimerProperty timer = dst.timerFunction;
-		if (timer == null && dst.timer > 0) {
-			timer = TimerPropertyFactory.getTimerProperty(dst.timer);
-		}
 		Animation prev = null;
 		for (Animation a : dst.dst) {
 			if (prev == null) {
@@ -1099,10 +1095,10 @@ public class JSONSkinLoader extends SkinLoader{
 			}
 			if(dst.draw != null) {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
-						a.angle, dst.center, dst.loop, timer, dst.draw);
+						a.angle, dst.center, dst.loop, dst.timer, dst.draw);
 			} else {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
-						a.angle, dst.center, dst.loop, timer, dst.op);
+						a.angle, dst.center, dst.loop, dst.timer, dst.op);
 			}
 			if (dst.mouseRect != null) {
 				skin.setMouseRect(obj, dst.mouseRect.x, dst.mouseRect.y, dst.mouseRect.w, dst.mouseRect.h);
@@ -1335,7 +1331,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int h;
 		public int divx = 1;
 		public int divy = 1;
-		public int timer;
+		public TimerProperty timer;
 		public int cycle;
 		public int len;
 		public int ref;
@@ -1360,7 +1356,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int h;
 		public int divx = 1;
 		public int divy = 1;
-		public int timer;
+		public TimerProperty timer;
 		public int cycle;
 		public int align;
 		public int digit;
@@ -1396,7 +1392,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int h;
 		public int divx = 1;
 		public int divy = 1;
-		public int timer;
+		public TimerProperty timer;
 		public int cycle;
 		public int angle;
 		public int range;
@@ -1417,7 +1413,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int h;
 		public int divx = 1;
 		public int divy = 1;
-		public int timer;
+		public TimerProperty timer;
 		public int cycle;
 		public int angle = 1;
 		public int type;
@@ -1530,7 +1526,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int h;
 		public int divx = 1;
 		public int divy = 1;
-		public int timer;
+		public TimerProperty timer;
 		public int cycle;
 		public int disapearLine = -1;
 		public boolean isDisapearLineLinkLift = true;
@@ -1568,7 +1564,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public String id;
 		public int blend;
 		public int filter;
-		public int timer;
+		public TimerProperty timer;
 		public int loop;
 		public int center;
 		public int offset;
@@ -1576,7 +1572,6 @@ public class JSONSkinLoader extends SkinLoader{
 		public int stretch = -1;
 		public int[] op = new int[0];
 		public BooleanProperty draw;
-		public TimerProperty timerFunction;
 		public Animation[] dst = new Animation[0];
 		public Rect mouseRect;
 	}

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1066,6 +1066,10 @@ public class JSONSkinLoader extends SkinLoader{
 	}
 
 	private void setDestination(Skin skin, SkinObject obj, Destination dst) {
+		TimerProperty timer = dst.timerFunction;
+		if (timer == null && dst.timer > 0) {
+			timer = TimerPropertyFactory.getTimerProperty(dst.timer);
+		}
 		Animation prev = null;
 		for (Animation a : dst.dst) {
 			if (prev == null) {
@@ -1095,10 +1099,10 @@ public class JSONSkinLoader extends SkinLoader{
 			}
 			if(dst.draw != null) {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
-						a.angle, dst.center, dst.loop, dst.timer, dst.draw);
+						a.angle, dst.center, dst.loop, timer, dst.draw);
 			} else {
 				skin.setDestination(obj, a.time, a.x, a.y, a.w, a.h, a.acc, a.a, a.r, a.g, a.b, dst.blend, dst.filter,
-						a.angle, dst.center, dst.loop, dst.timer, dst.op);
+						a.angle, dst.center, dst.loop, timer, dst.op);
 			}
 			if (dst.mouseRect != null) {
 				skin.setMouseRect(obj, dst.mouseRect.x, dst.mouseRect.y, dst.mouseRect.w, dst.mouseRect.h);
@@ -1572,6 +1576,7 @@ public class JSONSkinLoader extends SkinLoader{
 		public int stretch = -1;
 		public int[] op = new int[0];
 		public BooleanProperty draw;
+		public TimerProperty timerFunction;
 		public Animation[] dst = new Animation[0];
 		public Rect mouseRect;
 	}

--- a/src/bms/player/beatoraja/skin/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/JSONSkinLoader.java
@@ -1689,6 +1689,7 @@ public class JSONSkinLoader extends SkinLoader{
 		json.setSerializer(IntegerProperty.class, new LuaScriptSerializer<>(s -> lua.loadIntegerProperty(s)));
 		json.setSerializer(FloatProperty.class, new LuaScriptSerializer<>(s -> lua.loadFloatProperty(s)));
 		json.setSerializer(StringProperty.class, new LuaScriptSerializer<>(s -> lua.loadStringProperty(s)));
+		json.setSerializer(TimerProperty.class, new LuaScriptSerializer<>(s -> lua.loadTimerProperty(s)));
 		json.setSerializer(FloatWriter.class, new LuaScriptSerializer<>(s -> lua.loadFloatWriter(s)));
 		json.setSerializer(Event.class, new LuaScriptSerializer<>(s -> lua.loadEvent(s)));
 	}

--- a/src/bms/player/beatoraja/skin/PomyuCharaLoader.java
+++ b/src/bms/player/beatoraja/skin/PomyuCharaLoader.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.*;
 import com.badlogic.gdx.graphics.Pixmap.Format;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
@@ -38,6 +39,10 @@ public class PomyuCharaLoader {
 
 	public PomyuCharaLoader(Skin skin) {
 		this.skin = skin;
+	}
+
+	public SkinImage load(boolean usecim, File imagefile, int type, int color, float dstx, float dsty, float dstw, float dsth, int side, TimerProperty dsttimer, int dstOp1, int dstOp2, int dstOp3, int dstOffset) {
+		return load(usecim, imagefile, type, color, dstx, dsty, dstw, dsth, side, dsttimer.getTimerId(), dstOp1, dstOp2, dstOp3, dstOffset);
 	}
 
 	public SkinImage load(boolean usecim, File imagefile, int type, int color, float dstx, float dsty, float dstw, float dsth, int side, int dsttimer, int dstOp1, int dstOp2, int dstOp3, int dstOffset) {

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -8,6 +8,8 @@ import bms.player.beatoraja.skin.SkinObject.SkinOffset;
 import bms.player.beatoraja.skin.property.BooleanProperty;
 import bms.player.beatoraja.play.BMSPlayer;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
+import bms.player.beatoraja.skin.property.TimerPropertyFactory;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.GL20;
@@ -86,39 +88,32 @@ public class Skin {
 
 	public void setDestination(SkinObject object, long time, float x, float y, float w, float h, int acc, int a,
 			int r, int g, int b, int blend, int filter, int angle, int center, int loop, int timer, int op1, int op2,
-			int op3, int offset) {
-		object.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center,
-				loop, timer, op1, op2, op3, offset);
-	}
-
-	public void setDestination(SkinObject object, long time, float x, float y, float w, float h, int acc, int a,
-			int r, int g, int b, int blend, int filter, int angle, int center, int loop, int timer, int op1, int op2,
 			int op3, int[] offset) {
 		object.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center,
-				loop, timer, op1, op2, op3, offset);
+				loop, timer > 0 ? TimerPropertyFactory.getTimerProperty(timer) : null, op1, op2, op3, offset);
 	}
 
 	public void setDestination(SkinObject object, long time, float x, float y, float w, float h, int acc, int a,
-			int r, int g, int b, int blend, int filter, int angle, int center, int loop, int timer, int[] op) {
+	                           int r, int g, int b, int blend, int filter, int angle, int center, int loop, TimerProperty timer, int[] op) {
 		object.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center,
 				loop, timer, op);
 	}
 
 	public void setDestination(SkinObject object, long time, float x, float y, float w, float h, int acc, int a,
-			int r, int g, int b, int blend, int filter, int angle, int center, int loop, int timer, BooleanProperty draw) {
+	                           int r, int g, int b, int blend, int filter, int angle, int center, int loop, TimerProperty timer, BooleanProperty draw) {
 		object.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center,
 				loop, timer, draw);
 	}
 
 	public void addNumber(SkinNumber number, long time, float x, float y, float w, float h, int acc, int a, int r,
-			int g, int b, int blend, int filter, int angle, int center, int loop, int timer, int op1, int op2, int op3, int offset) {
+			int g, int b, int blend, int filter, int angle, int center, int loop, TimerProperty timer, int op1, int op2, int op3, int offset) {
 		number.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center,
 				loop, timer, op1, op2, op3, offset);
 		objects.add(number);
 	}
 
 	public SkinImage addImage(TextureRegion tr, long time, float x, float y, float w, float h, int acc, int a,
-			int r, int g, int b, int blend, int filter, int angle, int center, int loop, int timer, int op1, int op2,
+			int r, int g, int b, int blend, int filter, int angle, int center, int loop, TimerProperty timer, int op1, int op2,
 			int op3, int offset) {
 		SkinImage si = new SkinImage(tr);
 		si.setDestination(time, x * dw, y * dh, w * dw, h * dh, acc, a, r, g, b, blend, filter, angle, center, loop,

--- a/src/bms/player/beatoraja/skin/SkinGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinGraph.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.FloatProperty;
 import bms.player.beatoraja.skin.property.FloatPropertyFactory;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
@@ -54,6 +55,21 @@ public class SkinGraph extends SkinObject {
 	}
 
 	public SkinGraph(TextureRegion[] image, int timer, int cycle, int id, int min, int max) {
+		source = new SkinSourceImage(image, timer, cycle);
+		ref = new RateProperty(id, min, max);
+	}
+
+	public SkinGraph(TextureRegion[] image, TimerProperty timer, int cycle, int id) {
+		source = new SkinSourceImage(image, timer, cycle);
+		ref = FloatPropertyFactory.getFloatProperty(id);
+	}
+
+	public SkinGraph(TextureRegion[] image, TimerProperty timer, int cycle, FloatProperty ref) {
+		source = new SkinSourceImage(image, timer, cycle);
+		this.ref = ref;
+	}
+
+	public SkinGraph(TextureRegion[] image, TimerProperty timer, int cycle, int id, int min, int max) {
 		source = new SkinSourceImage(image, timer, cycle);
 		ref = new RateProperty(id, min, max);
 	}

--- a/src/bms/player/beatoraja/skin/SkinImage.java
+++ b/src/bms/player/beatoraja/skin/SkinImage.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.IntegerProperty;
 import bms.player.beatoraja.skin.property.IntegerPropertyFactory;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
@@ -37,11 +38,19 @@ public class SkinImage extends SkinObject {
 	public SkinImage(TextureRegion[] image, int timer, int cycle) {
 		setImage(image, timer, cycle);
 	}
-		
+
 	public SkinImage(TextureRegion[][] image, int timer, int cycle) {
 		setImage(image, timer, cycle);
 	}
-		
+
+	public SkinImage(TextureRegion[] image, TimerProperty timer, int cycle) {
+		setImage(image, timer, cycle);
+	}
+
+	public SkinImage(TextureRegion[][] image, TimerProperty timer, int cycle) {
+		setImage(image, timer, cycle);
+	}
+
 	public TextureRegion getImage(long time, MainState state) {
 		return getImage(0 ,time, state);
 	}
@@ -58,7 +67,7 @@ public class SkinImage extends SkinObject {
 		}
 		return image[value].getImage(time, state);
 	}
-	
+
 	public void setImage(TextureRegion[] image, int timer, int cycle) {
 		this.image = new SkinSource[1];
 		this.image[0] = new SkinSourceImage(image, timer, cycle);
@@ -69,6 +78,18 @@ public class SkinImage extends SkinObject {
 		for(int i = 0;i < image.length;i++) {
 			this.image[i] = new SkinSourceImage(image[i], timer, cycle);
 		}		
+	}
+
+	public void setImage(TextureRegion[] image, TimerProperty timer, int cycle) {
+		this.image = new SkinSource[1];
+		this.image[0] = new SkinSourceImage(image, timer, cycle);
+	}
+
+	public void setImage(TextureRegion[][] image, TimerProperty timer, int cycle) {
+		this.image = new SkinSource[image.length];
+		for(int i = 0;i < image.length;i++) {
+			this.image[i] = new SkinSourceImage(image[i], timer, cycle);
+		}
 	}
 
 	public void draw(SkinObjectRenderer sprite, long time, MainState state) {

--- a/src/bms/player/beatoraja/skin/SkinNumber.java
+++ b/src/bms/player/beatoraja/skin/SkinNumber.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.IntegerProperty;
 import bms.player.beatoraja.skin.property.IntegerPropertyFactory;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
@@ -52,6 +53,14 @@ public class SkinNumber extends SkinObject {
 		this(image, null, timer, cycle, keta, zeropadding, ref);
 	}
 
+	public SkinNumber(TextureRegion[][] image, TimerProperty timer, int cycle, int keta, int zeropadding, int rid) {
+		this(image, null, timer, cycle, keta, zeropadding, rid);
+	}
+
+	public SkinNumber(TextureRegion[][] image, TimerProperty timer, int cycle, int keta, int zeropadding, IntegerProperty ref) {
+		this(image, null, timer, cycle, keta, zeropadding, ref);
+	}
+
 	public SkinNumber(TextureRegion[][] image, TextureRegion[][] mimage, int timer, int cycle, int keta, int zeropadding, int id) {
 		this.image = new SkinSourceImage(image, timer, cycle) ;
 		this.mimage = mimage != null ? new SkinSourceImage(mimage, timer, cycle) : null;
@@ -61,6 +70,22 @@ public class SkinNumber extends SkinObject {
 	}
 
 	public SkinNumber(TextureRegion[][] image, TextureRegion[][] mimage, int timer, int cycle, int keta, int zeropadding, IntegerProperty ref) {
+		this.image = new SkinSourceImage(image, timer, cycle) ;
+		this.mimage = mimage != null ? new SkinSourceImage(mimage, timer, cycle) : null;
+		this.setKeta(keta);
+		this.zeropadding = zeropadding;
+		this.ref = ref;
+	}
+
+	public SkinNumber(TextureRegion[][] image, TextureRegion[][] mimage, TimerProperty timer, int cycle, int keta, int zeropadding, int id) {
+		this.image = new SkinSourceImage(image, timer, cycle) ;
+		this.mimage = mimage != null ? new SkinSourceImage(mimage, timer, cycle) : null;
+		this.setKeta(keta);
+		this.zeropadding = zeropadding;
+		ref = IntegerPropertyFactory.getIntegerProperty(id);
+	}
+
+	public SkinNumber(TextureRegion[][] image, TextureRegion[][] mimage, TimerProperty timer, int cycle, int keta, int zeropadding, IntegerProperty ref) {
 		this.image = new SkinSourceImage(image, timer, cycle) ;
 		this.mimage = mimage != null ? new SkinSourceImage(mimage, timer, cycle) : null;
 		this.setKeta(keta);

--- a/src/bms/player/beatoraja/skin/SkinSlider.java
+++ b/src/bms/player/beatoraja/skin/SkinSlider.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
 import bms.player.beatoraja.skin.property.FloatProperty;
 import bms.player.beatoraja.skin.property.FloatPropertyFactory;
 
+import bms.player.beatoraja.skin.property.TimerProperty;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 
@@ -54,6 +55,30 @@ public class SkinSlider extends SkinObject {
 	}
 
 	public SkinSlider(TextureRegion[] image, int timer, int cycle, int angle, int range, int type, int min, int max) {
+		source = new SkinSourceImage(image, timer ,cycle);
+		this.direction = angle;
+		this.range = range;
+		ref = new RateProperty(type, min, max);
+		writer = null;
+	}
+
+	public SkinSlider(TextureRegion[] image, TimerProperty timer, int cycle, int angle, int range, int type) {
+		source = new SkinSourceImage(image, timer ,cycle);
+		this.direction = angle;
+		this.range = range;
+		ref = FloatPropertyFactory.getFloatProperty(type);
+		writer = FloatPropertyFactory.getFloatWriter(type);
+	}
+
+	public SkinSlider(TextureRegion[] image, TimerProperty timer, int cycle, int angle, int range, FloatProperty ref, FloatWriter writer) {
+		source = new SkinSourceImage(image, timer ,cycle);
+		this.direction = angle;
+		this.range = range;
+		this.ref = ref;
+		this.writer = writer;
+	}
+
+	public SkinSlider(TextureRegion[] image, TimerProperty timer, int cycle, int angle, int range, int type, int min, int max) {
 		source = new SkinSourceImage(image, timer ,cycle);
 		this.direction = angle;
 		this.range = range;

--- a/src/bms/player/beatoraja/skin/SkinSourceImage.java
+++ b/src/bms/player/beatoraja/skin/SkinSourceImage.java
@@ -1,6 +1,8 @@
 package bms.player.beatoraja.skin;
 
 import bms.player.beatoraja.MainController;
+import bms.player.beatoraja.skin.property.TimerProperty;
+import bms.player.beatoraja.skin.property.TimerPropertyFactory;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 
 import bms.player.beatoraja.MainState;
@@ -12,7 +14,8 @@ public class SkinSourceImage implements SkinSource {
 	 */
 	private TextureRegion[][] image;
 
-	private final int timer;
+	private final TimerProperty timer;
+
 	private final int cycle;
 
 	public SkinSourceImage(TextureRegion image) {
@@ -24,6 +27,16 @@ public class SkinSourceImage implements SkinSource {
 	}
 
 	public SkinSourceImage(TextureRegion[][] image, int timer, int cycle) {
+		this.image = image;
+		this.timer = timer > 0 ? TimerPropertyFactory.getTimerProperty(timer) : null;
+		this.cycle = cycle;
+	}
+
+	public SkinSourceImage(TextureRegion[] image, TimerProperty timer, int cycle) {
+		this(new TextureRegion[][] { image }, timer, cycle);
+	}
+
+	public SkinSourceImage(TextureRegion[][] image, TimerProperty timer, int cycle) {
 		this.image = image;
 		this.timer = timer;
 		this.cycle = cycle;
@@ -52,11 +65,11 @@ public class SkinSourceImage implements SkinSource {
 			return 0;
 		}
 
-		if (timer != 0 && timer < MainController.timerCount) {
-			if (!state.main.isTimerOn(timer)) {
+		if (timer != null) {
+			if (timer.isOff(state)) {
 				return 0;
 			}
-			time -= state.main.getTimer(timer);
+			time -= timer.get(state);
 		}
 		if (time < 0) {
 			return 0;

--- a/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
@@ -14,7 +14,9 @@ import org.luaj.vm2.LuaValue;
 
 import java.lang.reflect.Array;
 import java.nio.file.Path;
-import java.util.logging.Logger;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
 public class LuaSkinLoader extends JSONSkinLoader {
 
@@ -63,9 +65,49 @@ public class LuaSkinLoader extends JSONSkinLoader {
 		return skin;
 	}
 
+	private Map<Class, Function<LuaValue, Object>> serializerMap = new HashMap<Class, Function<LuaValue, Object>>() {
+		{
+			put(boolean.class, LuaValue::toboolean);
+			put(Boolean.class, LuaValue::toboolean);
+			put(int.class, LuaValue::toint);
+			put(Integer.class, LuaValue::toint);
+			put(float.class, LuaValue::tofloat);
+			put(Float.class, LuaValue::tofloat);
+			put(String.class, LuaValue::tojstring);
+			put(BooleanProperty.class, lv ->
+					serializeLuaScript(lv, lua::loadBooleanProperty, lua::loadBooleanProperty, BooleanPropertyFactory::getBooleanProperty));
+			put(IntegerProperty.class, lv ->
+					serializeLuaScript(lv, lua::loadIntegerProperty, lua::loadIntegerProperty, IntegerPropertyFactory::getIntegerProperty));
+			put(FloatProperty.class, lv ->
+					serializeLuaScript(lv, lua::loadFloatProperty, lua::loadFloatProperty, FloatPropertyFactory::getFloatProperty));
+			put(StringProperty.class, lv ->
+					serializeLuaScript(lv, lua::loadStringProperty, lua::loadStringProperty, StringPropertyFactory::getStringProperty));
+			put(TimerProperty.class, lv ->
+					serializeLuaScript(lv, lua::loadTimerProperty, lua::loadTimerProperty, TimerPropertyFactory::getTimerProperty));
+			put(SkinObject.FloatWriter.class, lv ->
+					serializeLuaScript(lv, lua::loadFloatWriter, lua::loadFloatWriter, FloatPropertyFactory::getFloatWriter));
+			put(SkinObject.Event.class, lv ->
+					serializeLuaScript(lv, lua::loadEvent, lua::loadEvent, null));
+		}
+	};
+
+	private static <T> T serializeLuaScript(LuaValue lv, Function<LuaFunction, T> asFunction, Function<String, T> asScript, Function<Integer, T> byId) {
+		if (lv.isfunction()) {
+			return asFunction.apply(lv.checkfunction());
+		} else if (lv.isnumber() && byId != null) {
+			return byId.apply(lv.toint());
+		} else if (lv.isstring()) {
+			return asScript.apply(lv.tojstring());
+		} else {
+			return null;
+		}
+	}
+
 	@SuppressWarnings("unchecked")
 	<T> T fromLuaValue(Class<T> cls, LuaValue lv) {
-		if (cls.isArray()) {
+		if (serializerMap.containsKey(cls)) {
+			return (T) serializerMap.get(cls).apply(lv);
+		} else if (cls.isArray()) {
 			Class componentClass = cls.getComponentType();
 			if (lv.istable()) {
 				LuaTable table = (LuaTable) lv;
@@ -78,42 +120,6 @@ public class LuaSkinLoader extends JSONSkinLoader {
 			} else {
 				return (T) Array.newInstance(componentClass, 0);
 			}
-		} else if (cls == boolean.class || cls == Boolean.class) {
-			return (T) (Boolean) lv.toboolean();
-		} else if (cls == int.class || cls == Integer.class) {
-			return (T) (Integer) lv.toint();
-		} else if (cls == float.class || cls == Float.class) {
-			return (T) (Float) lv.tofloat();
-		} else if (cls == String.class) {
-			return (T) lv.tojstring();
-		} else if (cls == BooleanProperty.class) {
-			return (T) (lv.isfunction()
-					? lua.loadBooleanProperty((LuaFunction)lv)
-					: lua.loadBooleanProperty(lv.tojstring()));
-		} else if (cls == IntegerProperty.class) {
-			return (T) (lv.isfunction()
-					? lua.loadIntegerProperty((LuaFunction)lv)
-					: lua.loadIntegerProperty(lv.tojstring()));
-		} else if (cls == FloatProperty.class) {
-			return (T) (lv.isfunction()
-					? lua.loadFloatProperty((LuaFunction)lv)
-					: lua.loadFloatProperty(lv.tojstring()));
-		} else if (cls == StringProperty.class) {
-			return (T) (lv.isfunction()
-					? lua.loadStringProperty((LuaFunction)lv)
-					: lua.loadStringProperty(lv.tojstring()));
-		} else if (cls == TimerProperty.class) {
-			return (T) (lv.isfunction()
-					? lua.loadTimerProperty((LuaFunction)lv)
-					: lua.loadTimerProperty(lv.tojstring()));
-		} else if (cls == SkinObject.FloatWriter.class) {
-			return (T) (lv.isfunction()
-					? lua.loadFloatWriter((LuaFunction)lv)
-					: lua.loadFloatWriter(lv.tojstring()));
-		} else if (cls == SkinObject.Event.class) {
-			return (T) (lv.isfunction()
-					? lua.loadEvent((LuaFunction)lv)
-					: lua.loadEvent(lv.tojstring()));
 		} else {
 			try {
 				T instance = (T) ClassReflection.newInstance(cls);

--- a/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
@@ -102,6 +102,10 @@ public class LuaSkinLoader extends JSONSkinLoader {
 			return (T) (lv.isfunction()
 					? lua.loadStringProperty((LuaFunction)lv)
 					: lua.loadStringProperty(lv.tojstring()));
+		} else if (cls == TimerProperty.class) {
+			return (T) (lv.isfunction()
+					? lua.loadTimerProperty((LuaFunction)lv)
+					: lua.loadTimerProperty(lv.tojstring()));
 		} else if (cls == SkinObject.FloatWriter.class) {
 			return (T) (lv.isfunction()
 					? lua.loadFloatWriter((LuaFunction)lv)

--- a/src/bms/player/beatoraja/skin/property/TimerProperty.java
+++ b/src/bms/player/beatoraja/skin/property/TimerProperty.java
@@ -1,0 +1,24 @@
+package bms.player.beatoraja.skin.property;
+
+import bms.player.beatoraja.MainState;
+
+public interface TimerProperty {
+	long getMicro(MainState state);
+
+	default long get(MainState state) {
+		return getMicro(state) / 1000;
+	}
+
+	default long getNowTime(MainState state) {
+		long time = getMicro(state);
+		return time == Long.MIN_VALUE ? 0 : state.main.getNowTime() - time / 1000;
+	}
+
+	default boolean isOn(MainState state) {
+		return getMicro(state) != Long.MIN_VALUE;
+	}
+
+	default boolean isOff(MainState state) {
+		return getMicro(state) == Long.MIN_VALUE;
+	}
+}

--- a/src/bms/player/beatoraja/skin/property/TimerProperty.java
+++ b/src/bms/player/beatoraja/skin/property/TimerProperty.java
@@ -21,4 +21,12 @@ public interface TimerProperty {
 	default boolean isOff(MainState state) {
 		return getMicro(state) == Long.MIN_VALUE;
 	}
+
+	/**
+	 * タイマーIDに依存した処理のためのバックドア
+	 * @return タイマーID (スクリプトによるタイマー定義の場合は {@code Integer.MIN_VALUE})
+	 */
+	default int getTimerId() {
+		return Integer.MIN_VALUE;
+	}
 }

--- a/src/bms/player/beatoraja/skin/property/TimerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/TimerPropertyFactory.java
@@ -1,0 +1,38 @@
+package bms.player.beatoraja.skin.property;
+
+import bms.player.beatoraja.MainController;
+import bms.player.beatoraja.MainState;
+
+public class TimerPropertyFactory {
+	public static TimerProperty getTimerProperty(int timerId) {
+		if (timerId < 0 || timerId >= MainController.timerCount)
+			return null;
+
+		return new TimerProperty() {
+			@Override
+			public long getMicro(MainState state) {
+				return state.main.getMicroTimer(timerId);
+			}
+
+			@Override
+			public long get(MainState state) {
+				return state.main.getTimer(timerId);
+			}
+
+			@Override
+			public long getNowTime(MainState state) {
+				return state.main.getNowTime(timerId);
+			}
+
+			@Override
+			public boolean isOn(MainState state) {
+				return state.main.isTimerOn(timerId);
+			}
+
+			@Override
+			public boolean isOff(MainState state) {
+				return !state.main.isTimerOn(timerId);
+			}
+		};
+	}
+}

--- a/src/bms/player/beatoraja/skin/property/TimerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/TimerPropertyFactory.java
@@ -33,6 +33,11 @@ public class TimerPropertyFactory {
 			public boolean isOff(MainState state) {
 				return !state.main.isTimerOn(timerId);
 			}
+
+			@Override
+			public int getTimerId() {
+				return timerId;
+			}
 		};
 	}
 }


### PR DESCRIPTION
#370 

* Built-in timer accessors for Lua
  * 例によって変数をテーブルに入れたり関数名を変更したりといった変更を行うかもしれません。
* Replace timer id with TimerProperty
  * Destination と Source で参照しているタイマーをIDベースから TimerProperty に変更し、スクリプトで作成したタイマーを利用可能にしました。
  * IDを指定するフィールドであった `timer` に、そのままスクリプト（文字列）または関数を渡せるようになっています。
    * `value` や `draw` などはID指定とは別フィールドになっていたので、`timer` とは別に関数用のフィールドを新しく作るかどうか迷いましたが、`JsonSkinLoader` 内の処理が非常に煩雑になってしまうのを避けるためまとめました。
    * 逆に、 `value` などに文字列や関数ではなく数値を指定すると参照IDとして解釈するようにしました。（`ref` とか `op` に関数を渡せるように拡張するのは名前的に不自然ですが、こちらの方向であればそれほど不自然ではないため）
  * 一部タイマーIDに依存した処理を行っていた箇所があるため、ID指定のタイマーは後からIDを取得できるように特殊対応
* タイマーの書き方の例

```lua
timer = 46 -- 従来のID指定
timer = "timer(46)" -- スクリプト文字列
timer = function()  -- 関数
  return timer(46)
end
```

* 複雑なタイマーの例

```lua
-- タイマーID id1, id2 が両方アクティブなときにONになるタイマー
function both_active(id1, id2)
  -- タイマーがもつ内部状態
  local t = timer_off_value
  return function() -- この関数が毎フレーム呼び出される
    if is_timer_on(id1) and is_timer_on(id2) then
      if t == timer_off_value then
        -- タイマーがOFFからONになる
        t = time()
      end
    else
      t = timer_off_value
    end
    return t
  end
end
timer = both_active(46, 47)
```