### PR TITLE
Skin Gauge: fix color bug

### DIFF
--- a/src/bms/player/beatoraja/play/SkinGauge.java
+++ b/src/bms/player/beatoraja/play/SkinGauge.java
@@ -169,6 +169,9 @@ public class SkinGauge extends SkinObject {
 		final int notes = (type == HARD || type == EXHARD || type == HAZARD || type ==GrooveGauge.CLASS || type == EXCLASS || type == EXHARDCLASS)
 						&& value > 0 && ((int) (value * parts / max)) < 1
 						? 1 : (int) (value * parts / max);
+		sprite.setColor(getColor());
+		sprite.setBlend(getBlend());
+		sprite.setType(SkinObjectRenderer.TYPE_NORMAL);
 		for (int i = 1; i <= parts; i++) {
 			final float border = i * max / parts;
 			sprite.draw(


### PR DESCRIPTION
SkinGaugeの直前で色付きのオブジェクトを描画しているとゲージが変色するのを修正