### PR TITLE
Fix searchtextfield

### DIFF
--- a/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -124,6 +124,7 @@ public class BMSPlayerInputProcessor {
 
 	private boolean exitPressed;
 	private boolean enterPressed;
+	private boolean enterLocked;
 	private boolean deletePressed;
 
 	boolean[] cursor = new boolean[4];
@@ -336,7 +337,17 @@ public class BMSPlayerInputProcessor {
 	}
 
 	public void setEnterPressed(boolean enterPressed) {
-		this.enterPressed = enterPressed;
+		if (!enterPressed || !enterLocked) {
+			this.enterPressed = enterPressed;
+		}
+		if (enterLocked) {
+			enterLocked = false;
+		}
+	}
+
+	public void lockEnterPress() {
+		setEnterPressed(false);
+		enterLocked = true;
 	}
 
 	public boolean isDeletePressed() {

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -8,6 +8,7 @@ import java.nio.file.*;
 import java.util.logging.Logger;
 
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.*;
 import com.badlogic.gdx.utils.ObjectMap.Keys;
 
@@ -281,7 +282,9 @@ public class MusicSelector extends MainState {
 		loadSkin(SkinType.MUSIC_SELECT);
 
 		// search text field
-		if (getStage() == null && ((MusicSelectSkin) getSkin()).getSearchTextRegion() != null) {
+		Rectangle searchRegion = ((MusicSelectSkin) getSkin()).getSearchTextRegion();
+		if (searchRegion != null && (getStage() == null ||
+				(search != null && !searchRegion.equals(search.getSearchBounds())))) {
 			if(search != null) {
 				search.dispose();
 			}

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -351,6 +351,7 @@ public class MusicSelector extends MainState {
 						}
 						preview.stop();
 						main.changeState(MainStateType.DECIDE);
+						search.unfocus(this);
 						banners.disposeOld();
 						stagefiles.disposeOld();
 					} else {
@@ -387,6 +388,7 @@ public class MusicSelector extends MainState {
 					}
 					preview.stop();
 					main.changeState(MainStateType.DECIDE);
+					search.unfocus(this);
 					banners.disposeOld();
 					stagefiles.disposeOld();
 				} else {
@@ -411,6 +413,7 @@ public class MusicSelector extends MainState {
 						if(resource.nextSong()) {
 							preview.stop();
 							main.changeState(MainStateType.DECIDE);
+							search.unfocus(this);
 							banners.disposeOld();
 							stagefiles.disposeOld();
 						}
@@ -427,9 +430,11 @@ public class MusicSelector extends MainState {
 		if (input.getNumberState()[6]) {
 			preview.stop();
 			main.changeState(MainStateType.CONFIG);
+			search.unfocus(this);
 		} else if (input.isActivated(KeyCommand.OPEN_SKIN_CONFIGURATION)) {
 			preview.stop();
 			main.changeState(MainStateType.SKINCONFIG);
+			search.unfocus(this);
 		}
 
 		musicinput.input();
@@ -519,6 +524,7 @@ public class MusicSelector extends MainState {
 			resource.setCourseData(course.getCourseData());
 			resource.setBMSFile(files[0], mode);
 			main.changeState(MainStateType.DECIDE);
+			search.unfocus(this);
 			banners.disposeOld();
 			stagefiles.disposeOld();
 		} else {

--- a/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/src/bms/player/beatoraja/select/SearchTextField.java
@@ -159,4 +159,8 @@ public class SearchTextField extends Stage {
 			searchfont = null;
 		}
 	}
+
+	public Rectangle getSearchBounds() {
+		return new Rectangle(search.getX(), search.getY(), search.getWidth(), search.getHeight());
+	}
 }

--- a/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/src/bms/player/beatoraja/select/SearchTextField.java
@@ -61,6 +61,7 @@ public class SearchTextField extends Stage {
 
 				public void keyTyped(TextField textField, char key) {
 					if (key == '\n' || key == 13) {
+						boolean searched = false;
 						if (textField.getText().length() > 0) {
 							SearchWordBar swb = new SearchWordBar(selector, textField.getText());
 							int count = swb.getChildren().length;
@@ -71,12 +72,16 @@ public class SearchTextField extends Stage {
 								textField.setText("");
 								textField.setMessageText(count + " song(s) found");
 								textFieldStyle.messageFontColor = Color.valueOf("00c0c0");
+								searched = true;
 							} else {
-								selector.main.getInputProcessor().setEnterPressed(false);
 								textField.setText("");
 								textField.setMessageText("no song found");
 								textFieldStyle.messageFontColor = Color.DARK_GRAY;
 							}
+						}
+						if (!searched) {
+							// Enter入力がTextFieldとInputProcessorで2回発生するので、後者のEnter入力を一時的にロックする
+							selector.main.getInputProcessor().lockEnterPress();
 						}
 						textField.getOnscreenKeyboard().show(false);
 						setKeyboardFocus(null);

--- a/src/bms/player/beatoraja/select/SearchTextField.java
+++ b/src/bms/player/beatoraja/select/SearchTextField.java
@@ -15,6 +15,7 @@ import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.scenes.scene2d.*;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField;
 import com.badlogic.gdx.scenes.scene2d.ui.TextField.TextFieldListener;
+import com.badlogic.gdx.scenes.scene2d.utils.ClickListener;
 import com.badlogic.gdx.scenes.scene2d.utils.TextureRegionDrawable;
 import com.badlogic.gdx.utils.GdxRuntimeException;
 import com.badlogic.gdx.utils.viewport.FitViewport;
@@ -35,6 +36,10 @@ public class SearchTextField extends Stage {
 	private BitmapFont searchfont;
 
 	private TextField search;
+	/**
+	 * 画面クリック感知用Actor
+	 */
+	private Group screen;
 
 	public SearchTextField(MusicSelector selector, Resolution resolution) {
 		super(new FitViewport(resolution.width, resolution.height));
@@ -104,7 +109,6 @@ public class SearchTextField extends Stage {
 			search.setBounds(r.x, r.y, r.width, r.height);
 			search.setMaxLength(50);
 			search.setFocusTraversal(false);
-			addActor(search);
 
 			search.setVisible(true);
 			search.addListener(new EventListener() {
@@ -117,9 +121,31 @@ public class SearchTextField extends Stage {
 					return false;
 				}
 			});			
+
+			screen = new Group();
+			screen.setBounds(0, 0, resolution.width, resolution.height);
+			screen.addListener(new ClickListener() {
+				public boolean touchDown(InputEvent event, float x, float y, int pointer, int button) {
+					if (getKeyboardFocus() != null && !r.contains(x, y)) {
+						unfocus(selector);
+					}
+					return false;
+				}
+			});
+			screen.addActor(search);
+			addActor(screen);
 		} catch (GdxRuntimeException e) {
 			Logger.getGlobal().warning("Search Text読み込み失敗");
 		}
+	}
+
+	public void unfocus(MusicSelector selector) {
+		search.setText("");
+		search.setMessageText("search song");
+		search.getStyle().messageFontColor = Color.GRAY;
+		search.getOnscreenKeyboard().show(false);
+		setKeyboardFocus(null);
+		selector.main.getInputProcessor().getKeyBoardInputProcesseor().setEnable(true);
 	}
 
 	public void dispose() {


### PR DESCRIPTION
- 検索窓に空文字が入力された状態でEnterを入力した時に、"検索"と"曲/フォルダ選択"の2回アクションが実行される問題を修正。
- 検索窓にフォーカスしている(カーソルがある)状態で、検索窓の外をクリックするとフォーカスが外れるよう変更。
- 検索窓にフォーカスしている(カーソルがある)状態で、Stateが変わる(画面遷移する)とフォーカスが外れるよう変更。
- 選曲スキンを変更した時に、検索窓の位置が更新されない問題を修正。