### PR TITLE
Change NUMBER_MAXSCORE to getNotes() * 2

### DIFF
--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -240,7 +240,7 @@ public class IntegerPropertyFactory {
 			return (state) -> (state.getScoreDataProperty().getNowScore());
 		case NUMBER_MAXSCORE:
 			return (state) -> (state.getScoreDataProperty().getScoreData() != null
-					? state.getScoreDataProperty().getScoreData().getNotes()
+					? state.getScoreDataProperty().getScoreData().getNotes() * 2
 					: 0);
 		case NUMBER_DIFF_NEXTRANK:
 			return (state) -> (state.getScoreDataProperty().getNextRank());


### PR DESCRIPTION
I think the skin property NUMBER_MAXSCORE should be `getNotes() * 2`
Please review this change. If this is wrong, reject this pull request.