### PR TITLE
Fix bga extension complement

### DIFF
--- a/src/bms/player/beatoraja/play/bga/BGAProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGAProcessor.java
@@ -165,11 +165,13 @@ public class BGAProcessor {
 								break;
 							}
 						}
-						for (String mov : BGImageProcessor.pic_extension) {
-							final Path picfile = dpath.resolve(name + "." + mov);
-							if (Files.exists(picfile)) {
-								f = picfile;
-								break;
+						if (f == null) {
+							for (String mov : BGImageProcessor.pic_extension) {
+								final Path picfile = dpath.resolve(name + "." + mov);
+								if (Files.exists(picfile)) {
+									f = picfile;
+									break;
+								}
 							}
 						}
 					}


### PR DESCRIPTION
#BMPxxで定義されているファイル名と一致する動画ファイルが存在しなかった場合の拡張子補完で、優先順位が画像拡張子>動画拡張子だったのを動画拡張子>画像拡張子になるよう修正。

例: 定義がbga.mpgで同梱がbga.mp4とbga.pngの場合
- 変更前: bga.pngが使用される
- 変更後: bga.mp4が使用される