### PR TITLE
Fix Bitmap Font not loaded

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -29,7 +29,6 @@ public class SkinTextBitmap extends SkinText {
 
 	@Override
 	public void load() {
-		font = source.getFont();
 	}
 
 	public SkinTextBitmap(SkinTextBitmapSource source, float size) {
@@ -41,6 +40,7 @@ public class SkinTextBitmap extends SkinText {
 		this.source = source;
 		this.size = size;
 		this.layout =new GlyphLayout();
+		this.font = source.getFont();
 	}
 
 	@Override


### PR DESCRIPTION
Beatoraja 0.7.4 with LITONE6 or LITONE7, bitmap fonts are not able to be loaded. Just to initialize `SkinTextBitmap` once with constructor will be fine to load it properly.