### PR TITLE
[BugFix] Fixed a bug that prevented you from changing the green value in the song selection screen

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelectCommand.java
+++ b/src/bms/player/beatoraja/select/MusicSelectCommand.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import bms.player.beatoraja.PlayConfig;
+import bms.player.beatoraja.PlayModeConfig;
 import bms.player.beatoraja.PlayerConfig;
 import bms.player.beatoraja.PlayerInformation;
 import bms.player.beatoraja.ir.IRChartData;
@@ -545,7 +546,9 @@ public enum MusicSelectCommand {
     DURATION_UP {
 		@Override
 		public void execute(MusicSelector selector) {
-            PlayConfig pc = selector.getSelectedBarPlayConfig();
+	    final PlayerConfig config = selector.main.getPlayerConfig();
+	    PlayModeConfig pmc = config.getPlayConfig(config.getMode());
+	    PlayConfig pc = pmc.getPlayconfig();
             if (pc != null && pc.getDuration() < 5000) {
                 pc.setDuration(pc.getDuration() + 1);
                 selector.play(SOUND_OPTIONCHANGE);
@@ -555,7 +558,9 @@ public enum MusicSelectCommand {
     DURATION_DOWN {
 		@Override
 		public void execute(MusicSelector selector) {
-            PlayConfig pc = selector.getSelectedBarPlayConfig();
+	    final PlayerConfig config = selector.main.getPlayerConfig();
+	    PlayModeConfig pmc = config.getPlayConfig(config.getMode());
+	    PlayConfig pc = pmc.getPlayconfig();
             if (pc != null && pc.getDuration() > 1) {
                 pc.setDuration(pc.getDuration() - 1);
                 selector.play(SOUND_OPTIONCHANGE);
@@ -565,7 +570,9 @@ public enum MusicSelectCommand {
     DURATION_UP_LARGE {
         @Override
         public void execute(MusicSelector selector) {
-            PlayConfig pc = selector.getSelectedBarPlayConfig();
+	    final PlayerConfig config = selector.main.getPlayerConfig();
+	    PlayModeConfig pmc = config.getPlayConfig(config.getMode());
+	    PlayConfig pc = pmc.getPlayconfig();
             if (pc != null && pc.getDuration() < 5000) {
                 int duration = pc.getDuration() + 10;
                 pc.setDuration(duration - duration % 10);
@@ -576,7 +583,9 @@ public enum MusicSelectCommand {
     DURATION_DOWN_LARGE {
         @Override
         public void execute(MusicSelector selector) {
-            PlayConfig pc = selector.getSelectedBarPlayConfig();
+	    final PlayerConfig config = selector.main.getPlayerConfig();
+	    PlayModeConfig pmc = config.getPlayConfig(config.getMode());
+	    PlayConfig pc = pmc.getPlayconfig();
             if (pc != null && pc.getDuration() > 10) {
                 int duration = pc.getDuration() - 10;
                 pc.setDuration(duration - duration % 10);


### PR DESCRIPTION
選曲画面で START + SELECT を押すと、4鍵と6鍵で緑数値を下げる/上げる機能があると思います
今のバージョンではそれがうまく動いていないようでした
正直なところ、beatoraja のソースはまだ見始めたばかりでこれが正しい修正なのかは分かりません（とりあえずこれで直った、レベルです。すいません）
もっといい修正方法等あれば教えてください
よろしくおねがいします