### PR TITLE
Move Lua accessors to modules, and add new functions

### DIFF
--- a/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -43,6 +43,9 @@ public class JSONSkinLoader extends SkinLoader {
 
 	protected JsonSkinSerializer serializer;
 
+	/**
+	 * ヘッダの読み込みに使われるコンストラクタ
+	 */
 	public JSONSkinLoader() {
 		this(null);
 	}
@@ -53,6 +56,11 @@ public class JSONSkinLoader extends SkinLoader {
 		usecim = false;
 	}
 
+	/**
+	 * スキン本体の読み込みに使われるコンストラクタ
+	 * @param state
+	 * @param c
+	 */
 	public JSONSkinLoader(MainState state, Config c) {
 		this(state, c, new SkinLuaAccessor(true));
 	}

--- a/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -44,9 +44,7 @@ public class JSONSkinLoader extends SkinLoader {
 	protected JsonSkinSerializer serializer;
 
 	public JSONSkinLoader() {
-		lua = null;
-		dstr = HD;
-		usecim = false;
+		this(null);
 	}
 
 	public JSONSkinLoader(SkinLuaAccessor lua) {
@@ -56,10 +54,15 @@ public class JSONSkinLoader extends SkinLoader {
 	}
 
 	public JSONSkinLoader(MainState state, Config c) {
-		lua = new SkinLuaAccessor(state);
+		this(state, c, new SkinLuaAccessor(true));
+	}
+
+	public JSONSkinLoader(MainState state, Config c, SkinLuaAccessor lua) {
+		this.lua = lua;
 		dstr = c.getResolution();
 		usecim = false;
 		bgaExpand = c.getBgaExpand();
+		lua.exportMainStateAccessor(state);
 	}
 
 	public Skin loadSkin(Path p, SkinType type, SkinConfig.Property property) {
@@ -161,6 +164,9 @@ public class JSONSkinLoader extends SkinLoader {
 
 			serializer.setSerializers(json, getEnabledOptions(header, property), p);
 			initFileMap(header, property);
+			lua.exportSkinProperty(property, (String path) -> {
+				return getPath(p.getParent().toString() + "/" + path, filemap).getPath();
+			});
 
 			sk = json.fromJson(JsonSkin.Skin.class, new FileReader(p.toFile()));
 			skin = loadJsonSkin(header, sk, type, property, p);

--- a/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -71,6 +71,7 @@ public class JSONSkinLoader extends SkinLoader {
 		usecim = false;
 		bgaExpand = c.getBgaExpand();
 		lua.exportMainStateAccessor(state);
+		lua.exportUtilities(state);
 	}
 
 	public Skin loadSkin(Path p, SkinType type, SkinConfig.Property property) {

--- a/src/bms/player/beatoraja/skin/lua/EventUtility.java
+++ b/src/bms/player/beatoraja/skin/lua/EventUtility.java
@@ -1,0 +1,207 @@
+package bms.player.beatoraja.skin.lua;
+
+import bms.player.beatoraja.MainState;
+import org.luaj.vm2.*;
+import org.luaj.vm2.lib.*;
+
+/**
+ * Lua用のイベント関連の便利関数集
+ */
+public class EventUtility {
+	private final MainState state;
+
+	public EventUtility(MainState state) {
+		this.state = state;
+	}
+
+	public void export(LuaTable table) {
+		table.set("event_observe_turn_true", new event_observe_turn_true());
+		table.set("event_observe_timer", new event_observe_timer());
+		table.set("event_observe_timer_on", new event_observe_timer_on());
+		table.set("event_observe_timer_off", new event_observe_timer_off());
+		table.set("event_min_interval", this.new event_min_interval());
+	}
+
+	/**
+	 * 与えられた関数の実行結果がtrueになった瞬間に特定の処理を実行するイベントを作成する
+	 * arg func: 観測対象の関数 (() -> boolean)
+	 * arg action: 実行するイベント関数
+	 * return: イベント関数 (ゼロ引数関数, CustomEvent の action に設定する想定)
+	 * equivalent to:
+	 *   local isOn = false
+	 *   return function()
+	 *     local on = func()
+	 *     if isOn != on then
+	 *       isOn = on
+	 *       if isOn then
+	 *         action()
+	 *       end
+	 *     end
+	 *   end
+	 */
+	private static class event_observe_turn_true extends TwoArgFunction {
+		@Override
+		public LuaValue call(LuaValue func, LuaValue action) {
+			LuaFunction f = func.checkfunction();
+			LuaFunction act = action.checkfunction();
+			State state = new State();
+			state.isOn = false;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					boolean on = f.call().toboolean();
+					if (state.isOn != on) {
+						state.isOn = on;
+						if (state.isOn) {
+							act.call();
+						}
+					}
+					return TRUE;
+				}
+			};
+		}
+		private static class State {
+			boolean isOn;
+		}
+	}
+
+	/**
+	 * タイマーが設定された瞬間に特定の処理を実行するイベントを作成する
+	 * arg timerFunc: タイマー関数 (() -> number (micro sec))
+	 * arg action: 実行する関数
+	 * return: イベント関数 (ゼロ引数関数, CustomEvent の action に設定する想定)
+	 */
+	private static class event_observe_timer extends TwoArgFunction {
+		@Override
+		public LuaValue call(LuaValue timerFunc, LuaValue action) {
+			LuaFunction timer = timerFunc.checkfunction();
+			LuaFunction act = action.checkfunction();
+			State state = new State();
+			state.value = Long.MIN_VALUE;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					long newValue = timer.call().tolong();
+					if (newValue != state.value && newValue != Long.MIN_VALUE) {
+						state.value = newValue;
+						act.call();
+					}
+					return TRUE;
+				}
+			};
+		}
+		private static class State {
+			long value;
+		}
+	}
+
+	/**
+	 * タイマーがOFFからONになった瞬間に特定の処理を実行するイベントを作成する
+	 * arg timerFunc: タイマー関数 (() -> number (micro sec))
+	 * arg action: 実行する関数
+	 * return: イベント関数 (ゼロ引数関数, CustomEvent の action に設定する想定)
+	 * equivalent to:
+	 *   event_observe_turn_true(
+	 *     function()
+	 *       return timer_util.is_on(timerFunc())
+	 *     end,
+	 *     action)
+	 */
+	private static class event_observe_timer_on extends TwoArgFunction {
+		@Override
+		public LuaValue call(LuaValue timerFunc, LuaValue action) {
+			LuaFunction timer = timerFunc.checkfunction();
+			LuaFunction act = action.checkfunction();
+			State state = new State();
+			state.isOn = false;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					boolean on = timer.call().tolong() != Long.MIN_VALUE;
+					if (state.isOn != on) {
+						state.isOn = on;
+						if (state.isOn) {
+							act.call();
+						}
+					}
+					return TRUE;
+				}
+			};
+		}
+		private static class State {
+			boolean isOn;
+		}
+	}
+
+	/**
+	 * タイマーがONからOFFになった瞬間に特定の処理を実行するイベントを作成する
+	 * arg timerFunc: タイマー関数 (() -> number (micro sec))
+	 * arg action: 実行する関数
+	 * return: イベント関数 (ゼロ引数関数, CustomEvent の action に設定する想定)
+	 * equivalent to:
+	 *   event_observe_turn_true(
+	 *     function()
+	 *       return timer_util.is_off(timerFunc())
+	 *     end,
+	 *     action)
+	 */
+	private static class event_observe_timer_off extends TwoArgFunction {
+		@Override
+		public LuaValue call(LuaValue timerFunc, LuaValue action) {
+			LuaFunction timer = timerFunc.checkfunction();
+			LuaFunction act = action.checkfunction();
+			State state = new State();
+			state.isOff = false;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					boolean off = timer.call().tolong() == Long.MIN_VALUE;
+					if (state.isOff != off) {
+						state.isOff = off;
+						if (state.isOff) {
+							act.call();
+						}
+					}
+					return TRUE;
+				}
+			};
+		}
+		private static class State {
+			boolean isOff;
+		}
+	}
+
+	/**
+	 * イベントの実行間隔が最低でも与えられた値以上になるように制限されたイベントを作成する
+	 * arg minInterval: 最小間隔 (milliseconds)
+	 * arg action: イベント関数
+	 * return: イベント関数
+	 * NOTE: カスタムイベントとして登録するイベントを間引くには minInterval を設定すれば同様のことができる。
+	 *   タイマーの観測は毎フレーム行うが、ONになった瞬間の処理は間引きたいという場合に、
+	 *   目的のアクションにこの関数を適用してから event_observe_timer_on に渡すとよい。
+	 *   event_observe_timer_on の結果に minInterval を設定するとタイマーを観測する間隔が間引かれてしまう。
+	 */
+	private class event_min_interval extends TwoArgFunction {
+		@Override
+		public LuaValue call(LuaValue minInterval, LuaValue action) {
+			int interval = minInterval.toint();
+			LuaFunction act = action.checkfunction();
+			State s = new State();
+			s.lastExecution = Long.MIN_VALUE;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					if (s.lastExecution == Long.MIN_VALUE
+							|| (state.main.getNowMicroTime() - s.lastExecution) / 1000 >= interval) {
+						s.lastExecution = state.main.getNowMicroTime();
+						act.call();
+					}
+					return TRUE;
+				}
+			};
+		}
+		private class State {
+			long lastExecution;
+		}
+	}
+}

--- a/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lua/LuaSkinLoader.java
@@ -23,11 +23,11 @@ import java.util.function.Function;
 public class LuaSkinLoader extends JSONSkinLoader {
 
 	public LuaSkinLoader() {
-		super(new SkinLuaAccessor());
+		super(new SkinLuaAccessor(false));
 	}
 
 	public LuaSkinLoader(MainState state, Config c) {
-		super(state, c);
+		super(state, c, new SkinLuaAccessor(false));
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class LuaSkinLoader extends JSONSkinLoader {
 		SkinHeader header = loadHeader(p);
 		try {
 			initFileMap(header, property);
-			lua.setSkinProperty(property, (String path) -> {
+			lua.exportSkinProperty(property, (String path) -> {
 				return getPath(p.getParent().toString() + "/" + path, filemap).getPath();
 			});
 			LuaValue value = lua.execFile(p);

--- a/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
@@ -28,8 +28,6 @@ public class MainStateAccessor {
 		table.set("offset", this.new offset());
 		table.set("timer", this.new timer());
 		table.set("timer_off_value", MainStateAccessor.timer_off_value);
-		table.set("is_timer_on", this.new is_timer_on());
-		table.set("now_timer", this.new now_timer());
 		table.set("time", this.new time());
 		table.set("set_timer", this.new set_timer());
 		table.set("event_exec", this.new event_exec());
@@ -219,27 +217,6 @@ public class MainStateAccessor {
 	 * タイマーがOFFの状態を表す定数
 	 */
 	private static final Long timer_off_value = Long.MIN_VALUE;
-
-	/**
-	 * ID指定でタイマーがONかどうかを取得する関数
-	 */
-	private class is_timer_on extends OneArgFunction {
-		@Override
-		public LuaValue call(LuaValue value) {
-			return LuaNumber.valueOf(state.main.isTimerOn(value.toint()));
-		}
-	}
-
-	/**
-	 * ID指定でタイマーの経過時間を取得する関数
-	 * return: ONになってからの経過時間 (micro sec) | 0 (OFFのとき)
-	 */
-	private class now_timer extends OneArgFunction {
-		@Override
-		public LuaValue call(LuaValue value) {
-			return LuaNumber.valueOf(state.main.getNowMicroTime(value.toint()));
-		}
-	}
 
 	/**
 	 * 現在時刻を取得する関数

--- a/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
@@ -1,0 +1,178 @@
+package bms.player.beatoraja.skin.lua;
+
+import bms.player.beatoraja.MainState;
+import bms.player.beatoraja.play.BMSPlayer;
+import bms.player.beatoraja.skin.SkinPropertyMapper;
+import org.luaj.vm2.*;
+import org.luaj.vm2.lib.*;
+
+public class MainStateAccessor {
+
+	private final MainState state;
+
+	public MainStateAccessor(MainState state) {
+		this.state = state;
+	}
+
+	public void export(LuaTable table) {
+		table.set("timer", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				return LuaNumber.valueOf(state.main.getMicroTimer(value.toint()));
+			}
+		});
+		table.set("timer_off_value", Long.MIN_VALUE);
+		table.set("is_timer_on", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				return LuaNumber.valueOf(state.main.isTimerOn(value.toint()));
+			}
+		});
+		table.set("now_timer", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				return LuaNumber.valueOf(state.main.getNowMicroTime(value.toint()));
+			}
+		});
+		table.set("time", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaNumber.valueOf(state.main.getNowMicroTime());
+			}
+		});
+		table.set("set_timer", new TwoArgFunction() {
+			@Override
+			public LuaValue call(LuaValue timerId, LuaValue timerValue) {
+				int id = timerId.toint();
+				if (!SkinPropertyMapper.isTimerWritableBySkin(id))
+					throw new IllegalArgumentException("指定されたタイマーはスキンから変更できません");
+				state.main.setMicroTimer(id, timerValue.tolong());
+				return LuaBoolean.TRUE;
+			}
+		});
+		table.set("rate", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getNowRate());
+			}
+		});
+		table.set("exscore", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getNowEXScore());
+			}
+		});
+		table.set("rate_best", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getNowBestScoreRate());
+			}
+		});
+		table.set("exscore_best", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getBestScore());
+			}
+		});
+		table.set("rate_rival", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getRivalScoreRate());
+			}
+		});
+		table.set("exscore_rival", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.getScoreDataProperty().getRivalScore());
+			}
+		});
+		table.set("volume_sys", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.main.getConfig().getSystemvolume());
+			}
+		});
+		table.set("set_volume_sys", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				state.main.getConfig().setSystemvolume(value.tofloat());
+				return LuaBoolean.TRUE;
+			}
+		});
+		table.set("volume_key", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.main.getConfig().getKeyvolume());
+			}
+		});
+		table.set("set_volume_key", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				state.main.getConfig().setKeyvolume(value.tofloat());
+				return LuaBoolean.TRUE;
+			}
+		});
+		table.set("volume_bg", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				return LuaDouble.valueOf(state.main.getConfig().getBgvolume());
+			}
+		});
+		table.set("set_volume_bg", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				state.main.getConfig().setBgvolume(value.tofloat());
+				return LuaBoolean.TRUE;
+			}
+		});
+		table.set("judge", new OneArgFunction() {
+			@Override
+			public LuaValue call(LuaValue value) {
+				return LuaInteger.valueOf(state.getJudgeCount(value.toint(), true) + state.getJudgeCount(value.toint(), false));
+			}
+		});
+		table.set("gauge", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				if(state instanceof BMSPlayer) {
+					BMSPlayer player = (BMSPlayer) state;
+					return LuaDouble.valueOf(player.getGauge().getValue());
+				}
+				return LuaInteger.ZERO;
+			}
+		});
+		table.set("gauge_type", new ZeroArgFunction() {
+			@Override
+			public LuaValue call() {
+				if(state instanceof BMSPlayer) {
+					BMSPlayer player = (BMSPlayer) state;
+					return LuaDouble.valueOf(player.getGauge().getType());
+				}
+				return LuaInteger.ZERO;
+			}
+		});
+		table.set("event_exec", new VarArgFunction() {
+			@Override
+			public LuaValue call(LuaValue luaValue) {
+				state.executeEvent(getId(luaValue));
+				return LuaBoolean.TRUE;
+			}
+			@Override
+			public LuaValue call(LuaValue luaValue, LuaValue arg1) {
+				state.executeEvent(getId(luaValue), arg1.toint());
+				return LuaBoolean.TRUE;
+			}
+			@Override
+			public LuaValue call(LuaValue luaValue, LuaValue arg1, LuaValue arg2) {
+				state.executeEvent(getId(luaValue), arg1.toint(), arg2.toint());
+				return LuaBoolean.TRUE;
+			}
+			private int getId(LuaValue luaValue) {
+				int id = luaValue.toint();
+				if (!SkinPropertyMapper.isEventRunnableBySkin(id))
+					throw new IllegalArgumentException("指定されたイベントはスキンから実行できません");
+				return id;
+			}
+		});
+	}
+}

--- a/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/SkinLuaAccessor.java
@@ -21,6 +21,8 @@ public class SkinLuaAccessor {
 
 	// isGlobal == false のとき、エクスポートするモジュール名
 	private static final String MAIN_STATE = "main_state";
+	private static final String TIMER_UTIL = "timer_util";
+	private static final String EVENT_UTIL = "event_util";
 
 	public SkinLuaAccessor(boolean isGlobal) {
 		globals = JsePlatform.standardGlobals();
@@ -29,6 +31,8 @@ public class SkinLuaAccessor {
 		if (!isGlobal) {
 			// ヘッダ読み込み時に require("main_state") だけでエラーになると面倒なので、空のテーブルを入れておく
 			globals.package_.setIsLoaded(MAIN_STATE, new LuaTable());
+			globals.package_.setIsLoaded(TIMER_UTIL, new LuaTable());
+			globals.package_.setIsLoaded(EVENT_UTIL, new LuaTable());
 		}
 	}
 
@@ -272,6 +276,27 @@ public class SkinLuaAccessor {
 			LuaTable mainStateTable = new LuaTable();
 			accessor.export(mainStateTable);
 			globals.package_.setIsLoaded(MAIN_STATE, mainStateTable);
+		}
+	}
+
+	/**
+	 * その他のユーティリティーをエクスポートする。
+	 * ロードがそれほど重くなく、JSONスキンから使う可能性もあることが前提
+	 * @param state MainState
+	 */
+	public void exportUtilities(MainState state) {
+		TimerUtility timerUtil = new TimerUtility(state);
+		EventUtility eventUtil = new EventUtility(state);
+		if (isGlobal) {
+			timerUtil.export(globals);
+			eventUtil.export(globals);
+		} else {
+			LuaTable timerUtilTable = new LuaTable();
+			timerUtil.export(timerUtilTable);
+			globals.package_.setIsLoaded(TIMER_UTIL, timerUtilTable);
+			LuaTable eventUtilTable = new LuaTable();
+			eventUtil.export(eventUtilTable);
+			globals.package_.setIsLoaded(EVENT_UTIL, eventUtilTable);
 		}
 	}
 

--- a/src/bms/player/beatoraja/skin/lua/TimerUtility.java
+++ b/src/bms/player/beatoraja/skin/lua/TimerUtility.java
@@ -1,0 +1,164 @@
+package bms.player.beatoraja.skin.lua;
+
+import bms.player.beatoraja.MainState;
+import org.luaj.vm2.*;
+import org.luaj.vm2.lib.*;
+
+/**
+ * Lua用のタイマー関連の便利関数集
+ */
+public class TimerUtility {
+
+	private final MainState state;
+
+	public TimerUtility(MainState state) {
+		this.state = state;
+	}
+
+	public void export(LuaTable table) {
+		table.set("now_timer", new now_timer());
+		table.set("is_timer_on", new is_timer_on());
+		table.set("is_timer_off", new is_timer_off());
+		table.set("timer_function", this.new timer_function());
+		table.set("timer_observe_boolean", this.new timer_observe_boolean());
+		table.set("new_passive_timer", this.new new_passive_timer());
+	}
+
+	/**
+	 * タイマーの経過時間を取得する
+	 * arg luaValue: タイマーの値 (タイマーIDではない)
+	 * return: ONになってからの経過時間 (micro sec) | 0 (OFFのとき)
+	 */
+	private class now_timer extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue luaValue) {
+			long time = luaValue.tolong();
+			return LuaNumber.valueOf(time != Long.MIN_VALUE ? state.main.getNowMicroTime() - time : 0);
+		}
+	}
+
+	/**
+	 * タイマーの値がONかどうか
+	 * arg luaValue: タイマーの値 (タイマーIDではない)
+	 */
+	private static class is_timer_on extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue luaValue) {
+			return LuaBoolean.valueOf(luaValue.tolong() != Long.MIN_VALUE);
+		}
+	}
+
+	/**
+	 * タイマーの値がOFFかどうか
+	 * arg luaValue: タイマーの値 (タイマーIDではない)
+	 */
+	private static class is_timer_off extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue luaValue) {
+			return LuaBoolean.valueOf(luaValue.tolong() == Long.MIN_VALUE);
+		}
+	}
+
+	/**
+	 * ID指定のタイマーを観測するタイマー関数を作成する
+	 * arg timerId: TIMER_* or custom timer ID
+	 * return: function (() -> number)
+	 * equivalent to:
+	 *   function()
+	 *     return main_state.timer(timerId)
+	 *   end
+	 */
+	private class timer_function extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue timerId) {
+			final int id = timerId.toint();
+			return new OneArgFunction() {
+				@Override
+				public LuaValue call(LuaValue luaValue) {
+					return LuaNumber.valueOf(state.main.getMicroTimer(id));
+				}
+			};
+		}
+	}
+
+	/**
+	 * 与えられた関数の実行結果がtrueになった瞬間にON、falseになった瞬間にOFFになるタイマー関数を作成する
+	 * arg func: 観測対象の関数 (() -> boolean)
+	 * return: タイマー関数 (() -> number)
+	 */
+	private class timer_observe_boolean extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue func) {
+			LuaFunction f = func.checkfunction();
+			State observerState = new State();
+			observerState.timerValue = Long.MIN_VALUE;
+			return new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					boolean on = f.call().toboolean();
+					if (on && observerState.timerValue == Long.MIN_VALUE) {
+						observerState.timerValue = state.main.getNowMicroTime();
+					} else if (!on && observerState.timerValue != Long.MIN_VALUE) {
+						observerState.timerValue = Long.MIN_VALUE;
+					}
+					return LuaNumber.valueOf(observerState.timerValue);
+				}
+			};
+		}
+		private class State {
+			long timerValue;
+		}
+	}
+
+	/**
+	 * 受動的なタイマーを生成し、タイマー関数およびタイマーをON/OFFにするイベント関数を返す
+	 * return: {
+	 *     timer: タイマー関数 (() -> number)
+	 *     turn_on: ONにする(既にONの場合はリセットしない)関数
+	 *     turn_on_reset: ONにする(既にONの場合も時刻をリセットする)関数
+	 *     turn_off: OFFにする関数
+	 * }
+	 * NOTE: 受動的なカスタムタイマーでも同様のことが可能
+	 */
+	private class new_passive_timer extends ZeroArgFunction {
+		@Override
+		public LuaValue call() {
+			State s = new State();
+			s.timerValue = Long.MIN_VALUE;
+			LuaTable table = new LuaTable();
+			table.set("timer", new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					return LuaNumber.valueOf(s.timerValue);
+				}
+			});
+			table.set("turn_on", new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					if (s.timerValue == Long.MIN_VALUE) {
+						s.timerValue = state.main.getNowMicroTime();
+					}
+					return TRUE;
+				}
+			});
+			table.set("turn_on_reset", new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					s.timerValue = state.main.getNowMicroTime();
+					return TRUE;
+				}
+			});
+			table.set("turn_off", new ZeroArgFunction() {
+				@Override
+				public LuaValue call() {
+					s.timerValue = Long.MIN_VALUE;
+					return TRUE;
+				}
+			});
+			return table;
+		}
+		private class State {
+			long timerValue;
+		}
+	}
+}


### PR DESCRIPTION
#370 

「現在ある問題点」の2つ目、Luaに公開する関数がグローバル変数に置かれている（のでLuaスキンから使いにくい）という問題に以下のように対処しました。

* JSONスキンでは `value` などに書いたLuaスクリプト内部で変数を作成することが少なく、名前衝突を回避する必要があまりないため、短く書けることを重視してグローバル変数として公開
* Luaスキンでは、上記issueで書いているように単にテーブルに格納するよりも、`require` で読み込めるライブラリのような形で提供するのが良いと考え、`package.loaded` にテーブルを追加
* スキン設定を提供するグローバル変数 `skin_config` については、ライブラリというよりもLuaプログラムの引数のような役割であることと、ヘッダ読み込みかどうかの判定（`if skin_config then ...`）のしやすさを考慮してグローバル変数のままにしています

スキン側で必要な対応は以下の通りになります。（デフォルトスキンでは対応の必要な箇所なし）

* JSONスキンはそのままでOK
* Luaスキンで `timer` などの関数を使っている場合は以下のように変更

```Lua
-- main_state モジュールを読み込む（最初に書く）
local main_state = require("main_state")

...

-- local t = timer(id)                         -- 変更前
local t = main_state.timer(id)                 -- 変更後
```

また、カスタムイベントやカスタムタイマーを作成するための便利関数を `main_state` とは別のモジュールに公開しています。

* TimerUtility タイマー作成・加工用ライブラリ `timer_util`
* EventUtility イベント作成・加工用ライブラリ `event_util`

JSONスキンの場合はグローバル変数にそのまま公開され、Luaスキンの場合は `local timer_util = require("timer_util")` などとすることで使えます。