### PR TITLE
Fix crash when BGA is turned off - NullPointerException in FFmpegProcessor

### DIFF
--- a/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -53,16 +53,19 @@ public class FFmpegProcessor implements MovieProcessor {
 
 	@Override
 	public Texture getFrame(long time) {
+		if (processorDisposed) return null;
 		this.time = time;
 		return showingtex;
 	}
 	
 	public void play(long time, boolean loop) {
+		if (processorDisposed) return;
 		this.time = time;
 		movieseek.exec(loop ? Command.LOOP : Command.PLAY);
 	}
 
 	public void stop() {
+		if (processorDisposed) return;
 		movieseek.exec(Command.STOP);
 	}
 


### PR DESCRIPTION
# How to reproduce

1. Find a song with BGA
2. Play song with BGA ON. exit song.
3. Turn off BGA and play the song again. beatoraja will crash.

# Exception stack trace
```
Exception in thread "LWJGL Application" java.lang.NullPointerException
        at bms.player.beatoraja.play.bga.FFmpegProcessor.stop(FFmpegProcessor.java:66)
        at bms.player.beatoraja.play.bga.BGAProcessor.prepare(BGAProcessor.java:219)
        at bms.player.beatoraja.play.BMSPlayer.render(BMSPlayer.java:424)
        at bms.player.beatoraja.MainController.render(MainController.java:395)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)
```

# Cause of error

BGAProcessor continues to hold a pointer to FFmpegProcessor after FFmpegProcessor is disposed.
When `stop()` is called after FFmpegProcessor is disposed, a NullPointerException occurs because `movieseek` will be null.

# Changes in pull request

- Modify `play()` and `stop()` to do nothing when `processorDisposed == true`.
- Modify `getFrame()` to return null when `processorDisposed == true`.

It is safe to return null from `getFrame()`, because `null` is an expected return value (when FFmpegProcessor is not yet initialized using `create()`)
I tested this by making `getFrame()` always return null. This makes BGAs and skin background videos not display in game, but no problems occur.
