### PR TITLE
Fix NPE in MusicSelector

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -531,7 +531,9 @@ public class MusicSelector extends MainState {
 	void changeState(MainStateType type) {
 		preview.stop();
 		main.changeState(type);
-		search.unfocus(this);
+		if (search != null) {
+			search.unfocus(this);
+		}
 		banners.disposeOld();
 		stagefiles.disposeOld();
 	}


### PR DESCRIPTION
曲検索フィールドが無い選曲スキンを使用中に、選曲画面からスキン選択画面などの別ステートに遷移すると、NPEが発生するバグを修正