### PR TITLE
SkinConfiguration: fix NullPointerException

### DIFF
--- a/src/bms/player/beatoraja/config/SkinConfiguration.java
+++ b/src/bms/player/beatoraja/config/SkinConfiguration.java
@@ -135,7 +135,7 @@ public class SkinConfiguration extends MainState {
 				availableSkins.add(header);
 			}
 		}
-		if (this.config != null) {
+		if (config != null && this.config.getPath() != null && !config.getPath().isEmpty()) {
 			int index = -1;
 			for (int i = 0; i < availableSkins.size(); i++) {
 				SkinHeader header = availableSkins.get(i);


### PR DESCRIPTION
ゲーム中のスキン設定画面でスキンの存在しない項目を選択するとぬるぽで落ちるのを修正