### PR TITLE
Fix course constraint 'null' being overwritten in course creation config

### DIFF
--- a/src/bms/player/beatoraja/launcher/CourseEditorView.java
+++ b/src/bms/player/beatoraja/launcher/CourseEditorView.java
@@ -154,6 +154,11 @@ public class CourseEditorView implements Initializable {
 		
 		courseName.setText(selectedCourse.getName());
 		release.setSelected(selectedCourse.isRelease());
+		gradeType.setValue(null);
+		judgeType.setValue(null);
+		hispeedType.setValue(null);
+		gaugeType.setValue(null);
+		lnType.setValue(null);
 		for(CourseData.CourseDataConstraint constraint : course.getConstraint()) {
 			switch(constraint) {
 			case CLASS:


### PR DESCRIPTION
**Bug**:
1. open course tab in beatoraja config
2. create course "ABC", no constraints.
3. create course "DEF", add some constraints (e.g. CLASS, GAUGE_LR2)
4. if you click "DEF", then "ABC", the constraints will be copied over to ABC automatically. (should not happen, because ABC course constraints should be "null").

This fix makes it so that "null" constraints do not get overwritten by other courses.

![image](https://user-images.githubusercontent.com/27341392/54027704-60419780-41dd-11e9-905c-0f38834a66e4.png)
![image](https://user-images.githubusercontent.com/27341392/54027658-4607b980-41dd-11e9-9c2c-edbe11e44a39.png)
