### PR TITLE
Fix FFmpegProcessor crash when song is restarted too quickly

### DIFF
--- a/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -37,6 +37,10 @@ public class FFmpegProcessor implements MovieProcessor {
 	private MovieSeekThread movieseek;
 
 	private long time;
+	/**
+	 * dispose()を呼び出した後にprocessorDisposedはtrueになる
+	 */
+	private boolean processorDisposed = false;
 
 	public FFmpegProcessor(int fpsd) {
 		this.fpsd = fpsd;
@@ -64,6 +68,7 @@ public class FFmpegProcessor implements MovieProcessor {
 
 	@Override
 	public void dispose() {
+		processorDisposed = true;
 		if (movieseek != null) {
 			movieseek.exec(Command.HALT);
 			movieseek = null;
@@ -171,7 +176,8 @@ public class FFmpegProcessor implements MovieProcessor {
 								}
 								Gdx.app.postRunnable(() -> {
 									final Pixmap p = pixmap;
-									if (p == null) {
+									// dispose()を呼び出した後にshowingtexを使えばEXCEPTION_ACCESS_VIOLATIONが発生
+									if (p == null || processorDisposed) {
 										return;
 									}
 									if (showingtex != null) {


### PR DESCRIPTION
# How to reproduce bug
1. Use LITONE5 skin for MUSIC SELECT, use `Blue&Green Full of Stars.mp4` for movie background.
 - The other two mp4 movie backgrounds also work. But some other videos won't cause the crash.
2. Start playing a song.
3. Exit the song before the first note.
4. During exit, hold KEY 1 so that the song will restart immediately after returning to MUSIC SELECT.
5. When song is started again, beatoraja will crash with `EXCEPTION_ACCESS_VIOLATION (0xc0000005)`

# Cause of issue
1. This code runs with a delay:
```java
Gdx.app.postRunnable(() -> {
    final Pixmap p = pixmap;
    if (p == null) {
        return;
    }
    if (showingtex != null) {
        showingtex.draw(p, 0, 0);
    } else {
        showingtex = new Texture(p);
    }
});
```
2. When song is started, `showingtex.dispose()` is called. (because `SkinSourceMovie` calls `dispose()` on `FFmpegProcessor`.)
3. If song is started too quickly, `showingtex.dispose()` will be called **before** running the above code. The above code uses `showingtex`, so `EXCEPTION_ACCESS_VIOLATION (0xc0000005)` happens.

# Fix
Add flag `processorDisposed` to FFmpegProcessor.
```java
private boolean processorDisposed = false;
```
`processorDisposed` is set to true after `dispose()` is called.

This code will be skipped if `processorDisposed` has been set to true. (because there is no need to create the movie texture after the skin is disposed)
```java
Gdx.app.postRunnable(() -> {
    final Pixmap p = pixmap;
    if (p == null) {
        return;
    }
    if (showingtex != null) {
        showingtex.draw(p, 0, 0);
    } else {
        showingtex = new Texture(p);
    }
});
```