### PR TITLE
Fix analog scr setting

### DIFF
--- a/src/bms/player/beatoraja/launcher/ControllerConfigViewModel.java
+++ b/src/bms/player/beatoraja/launcher/ControllerConfigViewModel.java
@@ -1,0 +1,72 @@
+package bms.player.beatoraja.launcher;
+
+import bms.player.beatoraja.PlayModeConfig.ControllerConfig;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+
+/**
+ * ControllerConfig の ViewModel
+ */
+public class ControllerConfigViewModel {
+    private StringProperty nameProperty = new SimpleStringProperty();
+    private BooleanProperty isAnalogScratchProperty = new SimpleBooleanProperty();
+    private ObjectProperty<Integer> analogScratchThresholdProperty = new SimpleIntegerProperty().asObject();
+    private ObjectProperty<Integer> analogScratchModeProperty = new SimpleIntegerProperty().asObject();
+    
+    private ControllerConfig config;
+    
+    public ControllerConfigViewModel(ControllerConfig config) {
+        this.config = config;
+        
+        this.nameProperty.set(config.getName());
+        this.isAnalogScratchProperty.set(config.isAnalogScratch());
+        this.analogScratchThresholdProperty.set(config.getAnalogScratchThreshold());
+        this.analogScratchModeProperty.set(config.getAnalogScratchMode());
+        
+    }
+    
+    public String getName() {
+        return this.nameProperty.get();
+    }
+    public StringProperty getNameProperty() {
+        return nameProperty;
+    }
+
+    public boolean getIsAnalogScratch() {
+        return isAnalogScratchProperty.get();
+    }
+    public void setIsAnalogScratch(boolean isAnalogScratch) {
+        this.isAnalogScratchProperty.set(isAnalogScratch);
+    }
+    public BooleanProperty getIsAnalogScratchProperty() {
+        return isAnalogScratchProperty;
+    }
+
+    public int getAnalogScratchThreshold() {
+        return analogScratchThresholdProperty.get();
+    }
+    public void setAnalogScratchThreshold(Integer analogScratchThreshold) {
+        this.analogScratchThresholdProperty.set(analogScratchThreshold);
+    }
+    public ObjectProperty<Integer> getAnalogScratchThresholdProperty() {
+        return analogScratchThresholdProperty;
+    }
+    
+    public int getAnalogScratchMode() {
+        return this.analogScratchModeProperty.get();
+    }
+    public void setAnalogScratchMode(int analogScratchMode) {
+        this.analogScratchModeProperty.set(analogScratchMode);
+    }
+    public ObjectProperty<Integer> getAnalogScratchModeProperty() {
+        return analogScratchModeProperty;
+    }
+    
+    public ControllerConfig getConfig() {
+        return this.config;
+    }
+}

--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.fxml
@@ -37,29 +37,17 @@
             </HBox.margin>
         </CheckBox>
     </HBox>
-    <HBox prefHeight="37.0" prefWidth="723.0">
+    <HBox prefHeight="150.0" prefWidth="723.0">
         <VBox.margin>
             <Insets left="10.0" top="10.0" />
         </VBox.margin>
-        <CheckBox fx:id="analogScratch" contentDisplay="CENTER" prefHeight="18.0" prefWidth="160.0" text="%ANALOG_SCRATCH" textAlignment="CENTER">
-            <tooltip>
-                <Tooltip text="Use INF controller, is True." textAlignment="CENTER" />
-            </tooltip>
-        </CheckBox>
-        <Label prefHeight="24.0" prefWidth="185.0" text="%ANALOG_SCRATCH_THRESHOLD" />
-        <NumericSpinner fx:id="analogScratchThreshold" editable="true" prefWidth="80.0">
-            <valueFactory>
-                <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="1" initialValue="100" max="100" min="1" />
-            </valueFactory>
-            <HBox.margin>
-                <Insets right="20.0" />
-            </HBox.margin>
-        </NumericSpinner>
-        <Label prefHeight="24.0" prefWidth="185.0" text="%ANALOG_SCRATCH_ALGORITHM" />
-        <ComboBox fx:id="analogScratchMode" prefHeight="18.0" prefWidth="140.0">
-            <tooltip>
-                <Tooltip text="Choose Analog Scratch Algorithm." textAlignment="CENTER" />
-            </tooltip>
-        </ComboBox>
+	    <TableView fx:id="controller_tableView" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
+			<columns>
+				<TableColumn fx:id="nameCol" prefWidth="185.0" text="" />
+				<TableColumn fx:id="isAnalogCol" prefWidth="185.0" text="%ANALOG_SCRATCH" />
+				<TableColumn fx:id="analogThresholdCol" prefWidth="185.0" text="%ANALOG_SCRATCH_THRESHOLD" />
+				<TableColumn fx:id="analogModeCol" prefWidth="185.0" text="%ANALOG_SCRATCH_ALGORITHM" />
+			</columns>
+		</TableView>
     </HBox>
 </VBox>

--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.fxml
@@ -37,12 +37,13 @@
             </HBox.margin>
         </CheckBox>
     </HBox>
-    <HBox prefHeight="150.0" prefWidth="723.0">
+    <HBox prefHeight="74.0" prefWidth="723.0">
         <VBox.margin>
             <Insets left="10.0" top="10.0" />
         </VBox.margin>
 	    <TableView fx:id="controller_tableView" AnchorPane.bottomAnchor="0.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="0.0">
 			<columns>
+				<TableColumn fx:id="playsideCol" prefWidth="40.0" text="" />
 				<TableColumn fx:id="nameCol" prefWidth="185.0" text="" />
 				<TableColumn fx:id="isAnalogCol" prefWidth="185.0" text="%ANALOG_SCRATCH" />
 				<TableColumn fx:id="analogThresholdCol" prefWidth="185.0" text="%ANALOG_SCRATCH_THRESHOLD" />

--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.java
@@ -2,15 +2,36 @@ package bms.player.beatoraja.launcher;
 
 import bms.model.Mode;
 import bms.player.beatoraja.PlayModeConfig;
+import bms.player.beatoraja.PlayModeConfig.ControllerConfig;
 import bms.player.beatoraja.PlayerConfig;
+import javafx.application.Platform;
+import javafx.beans.property.BooleanProperty;
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleBooleanProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.StringProperty;
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Spinner;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.scene.control.cell.CheckBoxTableCell;
+import javafx.scene.control.cell.ComboBoxTableCell;
+import javafx.scene.control.cell.TextFieldTableCell;
+import javafx.scene.input.KeyCode;
+import javafx.util.converter.IntegerStringConverter;
 
 import java.net.URL;
+import java.util.Arrays;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 public class InputConfigurationView implements Initializable {
 
@@ -24,20 +45,83 @@ public class InputConfigurationView implements Initializable {
     @FXML
     private CheckBox jkoc_hack;
     @FXML
-    private CheckBox analogScratch;
+    private TableView<ControllerConfigViewModel> controller_tableView;
     @FXML
-    private ComboBox<Integer> analogScratchMode;
+    private TableColumn<ControllerConfigViewModel, String> nameCol;
     @FXML
-    private NumericSpinner<Integer> analogScratchThreshold;
+    private TableColumn<ControllerConfigViewModel, Boolean> isAnalogCol;
+    @FXML
+    private TableColumn<ControllerConfigViewModel, Integer> analogThresholdCol;
+    @FXML
+    private TableColumn<ControllerConfigViewModel, Integer> analogModeCol;
 
     private PlayerConfig player;
 
     private PlayConfigurationView.PlayMode mode;
+    
+    public class ControllerConfigViewModel {
+	private StringProperty nameProperty = new SimpleStringProperty();
+	private BooleanProperty isAnalogScratchProperty = new SimpleBooleanProperty();
+	private ObjectProperty<Integer> analogScratchThresholdProperty = new SimpleIntegerProperty().asObject();
+	private ObjectProperty<Integer> analogScratchModeProperty = new SimpleIntegerProperty().asObject();
+	
+	private ControllerConfig config;
+	
+	public ControllerConfigViewModel(ControllerConfig config) {
+	    this.config = config;
+	    
+	    this.nameProperty.set(config.getName());
+	    this.isAnalogScratchProperty.set(config.isAnalogScratch());
+	    this.analogScratchThresholdProperty.set(config.getAnalogScratchThreshold());
+	    this.analogScratchModeProperty.set(config.getAnalogScratchMode());
+	    
+	}
+	
+	public String getName() {
+	    return this.nameProperty.get();
+	}
+	public StringProperty getNameProperty() {
+	    return nameProperty;
+	}
+
+	public boolean getIsAnalogScratch() {
+	    return isAnalogScratchProperty.get();
+	}
+	public void setIsAnalogScratch(boolean isAnalogScratch) {
+	    this.isAnalogScratchProperty.set(isAnalogScratch);
+	}
+	public BooleanProperty getIsAnalogScratchProperty() {
+	    return isAnalogScratchProperty;
+	}
+
+	public int getAnalogScratchThreshold() {
+	    return analogScratchThresholdProperty.get();
+	}
+	public void setAnalogScratchThreshold(Integer analogScratchThreshold) {
+	    this.analogScratchThresholdProperty.set(analogScratchThreshold);
+	}
+	public ObjectProperty<Integer> getAnalogScratchThresholdProperty() {
+	    return analogScratchThresholdProperty;
+	}
+	
+	public int getAnalogScratchMode() {
+	    return this.analogScratchModeProperty.get();
+	}
+	public void setAnalogScratchMode(int analogScratchMode) {
+	    this.analogScratchModeProperty.set(analogScratchMode);
+	}
+	public ObjectProperty<Integer> getAnalogScratchModeProperty() {
+	    return analogScratchModeProperty;
+	}
+	
+	public ControllerConfig getConfig() {
+	    return this.config;
+	}
+    }
 
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         inputconfig.getItems().setAll(PlayConfigurationView.PlayMode.values());
-        PlayConfigurationView.initComboBox(analogScratchMode, new String[] { "Ver. 2 (Newest)", "Ver. 1 (~0.6.9)" });
     }
 
     @FXML
@@ -58,29 +142,124 @@ public class InputConfigurationView implements Initializable {
     }
 
     public void updateMode(PlayConfigurationView.PlayMode mode) {
-        this.mode = mode;
-        PlayModeConfig conf = player.getPlayConfig(Mode.valueOf(mode.name()));
-        inputduration.getValueFactory().setValue(conf.getKeyboardConfig().getDuration());
-        for(PlayModeConfig.ControllerConfig controller : conf.getController()) {
-            inputduration.getValueFactory().setValue(controller.getDuration());
-            jkoc_hack.setSelected(controller.getJKOC());
-            analogScratch.setSelected(controller.isAnalogScratch());
-            analogScratchMode.getSelectionModel().select(controller.getAnalogScratchMode());
-            analogScratchThreshold.getValueFactory().setValue(controller.getAnalogScratchThreshold());
-        }
+	this.mode = mode;
+	PlayModeConfig conf = player.getPlayConfig(Mode.valueOf(mode.name()));
+	inputduration.getValueFactory().setValue(conf.getKeyboardConfig().getDuration());
+	controller_tableView.setEditable(true);
+	nameCol.setEditable(false);
+	nameCol.setSortable(false);
+	isAnalogCol.setSortable(false);
+	analogThresholdCol.setSortable(false);
+	analogModeCol.setSortable(false);
 
+	nameCol.setCellValueFactory(col -> col.getValue().getNameProperty());
+	isAnalogCol.setCellValueFactory(col -> col.getValue().getIsAnalogScratchProperty());
+	analogThresholdCol.setCellValueFactory(col -> col.getValue().getAnalogScratchThresholdProperty());
+	analogModeCol.setCellValueFactory(col -> col.getValue().getAnalogScratchModeProperty());
+
+	nameCol.setCellFactory(TextFieldTableCell.forTableColumn());
+	isAnalogCol.setCellFactory(CheckBoxTableCell.forTableColumn(isAnalogCol));
+	analogThresholdCol.setCellFactory(col -> new SpinnerCell(1, 100, 100, 1));
+	analogModeCol.setCellFactory(ComboBoxTableCell.forTableColumn(new IntegerStringConverter() {
+	    @Override
+	    public Integer fromString(String arg0) {
+		if (arg0 == "Ver. 2 (Newest)") {
+		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2;
+		} else {
+		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_1;
+		}
+	    }
+
+	    @Override
+	    public String toString(Integer arg0) {
+		if (arg0 == PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2) {
+		    return "Ver. 2 (Newest)";
+		} else {
+		    return "Ver. 1 (~0.6.9)";
+		}
+	    }
+	}, PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2, PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_1));
+
+	ObservableList<ControllerConfigViewModel> data = FXCollections
+		.observableArrayList(Arrays.asList(conf.getController()).stream()
+			.map(config -> new ControllerConfigViewModel(config)).collect(Collectors.toList()));
+
+	controller_tableView.setItems(data);
+
+	for (PlayModeConfig.ControllerConfig controller : conf.getController()) {
+	    inputduration.getValueFactory().setValue(controller.getDuration());
+	    jkoc_hack.setSelected(controller.getJKOC());
+	}
+
+    }
+    
+    private final class SpinnerCell extends TableCell<ControllerConfigViewModel, Integer> {
+	private final NumericSpinner<Integer> spinner;
+
+	private SpinnerCell(int min, int max, int initial, int step) {
+	    spinner = new NumericSpinner<>();
+	    spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(min, max, initial, step));
+	    setEditable(true);
+	}
+
+	@Override
+	public void startEdit() {
+	    if (!isEmpty()) {
+		super.startEdit();
+		spinner.getValueFactory().setValue(getItem());
+
+		setOnKeyPressed(event -> {
+		    if (event.getCode() == KeyCode.ENTER) {
+			Platform.runLater(() -> {
+			    commitEdit(spinner.getValue());
+			});
+		    }
+		});
+
+		setText(null);
+		setGraphic(spinner);
+	    }
+	}
+
+	@Override
+	public void cancelEdit() {
+	    super.cancelEdit();
+
+	    setText(getItem().toString());
+	    setGraphic(null);
+	}
+
+	@Override
+	public void updateItem(Integer item, boolean empty) {
+	    super.updateItem(item, empty);
+
+	    if (empty) {
+		setText(null);
+		setGraphic(null);
+	    } else {
+		if (isEditing()) {
+		    setText(null);
+		    setGraphic(spinner);
+		} else {
+		    setText(getItem().toString());
+		    setGraphic(null);
+		}
+	    }
+	}
     }
 
     public void commitMode() {
         if (mode != null) {
             PlayModeConfig conf = player.getPlayConfig(Mode.valueOf(mode.name()));
             conf.getKeyboardConfig().setDuration(inputduration.getValue());
-            for(PlayModeConfig.ControllerConfig controller : conf.getController()) {
-                controller.setDuration(inputduration.getValue());
+            
+            for(ControllerConfigViewModel vm : this.controller_tableView.getItems()) {
+        	PlayModeConfig.ControllerConfig controller = vm.getConfig();
+        	controller.setDuration(inputduration.getValue());
                 controller.setJKOC(jkoc_hack.isSelected());
-                controller.setAnalogScratch(analogScratch.isSelected());
-                controller.setAnalogScratchThreshold(analogScratchThreshold.getValue());
-                controller.setAnalogScratchMode(analogScratchMode.getValue());
+                controller.setAnalogScratch(vm.getIsAnalogScratchProperty().get());
+                controller.setAnalogScratchThreshold(vm.getAnalogScratchThreshold());
+                controller.setAnalogScratchMode(vm.getAnalogScratchMode());
             }
         }
     }

--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.java
@@ -2,15 +2,8 @@ package bms.player.beatoraja.launcher;
 
 import bms.model.Mode;
 import bms.player.beatoraja.PlayModeConfig;
-import bms.player.beatoraja.PlayModeConfig.ControllerConfig;
 import bms.player.beatoraja.PlayerConfig;
-import javafx.application.Platform;
-import javafx.beans.property.BooleanProperty;
-import javafx.beans.property.ObjectProperty;
-import javafx.beans.property.SimpleBooleanProperty;
-import javafx.beans.property.SimpleIntegerProperty;
 import javafx.beans.property.SimpleStringProperty;
-import javafx.beans.property.StringProperty;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -18,18 +11,16 @@ import javafx.fxml.Initializable;
 import javafx.scene.control.CheckBox;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.Spinner;
-import javafx.scene.control.SpinnerValueFactory;
-import javafx.scene.control.TableCell;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableView;
 import javafx.scene.control.cell.CheckBoxTableCell;
 import javafx.scene.control.cell.ComboBoxTableCell;
 import javafx.scene.control.cell.TextFieldTableCell;
-import javafx.scene.input.KeyCode;
 import javafx.util.converter.IntegerStringConverter;
 
 import java.net.URL;
 import java.util.Arrays;
+import java.util.List;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
@@ -47,6 +38,8 @@ public class InputConfigurationView implements Initializable {
     @FXML
     private TableView<ControllerConfigViewModel> controller_tableView;
     @FXML
+    private TableColumn<ControllerConfigViewModel, String> playsideCol;
+    @FXML
     private TableColumn<ControllerConfigViewModel, String> nameCol;
     @FXML
     private TableColumn<ControllerConfigViewModel, Boolean> isAnalogCol;
@@ -59,66 +52,6 @@ public class InputConfigurationView implements Initializable {
 
     private PlayConfigurationView.PlayMode mode;
     
-    public class ControllerConfigViewModel {
-	private StringProperty nameProperty = new SimpleStringProperty();
-	private BooleanProperty isAnalogScratchProperty = new SimpleBooleanProperty();
-	private ObjectProperty<Integer> analogScratchThresholdProperty = new SimpleIntegerProperty().asObject();
-	private ObjectProperty<Integer> analogScratchModeProperty = new SimpleIntegerProperty().asObject();
-	
-	private ControllerConfig config;
-	
-	public ControllerConfigViewModel(ControllerConfig config) {
-	    this.config = config;
-	    
-	    this.nameProperty.set(config.getName());
-	    this.isAnalogScratchProperty.set(config.isAnalogScratch());
-	    this.analogScratchThresholdProperty.set(config.getAnalogScratchThreshold());
-	    this.analogScratchModeProperty.set(config.getAnalogScratchMode());
-	    
-	}
-	
-	public String getName() {
-	    return this.nameProperty.get();
-	}
-	public StringProperty getNameProperty() {
-	    return nameProperty;
-	}
-
-	public boolean getIsAnalogScratch() {
-	    return isAnalogScratchProperty.get();
-	}
-	public void setIsAnalogScratch(boolean isAnalogScratch) {
-	    this.isAnalogScratchProperty.set(isAnalogScratch);
-	}
-	public BooleanProperty getIsAnalogScratchProperty() {
-	    return isAnalogScratchProperty;
-	}
-
-	public int getAnalogScratchThreshold() {
-	    return analogScratchThresholdProperty.get();
-	}
-	public void setAnalogScratchThreshold(Integer analogScratchThreshold) {
-	    this.analogScratchThresholdProperty.set(analogScratchThreshold);
-	}
-	public ObjectProperty<Integer> getAnalogScratchThresholdProperty() {
-	    return analogScratchThresholdProperty;
-	}
-	
-	public int getAnalogScratchMode() {
-	    return this.analogScratchModeProperty.get();
-	}
-	public void setAnalogScratchMode(int analogScratchMode) {
-	    this.analogScratchModeProperty.set(analogScratchMode);
-	}
-	public ObjectProperty<Integer> getAnalogScratchModeProperty() {
-	    return analogScratchModeProperty;
-	}
-	
-	public ControllerConfig getConfig() {
-	    return this.config;
-	}
-    }
-
     @Override
     public void initialize(URL location, ResourceBundle resources) {
         inputconfig.getItems().setAll(PlayConfigurationView.PlayMode.values());
@@ -144,14 +77,23 @@ public class InputConfigurationView implements Initializable {
     public void updateMode(PlayConfigurationView.PlayMode mode) {
 	this.mode = mode;
 	PlayModeConfig conf = player.getPlayConfig(Mode.valueOf(mode.name()));
+	List<ControllerConfigViewModel> listControllerConfigViewModel = Arrays.asList(conf.getController()).stream()
+		.map(config -> new ControllerConfigViewModel(config)).collect(Collectors.toList());
+	
 	inputduration.getValueFactory().setValue(conf.getKeyboardConfig().getDuration());
 	controller_tableView.setEditable(true);
+	playsideCol.setEditable(false);
 	nameCol.setEditable(false);
+	playsideCol.setSortable(false);
 	nameCol.setSortable(false);
 	isAnalogCol.setSortable(false);
 	analogThresholdCol.setSortable(false);
 	analogModeCol.setSortable(false);
 
+	// Display "1P" or "2P"
+	playsideCol.setCellValueFactory(col -> new SimpleStringProperty(col != null && col.getValue() != null
+		? Integer.toString(listControllerConfigViewModel.indexOf(col.getValue()) + 1) + "P"
+		: ""));
 	nameCol.setCellValueFactory(col -> col.getValue().getNameProperty());
 	isAnalogCol.setCellValueFactory(col -> col.getValue().getIsAnalogScratchProperty());
 	analogThresholdCol.setCellValueFactory(col -> col.getValue().getAnalogScratchThresholdProperty());
@@ -161,9 +103,12 @@ public class InputConfigurationView implements Initializable {
 	isAnalogCol.setCellFactory(CheckBoxTableCell.forTableColumn(isAnalogCol));
 	analogThresholdCol.setCellFactory(col -> new SpinnerCell(1, 100, 100, 1));
 	analogModeCol.setCellFactory(ComboBoxTableCell.forTableColumn(new IntegerStringConverter() {
+	    private String v2String = "Ver. 2 (Newest)";
+	    private String v1String = "Ver. 1 (~0.6.9)";
+	    
 	    @Override
 	    public Integer fromString(String arg0) {
-		if (arg0 == "Ver. 2 (Newest)") {
+		if (arg0 == v2String) {
 		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2;
 		} else {
 		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_1;
@@ -173,16 +118,15 @@ public class InputConfigurationView implements Initializable {
 	    @Override
 	    public String toString(Integer arg0) {
 		if (arg0 == PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2) {
-		    return "Ver. 2 (Newest)";
+		    return v2String;
 		} else {
-		    return "Ver. 1 (~0.6.9)";
+		    return v1String;
 		}
 	    }
 	}, PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2, PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_1));
 
 	ObservableList<ControllerConfigViewModel> data = FXCollections
-		.observableArrayList(Arrays.asList(conf.getController()).stream()
-			.map(config -> new ControllerConfigViewModel(config)).collect(Collectors.toList()));
+		.observableArrayList(listControllerConfigViewModel);
 
 	controller_tableView.setItems(data);
 
@@ -193,61 +137,6 @@ public class InputConfigurationView implements Initializable {
 
     }
     
-    private final class SpinnerCell extends TableCell<ControllerConfigViewModel, Integer> {
-	private final NumericSpinner<Integer> spinner;
-
-	private SpinnerCell(int min, int max, int initial, int step) {
-	    spinner = new NumericSpinner<>();
-	    spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(min, max, initial, step));
-	    setEditable(true);
-	}
-
-	@Override
-	public void startEdit() {
-	    if (!isEmpty()) {
-		super.startEdit();
-		spinner.getValueFactory().setValue(getItem());
-
-		setOnKeyPressed(event -> {
-		    if (event.getCode() == KeyCode.ENTER) {
-			Platform.runLater(() -> {
-			    commitEdit(spinner.getValue());
-			});
-		    }
-		});
-
-		setText(null);
-		setGraphic(spinner);
-	    }
-	}
-
-	@Override
-	public void cancelEdit() {
-	    super.cancelEdit();
-
-	    setText(getItem().toString());
-	    setGraphic(null);
-	}
-
-	@Override
-	public void updateItem(Integer item, boolean empty) {
-	    super.updateItem(item, empty);
-
-	    if (empty) {
-		setText(null);
-		setGraphic(null);
-	    } else {
-		if (isEditing()) {
-		    setText(null);
-		    setGraphic(spinner);
-		} else {
-		    setText(getItem().toString());
-		    setGraphic(null);
-		}
-	    }
-	}
-    }
-
     public void commitMode() {
         if (mode != null) {
             PlayModeConfig conf = player.getPlayConfig(Mode.valueOf(mode.name()));

--- a/src/bms/player/beatoraja/launcher/SpinnerCell.java
+++ b/src/bms/player/beatoraja/launcher/SpinnerCell.java
@@ -1,0 +1,64 @@
+package bms.player.beatoraja.launcher;
+
+import javafx.application.Platform;
+import javafx.scene.control.SpinnerValueFactory;
+import javafx.scene.control.TableCell;
+import javafx.scene.input.KeyCode;
+
+/**
+ * TableCell用 NumericSpinner
+ */
+public final class SpinnerCell extends TableCell<ControllerConfigViewModel, Integer> {
+    private final NumericSpinner<Integer> spinner;
+
+    SpinnerCell(int min, int max, int initial, int step) {
+        spinner = new NumericSpinner<>();
+        spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(min, max, initial, step));
+        setEditable(true);
+    }
+
+    @Override
+    public void startEdit() {
+        if (!isEmpty()) {
+    	super.startEdit();
+    	spinner.getValueFactory().setValue(getItem());
+
+    	setOnKeyPressed(event -> {
+    	    if (event.getCode() == KeyCode.ENTER) {
+    		Platform.runLater(() -> {
+    		    commitEdit(spinner.getValue());
+    		});
+    	    }
+    	});
+
+    	setText(null);
+    	setGraphic(spinner);
+        }
+    }
+
+    @Override
+    public void cancelEdit() {
+        super.cancelEdit();
+
+        setText(getItem().toString());
+        setGraphic(null);
+    }
+
+    @Override
+    public void updateItem(Integer item, boolean empty) {
+        super.updateItem(item, empty);
+
+        if (empty) {
+    	setText(null);
+    	setGraphic(null);
+        } else {
+    	if (isEditing()) {
+    	    setText(null);
+    	    setGraphic(spinner);
+    	} else {
+    	    setText(getItem().toString());
+    	    setGraphic(null);
+    	}
+        }
+    }
+}


### PR DESCRIPTION
プレイサイドごと（コントローラーごと）にスクラッチ周りの設定をできるようにしました。

![image](https://user-images.githubusercontent.com/20876249/74353066-be6af780-4dfc-11ea-8c21-62e3fff39ba3.png)


### 懸案事項
#### プレイサイドで個別に設定を持つので、同じデバイスを使う場合、設定が展開されないので少し面倒
例：14KEYでアナログスクラッチを設定した場合、10KEYの同じデバイスにアナログスクラッチの設定が展開されない
