### PR TITLE
Fix display information of a course

### DIFF
--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -3,6 +3,7 @@ package bms.player.beatoraja.result;
 import static bms.player.beatoraja.ClearType.*;
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
+import java.util.Arrays;
 import java.util.logging.Logger;
 
 import bms.player.beatoraja.input.KeyCommand;
@@ -278,7 +279,8 @@ public class CourseResult extends AbstractResult {
 			oldscore = new IRScoreData();
 		}
 
-		getScoreDataProperty().setTargetScore(oldscore.getExscore(), resource.getRivalScoreData(), resource.getBMSModel().getTotalNotes());
+		getScoreDataProperty().setTargetScore(oldscore.getExscore(), resource.getRivalScoreData(),
+				Arrays.asList(resource.getCourseBMSModels()).stream().mapToInt(model -> model.getTotalNotes()).sum());
 		getScoreDataProperty().update(newscore);
 
 		main.getPlayDataAccessor().writeScoreDara(newscore, models, config.getLnmode(),

--- a/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -665,22 +665,22 @@ public class BooleanPropertyFactory {
 					(state) -> ((state instanceof BMSPlayer) ? ((BMSPlayer) state).getGauge().getGauge().isQualified() : false));
 		case OPTION_UPDATE_SCORE:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getExscore() > ((AbstractResult) state).getOldScore().getExscore() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getExscore() > ((AbstractResult) state).getOldScore().getExscore() : false));
 		case OPTION_DRAW_SCORE:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getExscore() == ((AbstractResult) state).getOldScore().getExscore() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getExscore() == ((AbstractResult) state).getOldScore().getExscore() : false));
 		case OPTION_UPDATE_MAXCOMBO:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getCombo() > ((AbstractResult) state).getOldScore().getCombo() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getCombo() > ((AbstractResult) state).getOldScore().getCombo() : false));
 		case OPTION_DRAW_MAXCOMBO:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getCombo() == ((AbstractResult) state).getOldScore().getCombo() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getCombo() == ((AbstractResult) state).getOldScore().getCombo() : false));
 		case OPTION_UPDATE_MISSCOUNT:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getMinbp() < ((AbstractResult) state).getOldScore().getMinbp() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getMinbp() < ((AbstractResult) state).getOldScore().getMinbp() : false));
 		case OPTION_DRAW_MISSCOUNT:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-					(state) -> ((state instanceof AbstractResult) ? state.main.getPlayerResource().getScoreData().getMinbp() == ((AbstractResult) state).getOldScore().getMinbp() : false));
+					(state) -> ((state instanceof AbstractResult) ? ((AbstractResult) state).getNewScore().getMinbp() == ((AbstractResult) state).getOldScore().getMinbp() : false));
 		case OPTION_UPDATE_SCORERANK:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
 					(state) -> (state.getScoreDataProperty().getNowRate() > state.getScoreDataProperty().getBestScoreRate()));

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.skin.property;
 
 import static bms.player.beatoraja.skin.SkinProperty.*;
 
+import java.util.Arrays;
 import java.util.Calendar;
 
 import com.badlogic.gdx.Gdx;
@@ -85,7 +86,10 @@ public class IntegerPropertyFactory {
 				}
 				return state.main.getPlayerResource().getSongdata() != null
 						? state.main.getPlayerResource().getSongdata().getNotes()
-						: Integer.MIN_VALUE;
+						: state.main.getPlayerResource().getCourseData() != null
+							? Arrays.asList(state.main.getPlayerResource().getCourseData().getSong()).stream()
+								.mapToInt(sd -> sd.getNotes()).sum()
+							: Integer.MIN_VALUE;
 			};
 		}
 		if (optionid == NUMBER_SONGLENGTH_MINUTE) {
@@ -875,9 +879,9 @@ public class IntegerPropertyFactory {
 					final Bar selected = ((MusicSelector) state).getBarRender().getSelected();
 					return selected.getScore() != null ? selected.getScore().getClear() : Integer.MIN_VALUE;
 				} else if (state instanceof AbstractResult) {
-					final PlayerResource resource = state.main.getPlayerResource();
-					if (resource.getScoreData() != null) {
-						return resource.getScoreData().getClear();
+					final IRScoreData score = ((AbstractResult) state).getNewScore();
+					if (score != null) {
+						return score.getClear();
 					}
 					return Integer.MIN_VALUE;
 				}


### PR DESCRIPTION
表示されるコースの情報を修正
- コースリザルト
  + クリアしてもクリアタイプがNO PLAYになる問題を修正
  + ベストランクがAAAになる問題を修正
  + ベストレートの数値が正しくない問題を修正
  + コースのトータルノーツを表示できるように修正
- 選曲画面
  + コースのトータルノーツを表示できるように修正