### PR TITLE
Add constantText to SkinText

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -30,6 +30,7 @@ public abstract class SkinText extends SkinObject {
     private final StringProperty ref;
     
     private String text = "";
+    private String constantText;
 
     private boolean editable;
 
@@ -71,13 +72,17 @@ public abstract class SkinText extends SkinObject {
         prepareText(text);
     }
 
+    public void setConstantText(String constantText) {
+        this.constantText = constantText;
+    }
+
     public abstract void prepareFont(String text);
 
     protected abstract void prepareText(String text);
     
     public void prepare(long time, MainState state) {
     	super.prepare(time, state);
-        currentText = ref != null ? ref.get(state) : null;
+        currentText = ref != null ? ref.get(state) : (constantText != null ? constantText : null);
         if(currentText == null || currentText.length() == 0) {
         	draw = false;
             return;

--- a/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JSONSkinLoader.java
@@ -1400,6 +1400,7 @@ public class JSONSkinLoader extends SkinLoader {
 				} else {
 					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, property);
 				}
+				skinText.setConstantText(text.constantText);
 				skinText.setAlign(text.align);
 				skinText.setWrapping(text.wrapping);
 				skinText.setOverflow(text.overflow);

--- a/src/bms/player/beatoraja/skin/json/JsonSkin.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkin.java
@@ -143,6 +143,7 @@ public class JsonSkin {
 		public int align;
 		public int ref;
 		public StringProperty value;
+		public String constantText;
 		public boolean wrapping = false;
 		public int overflow = SkinText.OVERFLOW_OVERFLOW;
 		public String outlineColor = "ffffff00";


### PR DESCRIPTION
json、luaスキンのtext定義にconstantTextパラメータを追加
- String型
- 任意の文字列を指定可能
- refパラメータが指定されている場合はrefが優先され、constantTextは無視される

意図
- 画像を用意するほどでもない簡単な任意のテキストをtext定義だけで作れるようになります