### PR TITLE
Fix beatoraja crash when path.resolve() is called with file name = ???

### DIFF
--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -283,8 +283,8 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 					}
 				}
 			} catch (InvalidPathException e) {
-                Logger.getGlobal().warning(e.getMessage());
-            }
+				Logger.getGlobal().warning(e.getMessage());
+			}
 			progress.incrementAndGet();
 		});
 

--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -3,6 +3,7 @@ package bms.player.beatoraja.audio;
 import bms.model.*;
 import bms.player.beatoraja.ResourcePool;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
@@ -249,38 +250,41 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				return;
 			}
 			String name = model.getWavList()[wavid];
-			for (Note note : waventry.getValue()) {
-				// 音切りあり・なし両方のデータが必要になるケースがある
-				if (note.getMicroStarttime() == 0 && note.getMicroDuration() == 0) {
-					// 音切りなしのケース
-					Path p = dpath.resolve(name);
-					wavmap[wavid] = cache.get(new AudioKey(p.toString(), note));
-					if (wavmap[wavid] == null) {
-						break;
-					}
-				} else {
-					// 音切りありのケース
-					boolean b = true;
-					if (slicesound[note.getWav()] == null) {
-						slicesound[note.getWav()] = new Array<SliceWav<T>>();
-					}
-					for (SliceWav<T> slice : slicesound[note.getWav()]) {
-						if (slice.starttime == note.getMicroStarttime() && slice.duration == note.getMicroDuration()) {
-							b = false;
+			try {
+				Path p = dpath.resolve(name);
+				for (Note note : waventry.getValue()) {
+					// 音切りあり・なし両方のデータが必要になるケースがある
+					if (note.getMicroStarttime() == 0 && note.getMicroDuration() == 0) {
+						// 音切りなしのケース
+						wavmap[wavid] = cache.get(new AudioKey(p.toString(), note));
+						if (wavmap[wavid] == null) {
 							break;
 						}
-					}
-					if (b) {
-						Path p = dpath.resolve(name);
-						T sliceaudio = cache.get(new AudioKey(p.toString(), note));
-						if (sliceaudio != null) {
-							slicesound[note.getWav()].add(new SliceWav<T>(note, sliceaudio));
-						} else {
-							return;
+					} else {
+						// 音切りありのケース
+						boolean b = true;
+						if (slicesound[note.getWav()] == null) {
+							slicesound[note.getWav()] = new Array<SliceWav<T>>();
+						}
+						for (SliceWav<T> slice : slicesound[note.getWav()]) {
+							if (slice.starttime == note.getMicroStarttime() && slice.duration == note.getMicroDuration()) {
+								b = false;
+								break;
+							}
+						}
+						if (b) {
+							T sliceaudio = cache.get(new AudioKey(p.toString(), note));
+							if (sliceaudio != null) {
+								slicesound[note.getWav()].add(new SliceWav<T>(note, sliceaudio));
+							} else {
+								return;
+							}
 						}
 					}
 				}
-			}
+			} catch (InvalidPathException e) {
+                Logger.getGlobal().warning(e.getMessage());
+            }
 			progress.incrementAndGet();
 		});
 

--- a/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -167,8 +167,8 @@ public class BGAProcessor {
 						}
 					}
 				} catch (InvalidPathException e) {
-	                Logger.getGlobal().warning(e.getMessage());
-	            }
+					Logger.getGlobal().warning(e.getMessage());
+				}
 
 				if (f != null) {
 					boolean isMovie = false;

--- a/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -126,16 +126,31 @@ public class BGAProcessor {
 					break;
 				}
 				Path f = null;
-				if (Files.exists(dpath.resolve(name))) {
-					final int index = name.lastIndexOf('.');
-					String fex = null;
-					if (index != -1) {
-						fex = name.substring(index + 1).toLowerCase();
+				try {
+					if (Files.exists(dpath.resolve(name))) {
+						final int index = name.lastIndexOf('.');
+						String fex = null;
+						if (index != -1) {
+							fex = name.substring(index + 1).toLowerCase();
+						}
+						if(fex != null && !(Arrays.asList(mov_extension).contains(fex))){
+							f = dpath.resolve(name);
+						}else if(fex != null){
+							name = name.substring(0, index);
+							for (String mov : mov_extension) {
+								final Path mpgfile = dpath.resolve(name + "." + mov);
+								if (Files.exists(mpgfile)) {
+									f = mpgfile;
+									break;
+								}
+							}
+						}
 					}
-					if(fex != null && !(Arrays.asList(mov_extension).contains(fex))){
-						f = dpath.resolve(name);
-					}else if(fex != null){
-						name = name.substring(0, index);
+					if (f == null) {
+						final int index = name.lastIndexOf('.');
+						if (index != -1) {
+							name = name.substring(0, index);
+						}
 						for (String mov : mov_extension) {
 							final Path mpgfile = dpath.resolve(name + "." + mov);
 							if (Files.exists(mpgfile)) {
@@ -143,28 +158,17 @@ public class BGAProcessor {
 								break;
 							}
 						}
-					}
-				}
-				if (f == null) {
-					final int index = name.lastIndexOf('.');
-					if (index != -1) {
-						name = name.substring(0, index);
-					}
-					for (String mov : mov_extension) {
-						final Path mpgfile = dpath.resolve(name + "." + mov);
-						if (Files.exists(mpgfile)) {
-							f = mpgfile;
-							break;
+						for (String mov : BGImageProcessor.pic_extension) {
+							final Path picfile = dpath.resolve(name + "." + mov);
+							if (Files.exists(picfile)) {
+								f = picfile;
+								break;
+							}
 						}
 					}
-					for (String mov : BGImageProcessor.pic_extension) {
-						final Path picfile = dpath.resolve(name + "." + mov);
-						if (Files.exists(picfile)) {
-							f = picfile;
-							break;
-						}
-					}
-				}
+				} catch (InvalidPathException e) {
+	                Logger.getGlobal().warning(e.getMessage());
+	            }
 
 				if (f != null) {
 					boolean isMovie = false;

--- a/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
+++ b/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
@@ -1,8 +1,10 @@
 package bms.player.beatoraja.select;
 
+import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Deque;
 import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.logging.Logger;
 
 import bms.player.beatoraja.Config;
 import bms.player.beatoraja.audio.AudioDriver;
@@ -44,8 +46,16 @@ public class PreviewMusicProcessor {
             preview.start();
         }
         current = song;
-        commands.add(song != null && song.getPreview() != null && song.getPreview().length() > 0 ?
-                Paths.get(song.getPath()).getParent().resolve(song.getPreview()).toString() : "");
+
+        String previewPath = "";
+        if (song != null && song.getPreview() != null && song.getPreview().length() > 0) {
+            try {
+                previewPath = Paths.get(song.getPath()).getParent().resolve(song.getPreview()).toString();
+            } catch (InvalidPathException e) {
+                Logger.getGlobal().warning(e.getMessage());
+            }
+        }
+        commands.add(previewPath);
     }
 
     public SongData getSongData() {


### PR DESCRIPTION
# Issue
[Path resolve(String other)](https://docs.oracle.com/javase/7/docs/api/java/nio/file/Path.html#resolve(java.lang.String)) will throw an InvalidPathException if `other` has invalid characters like `?`.

Example: `path.resolve("???.png")` throws an exception, can crash beatoraja.

# How to reproduce
`Path resolve(String other)` is used in many places in the code.
1. **BGAProcessor** (BGA issue)
  - If `#BMP01` is set to `???.png`, beatoraja will crash.
2. **AbstractAudioDriver** (Keysound issue)
  - If `#WAVxx` is set to `???.wav`, beatoraja will crash.
3. **PreviewMusicProcessor** (Preview issue)
  - If `#PREVIEW` is set to `???.wav`, beatoraja will crash.

I think there may be other places where `Path resolve(String other)` is used.
I only fixed the most important locations.

# BMS files that crash beatoraja
Sample 差分 x3 that will crash beatoraja: [crash_bms_test.zip](https://github.com/exch-bms2/beatoraja/files/3103109/crash_bms_test.zip)
本体: [PABAT!2019 Cursed Nightshade](http://k-bms.com/party_pabat/party2019.jsp?board_num=19&num=58)

This song [PABAT!2019 流れ星](http://k-bms.com/party_pabat/party2019.jsp?board_num=19&num=14&order=reg&odtype=a) will also crash beatoraja if the [Hyper] chart is the first chart played after starting beatoraja. (because of `#BMP01 ????.png`)

# Fix
try-catch InvalidPathException and log the exception.
