### PR TITLE
fix loading key sound files of upper case extension

### DIFF
--- a/src/bms/player/beatoraja/audio/GdxSoundDriver.java
+++ b/src/bms/player/beatoraja/audio/GdxSoundDriver.java
@@ -4,6 +4,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.nio.file.*;
+import java.util.Locale;
 import java.util.logging.Logger;
 
 import bms.player.beatoraja.Config;
@@ -62,7 +63,7 @@ public class GdxSoundDriver extends AbstractAudioDriver<Sound> {
 	}
 
 	private Sound getKeySound(String name, String ext) {
-		switch (ext) {
+		switch (ext.toLowerCase(Locale.ROOT)) {
 			case ".wav":
 			case ".flac":
 				return getKeySound(new PCMHandleStream(name + ext));


### PR DESCRIPTION
[Drop Down[A]](http://manbow.nothing.sh/event/event.cgi?action=More_def&num=189&event=116)をプレイしようとして発見したバグへの修正です。
#WAV宣言内の拡張子が大文字でも読み込めるようにしました。
