### PR TITLE
Fix error in LR2 hard gauge damage code

### DIFF
--- a/src/bms/player/beatoraja/play/GrooveGauge.java
+++ b/src/bms/player/beatoraja/play/GrooveGauge.java
@@ -302,7 +302,7 @@ public class GrooveGauge {
 					}else if(model.getTotal()>=150.0){
 						fix1=2.5f;
 					}else if(model.getTotal()>=130.0){
-						fix1=33.33f;
+						fix1=3.333f;
 					}else if(model.getTotal()>=120.0){
 						fix1=5.0f;
 					}else{


### PR DESCRIPTION
120.0 <= total < 130.0 should do 3.333x damage, not 33.33x damage

http://2nd.geocities.jp/yoshi_65c816/bms/LR2.html