### PR TITLE
Improve randomselect

### DIFF
--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -814,7 +814,7 @@ public class BarRenderer {
 				SongData[] randomTargets = Stream.of(newcurrentsongs).filter(
 						songBar -> songBar instanceof SongBar && ((SongBar) songBar).getSongData().getPath() != null)
 						.map(songBar -> ((SongBar) songBar).getSongData()).toArray(SongData[]::new);
-				if (randomTargets.length > 0) {
+				if (randomTargets.length >= 2) {
 					Bar randomBar = new ExecutableBar(randomTargets, select.main.getCurrentState());
 					bars.add(randomBar);
 				}

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -472,6 +472,7 @@ public class SkinProperty {
 	public static final int OPTION_GRADEBAR_LN = 1015;
 	public static final int OPTION_GRADEBAR_CN = 1016;
 	public static final int OPTION_GRADEBAR_HCN = 1017;
+	public static final int OPTION_RANDOMSELECTBAR = 1030;
 
 	public static final int OPTION_PLAYABLEBAR = 5;
 

--- a/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -27,11 +27,7 @@ import bms.player.beatoraja.result.AbstractResult;
 import bms.player.beatoraja.result.CourseResult;
 import bms.player.beatoraja.result.MusicResult;
 import bms.player.beatoraja.select.MusicSelector;
-import bms.player.beatoraja.select.bar.Bar;
-import bms.player.beatoraja.select.bar.DirectoryBar;
-import bms.player.beatoraja.select.bar.GradeBar;
-import bms.player.beatoraja.select.bar.SelectableBar;
-import bms.player.beatoraja.select.bar.SongBar;
+import bms.player.beatoraja.select.bar.*;
 import bms.player.beatoraja.skin.SkinObject;
 import bms.player.beatoraja.song.SongData;
 
@@ -483,13 +479,17 @@ public class BooleanPropertyFactory {
 		case OPTION_GRADEBAR:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
 					(state) -> ((state instanceof MusicSelector) ? ((MusicSelector) state).getSelectedBar() instanceof GradeBar : false));
+		case OPTION_RANDOMSELECTBAR:
+			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
+					(state) -> ((state instanceof MusicSelector) ? ((MusicSelector) state).getSelectedBar() instanceof ExecutableBar : false));
 		case OPTION_PLAYABLEBAR:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
 					(state) -> {
 						if(state instanceof MusicSelector) {
 							Bar selected = ((MusicSelector) state).getSelectedBar();
 							return ((selected instanceof SongBar) && ((SongBar)selected).getSongData().getPath() != null) ||
-									((selected instanceof GradeBar) && ((GradeBar)selected).existsAllSongs()); 
+									((selected instanceof GradeBar) && ((GradeBar)selected).existsAllSongs()) ||
+									(selected instanceof ExecutableBar);
 						}
 						return false;
 					});


### PR DESCRIPTION
- ランダムセレクトバーを表示する条件を、フォルダ内に1譜面以上から2譜面以上に変更
- SkinPropertyにランダムセレクトバーを判別するためのオプション(OPTION_RANDOMSELECTBAR)を追加
- ランダムセレクトバーを選択中に、OPTION_PLAYABLEBARがtrueを返すよう変更