### PR TITLE
Fix ArrayIndexOutOfBoundsException in BGAProcessor when song is started

### DIFF
--- a/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -100,6 +100,7 @@ public class BGAProcessor {
 		progress = 0;
 
 		cache.clear();
+		resetCurrentlyPlayingBGA();
 
 		int id = 0;
 
@@ -219,11 +220,15 @@ public class BGAProcessor {
 				mp.stop();				
 			}
 		}
+		resetCurrentlyPlayingBGA();
+		time = 0;		
+	}
+
+	private void resetCurrentlyPlayingBGA() {
 		playingbgaid = -1;
 		playinglayerid = -1;
 		misslayertime = 0;
 		misslayer = null;
-		time = 0;		
 	}
 
 	private Texture getBGAData(long time, int id, boolean cont) {


### PR DESCRIPTION
# How to Replicate

Depending on choice of SONG A, beatoraja may crash.

1. Find song with BGA. **[SONG A]**
2. Start song and wait until BGA starts playing.
3. Exit song.
4. Find a different song with BGA **[SONG B]**
5. Start song, and exit song before song starts.

## Effect:
You might see the song's BGA flash on the screen before the song exits.
This is only a visual issue - not a serious error.

However, if **[SONG A]**'s BGA is made from many images (example: FREEDOM DIVE), this will cause beatoraja to crash after step 5.

# Exception Stack Trace

```
Exception in thread "LWJGL Application" java.lang.ArrayIndexOutOfBoundsException: 258
        at bms.player.beatoraja.play.bga.BGAProcessor.getBGAData(BGAProcessor.java:234)
        at bms.player.beatoraja.play.bga.BGAProcessor.drawBGA(BGAProcessor.java:312)
        at bms.player.beatoraja.play.SkinBGA.draw(SkinBGA.java:57)
        at bms.player.beatoraja.skin.Skin.drawAllObjects(Skin.java:199)
        at bms.player.beatoraja.MainController.render(MainController.java:399)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:225)
        at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:126)
```

# Cause of Issue
In `BGAProcessor.java`, we render the movie `movies[playingbgaid]` during the song. The default value is `playingbgaid = -1`. We set `playingbgaid == -1` to not render any movie.

However, `playbgaid` is not reset back to `-1` when the song is exited.

When **[SONG B]** is started in Step 4, `playbgaid` is kept from the previous song.
- If **[SONG A]** only has one BGA movie, then `playbgaid = 0`.
- If **[SONG A]**'s BGA is made from many images, we may have something like `playbgaid = 120`.

If you exit the song, the BGA will be visible.
1. If `playbgaid = 0`, then you will see the current song's BGA "flash" before the song exits.
2. If `playbgaid` is large (120?), then the game crashes because the new song does not have BGA ID 120.
   (ArrayIndexOutOfBoundsException in `movies[]`)

# Timeline of Events
Normally, `playbgaid` is reset by calling `BGAProcessor.prepare()`.
But `BGAProcessor.prepare()` is not called until "GET READY". We can crash the game by exiting before "GET READY".

1. **PLAYER PRESSES START SONG**, switch to play skin
2. **BMS LOADS** - call `BGAProcessor.setModel()`.  
    This happens:
    ```
    movies = new MovieProcessor[model.getBgaList().length];
    ```
3. **KEYSOUNDS LOADING...**
    player can crash the game by exiting here.
4. **FINISH LOADING KEYSOUNDS. "GET READY"** - call `BGAProcessor.prepare()`
    ```
    playbgaid = 0;
    ```

# Fix

Set `playbgaid = 0` in `setModel()`.
So when the `movies` array is re-initialized, `playbgaid` will also be reset to 0 simultaneously.

- Now, we set `playbgaid = 0` two times during song loading. During `setModel()` and during `prepare()`.