### PR TITLE
Fix issue with wrong position of cursor line in practice mode when freq != 100

### DIFF
--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -272,7 +272,7 @@ public class PracticeConfiguration {
 		}
 
 		graph.draw(sprite, time, state, new Rectangle(r.x, r.y, r.width, r.height / 4), property.starttime,
-				property.endtime);
+				property.endtime, property.freq / 100f);
 	}
 
 	/**

--- a/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -120,10 +120,10 @@ public class SkinNoteDistributionGraph extends SkinObject {
 		if(state instanceof BMSPlayer) {
 			
 		}
-		draw(sprite, time, state, getDestination(time, state), -1, -1);
+		draw(sprite, time, state, getDestination(time, state), -1, -1, -1);
 	}
 
-	public void draw(SkinObjectRenderer sprite, long time, MainState state, Rectangle r, int starttime, int endtime) {
+	public void draw(SkinObjectRenderer sprite, long time, MainState state, Rectangle r, int starttime, int endtime, float freq) {
 		if (r == null) {
 			return;
 		}
@@ -183,7 +183,11 @@ public class SkinNoteDistributionGraph extends SkinObject {
 		}
 		// 現在カーソル描画
 		if (state instanceof BMSPlayer && state.main.isTimerOn(SkinProperty.TIMER_PLAY)) {
-			int dx = (int) (state.main.getNowTime(SkinProperty.TIMER_PLAY) * r.width / (data.length * 1000));
+			float currenttime = state.main.getNowTime(SkinProperty.TIMER_PLAY);
+			if (freq > 0) {
+				currenttime *= freq;
+			}
+			int dx = (int) (currenttime * r.width / (data.length * 1000));
 			sprite.draw(nowcursor, r.x + dx, r.y, 1, r.height);
 		}
 


### PR DESCRIPTION
If FREQ != 100, the position of the cursor line in the note distribution graph is wrong.
This happens in practice mode.

![image](https://user-images.githubusercontent.com/27341392/51606770-c8019300-1f4d-11e9-8611-638fa6fedf48.png)
![image](https://user-images.githubusercontent.com/27341392/51606771-c9cb5680-1f4d-11e9-9b77-77971df6f761.png)
