### PR TITLE
Fix SkinBPMGraph lastTime

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinBPMGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinBPMGraph.java
@@ -175,6 +175,10 @@ public class SkinBPMGraph extends SkinObject {
 			shape = new Pixmap(width, height, Pixmap.Format.RGBA8888);
 
 			int lastTime = (int) (data[data.length - 1][1] + 1000);
+			final SongData song = state.main.getPlayerResource().getSongdata();
+			if (song != null && song.getLength() < data[data.length - 1][1]) {
+				lastTime = song.getLength() + 1000;
+			}
 
 			// グラフ描画
 			int x1,x2,y1,y2;

--- a/src/bms/player/beatoraja/skin/SkinBPMGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinBPMGraph.java
@@ -174,11 +174,12 @@ public class SkinBPMGraph extends SkinObject {
 			final int height = (int) Math.abs(region.height);
 			shape = new Pixmap(width, height, Pixmap.Format.RGBA8888);
 
-			int lastTime = (int) (data[data.length - 1][1] + 1000);
+			int lastTime = (int) data[data.length - 1][1];
 			final SongData song = state.main.getPlayerResource().getSongdata();
-			if (song != null && song.getLength() < data[data.length - 1][1]) {
-				lastTime = song.getLength() + 1000;
+			if (song != null && song.getLength() < lastTime) {
+				lastTime = song.getLength();
 			}
+			lastTime += 1000;
 
 			// グラフ描画
 			int x1,x2,y1,y2;


### PR DESCRIPTION
最終ノーツ後にBPMオブジェが配置されている譜面で、BPMグラフとノーツ分布グラフの長さが同期されず、正常に表示されない問題を修正。

例: Andro [ANOTHER]
before
![image](https://user-images.githubusercontent.com/38182044/91564548-bd09b280-e97b-11ea-817e-4d43b1a04b5c.png)
after
![image](https://user-images.githubusercontent.com/38182044/91564401-8af85080-e97b-11ea-84c1-f6e38515e488.png)
