### PR TITLE
Fix bug: replays not working for player2, player3 etc..

### DIFF
--- a/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -537,7 +537,7 @@ public class PlayDataAccessor {
 	 *            LNモード
 	 */
 	public void wrireReplayData(ReplayData rd, BMSModel model, int lnmode, int index) {
-		File replaydir = new File("replay");
+		File replaydir = new File(this.getReplayDataFolder());
 		if (!replaydir.exists()) {
 			replaydir.mkdirs();
 		}
@@ -658,7 +658,7 @@ public class PlayDataAccessor {
 	}
 
 	private String getReplayDataFilePath(String hash, boolean ln, int lnmode, int index) {
-		return playerpath + File.separatorChar + player + File.separatorChar + "replay" + File.separatorChar
+		return this.getReplayDataFolder() + File.separatorChar
 				+ (ln ? replay[lnmode] : "") + hash + (index > 0 ? "_" + index : "");
 	}
 
@@ -679,9 +679,12 @@ public class PlayDataAccessor {
 				}
 			}
 		}
-		return playerpath + File.separatorChar + player + File.separatorChar + "replay" + File.separatorChar
+		return this.getReplayDataFolder() + File.separatorChar
 				+ (ln ? replay[lnmode] : "") + hash + (sb.length() > 0 ? "_" + sb.toString() : "")
 				+ (index > 0 ? "_" + index : "");
 	}
 
+	private String getReplayDataFolder() {
+		return playerpath + File.separatorChar + player + File.separatorChar + "replay";
+	}
 }


### PR DESCRIPTION
**Bug:** for player2, player3 etc, replay folder is not correctly created.
beatoraja creates `./replay` folder instead, which is wrong and is always empty.
player1/replay is created on beatoraja first startup, so no issue occurs with player1
but player2, player3 etc cannot save replays, unless the replay folder is manually created by the user.