### PR TITLE
Change SameFolderBar title to fullTitle

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
+++ b/src/bms/player/beatoraja/select/MusicSelectInputProcessor.java
@@ -329,7 +329,7 @@ public class MusicSelectInputProcessor {
                 if (current instanceof SongBar && ((SongBar) current).existsSong() &&
                         (bar.getDirectory().size == 0 || !(bar.getDirectory().last() instanceof SameFolderBar))) {
                     SongData sd = ((SongBar) current).getSongData();
-                    bar.updateBar(new SameFolderBar(select, sd.getTitle(), sd.getFolder()));
+                    bar.updateBar(new SameFolderBar(select, sd.getFullTitle(), sd.getFolder()));
                     select.play(SOUND_FOLDEROPEN);
                 } else if (current instanceof GradeBar) {
                     List<Bar> songbars = Arrays.asList(((GradeBar) current).getSongDatas()).stream()


### PR DESCRIPTION
SameFolderBarのTitleを譜面のTitleからFullTitleに変更
- SUBTITLEが存在する譜面からSameFolderBarを開くと、開いた位置に戻れない問題を修正するため