### PR TITLE
Change primarykey of  songdata.db song table

### DIFF
--- a/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -77,13 +77,13 @@ public class SQLiteSongDatabaseAccessor implements SongDatabaseAccessor {
 			}
 
 			if(qr.query("SELECT * FROM sqlite_master WHERE name = 'song' AND sql LIKE '%preview%'", new MapListHandler()).size() == 0) {
-				qr.update("ALTER TABLE song ADD COLUMN preview [TEXT]");
+				qr.update("ALTER TABLE song ADD COLUMN [preview] TEXT");
 			}
 			if(qr.query("SELECT * FROM sqlite_master WHERE name = 'song' AND sql LIKE '%length%'", new MapListHandler()).size() == 0) {
-				qr.update("ALTER TABLE song ADD COLUMN length [INTEGER]");
+				qr.update("ALTER TABLE song ADD COLUMN [length] INTEGER");
 			}
 			if(qr.query("SELECT * FROM sqlite_master WHERE name = 'song' AND sql LIKE '%charthash%'", new MapListHandler()).size() == 0) {
-				qr.update("ALTER TABLE song ADD COLUMN charthash [TEXT]");
+				qr.update("ALTER TABLE song ADD COLUMN [charthash] TEXT");
 			}
 
 			if (qr.query("SELECT * FROM sqlite_master WHERE name = ? and type='table';", new MapListHandler(), "folder")

--- a/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -99,7 +99,7 @@ public class SQLiteSongDatabaseAccessor implements SongDatabaseAccessor {
 						+ "folder, stagefile, banner, backbmp, preview, parent, level, difficulty,"
 						+ "maxbpm, minbpm, length, mode, judge, feature, content,"
 						+ "date, favorite, notes, adddate, charthash "
-						+ "FROM old_song GROUP BY path HAVING MAX(date)");
+						+ "FROM old_song GROUP BY path HAVING MAX(adddate)");
 				qr.update("DROP TABLE old_song");
 			}
 


### PR DESCRIPTION
songdata.dbのsongテーブルのprimary keyをpathのみに変更

### 目的
pathが同じまま譜面内容を更新した(sha256が変わった)場合に、songテーブルのprimary keyが`sha256`と`path`の2つであることで、楽曲更新時に`INSERT OR REPLACE`のREPLACE処理が実行されず、同じpathで異なるsha256を持つレコード2つが同時に存在できてしまっていた。

songテーブルの`sha256`カラムがprimary keyである必要はないので、楽曲更新時のREPLACEを正しく実行させるために、songテーブルのprimary keyを`path`のみに変更した。