### PR TITLE
Record and use player ghosts

### DIFF
--- a/src/bms/player/beatoraja/IRScoreData.java
+++ b/src/bms/player/beatoraja/IRScoreData.java
@@ -74,6 +74,10 @@ public class IRScoreData implements Validatable {
 	 */
 	private String trophy = "";
 	/**
+	 * ベストスコアのゴースト
+	 */
+	private String ghost = "";
+	/**
 	 * 更新時のRANDOM配列
 	 */
 	private int random;
@@ -368,6 +372,18 @@ public class IRScoreData implements Validatable {
 
 	public Mode getPlaymode() {
 		return playmode;
+	}
+
+	public int[] getGhost() {
+		if (ghost == null) {
+			return null;
+		}
+		// TODO
+		return null;
+	}
+
+	public void setGhost(int[] value){
+		// TODO
 	}
 
 	@Override

--- a/src/bms/player/beatoraja/PlayDataAccessor.java
+++ b/src/bms/player/beatoraja/PlayDataAccessor.java
@@ -443,6 +443,7 @@ public class PlayDataAccessor {
 			score.setEms(newscore.getEms());
 			score.setLms(newscore.getLms());
 			score.setOption(newscore.getOption());
+			score.setGhost(newscore.getGhost());
 			log.setSha256(hash);
 			log.setScore(newscore.getExscore());
 		}

--- a/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
@@ -68,12 +68,17 @@ public class ScoreDatabaseAccessor {
 						+ "[epg] INTEGER," + "[lpg] INTEGER," + "[egr] INTEGER," + "[lgr] INTEGER," + "[egd] INTEGER,"
 						+ "[lgd] INTEGER," + "[ebd] INTEGER," + "[lbd] INTEGER," + "[epr] INTEGER," + "[lpr] INTEGER,"
 						+ "[ems] INTEGER," + "[lms] INTEGER," + "[notes] INTEGER," + "[combo] INTEGER,"
-						+ "[minbp] INTEGER," + "[playcount] INTEGER," + "[clearcount] INTEGER," + "[trophy] TEXT,"
+						+ "[minbp] INTEGER," + "[playcount] INTEGER," + "[clearcount] INTEGER," + "[trophy] TEXT," + "[ghost] TEXT,"
 						+ "[scorehash] TEXT," + "[option] INTEGER," + "[random] INTEGER," + "[date] INTEGER,"
 						+ "[state] INTEGER," + "PRIMARY KEY(sha256, mode));");
-			}			
+			}
+
+			// 過去のバージョンで作成したテーブルにカラムが存在しない場合に作成
 			if(qr.query("SELECT * FROM sqlite_master WHERE name = 'score' AND sql LIKE '%trophy%'", new MapListHandler()).size() == 0) {
 				qr.update("ALTER TABLE score ADD COLUMN trophy [TEXT]");
+			}
+			if (qr.query("SELECT * FROM sqlite_master WHERE name = 'score' AND sql LIKE '%ghost%'", new MapListHandler()).size() == 0) {
+				qr.update("ALTER TABLE score ADD COLUMN ghost [TEXT]");
 			}
 
 		} catch (SQLException e) {

--- a/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/ScoreDatabaseAccessor.java
@@ -190,14 +190,14 @@ public class ScoreDatabaseAccessor {
 			con.setAutoCommit(false);
 			String sql = "INSERT OR REPLACE INTO score "
 					+ "(sha256, mode, clear, epg, lpg, egr, lgr, egd, lgd, ebd, lbd, epr, lpr, ems, lms, notes, combo, "
-					+ "minbp, playcount, clearcount, trophy, scorehash, option, random, date, state)"
-					+ "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);";
+					+ "minbp, playcount, clearcount, trophy, ghost, scorehash, option, random, date, state)"
+					+ "VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?);";
 			for (IRScoreData score : scores) {
 				qr.update(con, sql, score.getSha256(), score.getMode(), score.getClear(), score.getEpg(),
 						score.getLpg(), score.getEgr(), score.getLgr(), score.getEgd(), score.getLgd(), score.getEbd(),
 						score.getLbd(), score.getEpr(), score.getLpr(), score.getEms(), score.getLms(),
 						score.getNotes(), score.getCombo(), score.getMinbp(), score.getPlaycount(),
-						score.getClearcount(), score.getTrophy(), score.getScorehash(), score.getOption(),
+						score.getClearcount(), score.getTrophy(), score.getGhost(), score.getScorehash(), score.getOption(),
 						score.getRandom(), score.getDate(), score.getState());
 			}
 			con.commit();

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -378,7 +378,7 @@ public class BMSPlayer extends MainState {
 			practice.create(model);
 			state = STATE_PRACTICE;
 		} else {
-			getScoreDataProperty().setTargetScore(score.getExscore(), score.getGhost(), rivalscore, null, model.getTotalNotes());
+			getScoreDataProperty().setTargetScore(score.getExscore(), score.decodeGhost(), rivalscore, null, model.getTotalNotes());
 		}
 	}
 
@@ -789,6 +789,7 @@ public class BMSPlayer extends MainState {
 		score.setGauge(gauge.isTypeChanged() ? -1 : gauge.getType());
 		score.setOption(config.getRandom() + (model.getMode().player == 2
 				? (config.getRandom2() * 10 + config.getDoubleoption() * 100) : 0));
+		score.encodeGhost(judge.getGhost());
 		// リプレイデータ保存。スコア保存されない場合はリプレイ保存しない
 		final ReplayData replay = resource.getReplayData();
 		replay.player = main.getPlayerConfig().getName();

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -374,11 +374,11 @@ public class BMSPlayer extends MainState {
 		resource.setRivalScoreData(rivalscore);
 
 		if (autoplay == PlayMode.PRACTICE) {
-			getScoreDataProperty().setTargetScore(0, 0, model.getTotalNotes());
+			getScoreDataProperty().setTargetScore(0, null, 0, null, model.getTotalNotes());
 			practice.create(model);
 			state = STATE_PRACTICE;
 		} else {
-			getScoreDataProperty().setTargetScore(score.getExscore(), rivalscore, model.getTotalNotes());
+			getScoreDataProperty().setTargetScore(score.getExscore(), score.getGhost(), rivalscore, null, model.getTotalNotes());
 		}
 	}
 

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -68,6 +68,10 @@ public class JudgeManager {
 	private int[] judgenow;
 	private int[] judgecombo;
 	/**
+	 * ゴースト記録用の判定ログ
+	 */
+	private int[] ghost;
+	/**
 	 * 判定差時間(ms , +は早押しで-は遅押し)
 	 */
 	private long[] judgefast;
@@ -168,6 +172,10 @@ public class JudgeManager {
 		score = new IRScoreData(orgmode);
 		score.setNotes(model.getTotalNotes());
 		score.setSha256(model.getSHA256());
+		ghost = new int[model.getTotalNotes()];
+		for (int i=0; i<ghost.length; i++) {
+			ghost[i] = 4;
+		}
 
 		this.lntype = model.getLntype();
 		lanes = model.getLanes();
@@ -666,6 +674,9 @@ public class JudgeManager {
 
 	private void update(int lane, Note n, long time, int judge, long fast) {
 		if (judgeVanish[judge]) {
+			if (pastNotes < ghost.length) {
+				ghost[pastNotes] = judge;
+			}
 			n.setState(judge + 1);
 			pastNotes++;
 		}
@@ -836,5 +847,9 @@ public class JudgeManager {
 
 	public int getPMcharaJudge() {
 		return PMcharaJudge;
+	}
+
+	public int[] getGhost() {
+		return ghost;
 	}
 }


### PR DESCRIPTION
This implementation solves #340 for local best ghosts.

## Ghost encoding

A Judgment sequence is encoded into a string with GZIP and Base64Url. Example: `1,1,0,2,1,1,1,0,0,0,0,0,0,0,0,1,0,1,1,0,0,0,1,1,1,0,0,0,...` (~900 notes) → `H4sIAAAAAAAAAF1TCRKEMAgjGf__5rU0CbjVmR4COahAEU...` (~300 characters)

## Local best ghosts

The ghost corresponding to the best score is saved in `ghost` column of `score` table. So they are independent of replay data. If no ghost exists, the score graph goes at the linear speed.

## IR ghosts

IR ghosts may be available if `IRConnection` implementations uses `IRScoreData.ghost`.

## `#RANDOM` branching and long notes compatibility

The ghost is playbacked only if the actual total notes is equal to the recorded total notes. Otherwise, the score graph goes at the linear speed.

The order of judgments may be interchanged around long notes. This implementation do not care that matter because it seems to be almost harmless.

