### PR TITLE
Fix IRConfigurationView crash when no IR is available

### DIFF
--- a/src/bms/player/beatoraja/launcher/IRConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/IRConfigurationView.java
@@ -62,7 +62,11 @@ public class IRConfigurationView implements Initializable {
     	    	
 		primary = player.getIrconfig().length > 0 ? player.getIrconfig()[0].getIrname() : null;
 		if(!irname.getItems().contains(primary)) {
-			primary = irname.getItems().get(0);
+			if (irname.getItems().size() == 0) {
+				primary = null;
+			} else {
+				primary = irname.getItems().get(0);
+			}
 		}
 		irname.setValue(primary);
 		updateIRConnection();
@@ -126,7 +130,7 @@ public class IRConfigurationView implements Initializable {
 		iruserid.setText(currentir.getUserid());
 		irpassword.setText(currentir.getPassword());
 		irsend.setValue(currentir.getIrsend());
-		
-		primarybutton.setVisible(!irname.getValue().equals(primary));
+
+		primarybutton.setVisible(!(primary != null && irname.getValue().equals(primary)));
 	}
 }


### PR DESCRIPTION
IRConfigurationView will crash when no IR is available. (ArrayIndexOutOfBoundsException)
Crash happens when beatoraja config is opened.

Fix:
1. set `primary = null` when IR ComboBox has no IRs
2. fix NullPointerException in updateIRConnection when `primary == null`.