### PR TITLE
Add : quickretry (クイックリトライ機能の追加)

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -678,6 +678,22 @@ public class BMSPlayer extends MainState {
 				input.setStartTime(0);
 				if (autoplay == PlayMode.PRACTICE) {
 					state = STATE_PRACTICE;
+				} else if ((input.startPressed() ^ input.isSelectPressed())
+						&& resource.getCourseBMSModels() == null
+						&& !autoplay.isAutoPlayMode()){
+					main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
+					if (!resource.isUpdateScore()) {
+						resource.getReplayData().pattern = null;
+						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+					} else if (input.startPressed()){
+						resource.getReplayData().pattern = null;
+						Logger.getGlobal().info("オプションを変更せずリプレイ");
+					} else {
+						resource.setScoreData(createScoreData());
+						Logger.getGlobal().info("同じ譜面でリプレイ");
+					}
+					resource.reloadBMSFile();
+					main.changeState(MainStateType.PLAY);
 				} else if (resource.getScoreData() != null) {
 					main.changeState(MainStateType.RESULT);
 				} else {

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -680,16 +680,15 @@ public class BMSPlayer extends MainState {
 					state = STATE_PRACTICE;
 				} else if ((input.startPressed() ^ input.isSelectPressed())
 						&& resource.getCourseBMSModels() == null
-						&& !autoplay.isAutoPlayMode()){
+						&& !autoplay.isAutoPlayMode()) {
 					main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
 					if (!resource.isUpdateScore()) {
 						resource.getReplayData().pattern = null;
 						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
-					} else if (input.startPressed()){
+					} else if (input.startPressed()) {
 						resource.getReplayData().pattern = null;
 						Logger.getGlobal().info("オプションを変更せずリプレイ");
 					} else {
-						resource.setScoreData(createScoreData());
 						Logger.getGlobal().info("同じ譜面でリプレイ");
 					}
 					resource.reloadBMSFile();

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -240,7 +240,7 @@ public class BMSPlayer extends MainState {
 			PatternModifier.modify(model, pattern);
 			Logger.getGlobal().info("譜面オプション : 保存された譜面変更ログから譜面再現");
 		} else if (autoplay != PlayMode.PRACTICE) {
-			
+
 			Array<PatternModifier> mods = new Array<PatternModifier>();
 			// DP譜面オプション
 			if(model.getMode().player == 2) {
@@ -283,7 +283,7 @@ public class BMSPlayer extends MainState {
 					Logger.getGlobal().info("アシスト譜面オプションが選択されました");
 					assist = Math.max(assist, mod.getAssistLevel() == PatternModifier.AssistLevel.ASSIST ? 2 : 1);
 					score = false;
-				}				
+				}
 			}
 
 		}
@@ -353,10 +353,10 @@ public class BMSPlayer extends MainState {
 				if(paths.length > 0) {
 					main.getAudioProcessor().setAdditionalKeySound(i, true, paths[0].toString());
 					main.getAudioProcessor().setAdditionalKeySound(i, false, paths[0].toString());
-				}				
+				}
 			} else {
 				main.getAudioProcessor().setAdditionalKeySound(i, true, null);
-				main.getAudioProcessor().setAdditionalKeySound(i, false, null);								
+				main.getAudioProcessor().setAdditionalKeySound(i, false, null);
 			}
 		}
 
@@ -376,7 +376,7 @@ public class BMSPlayer extends MainState {
 
 		judge.init(model, resource);
 
-		rhythm = new RhythmTimerProcessor(model, 
+		rhythm = new RhythmTimerProcessor(model,
 				(getSkin() instanceof PlaySkin) ? ((PlaySkin) getSkin()).getNoteExpansionRate()[0] != 100 || ((PlaySkin) getSkin()).getNoteExpansionRate()[1] != 100 : false);
 
 		bga = resource.getBGAManager();
@@ -652,8 +652,21 @@ public class BMSPlayer extends MainState {
 		case STATE_FAILED:
 			keyinput.stopJudge();
 			keysound.stopBGPlay();
-
-			if (main.getNowTime(TIMER_FAILED) > skin.getClose()) {
+			if ((input.startPressed() ^ input.isSelectPressed())
+					&& resource.getCourseBMSModels() == null
+					&& !autoplay.isAutoPlayMode()
+					&& autoplay != PlayMode.PRACTICE) {
+				if (!resource.isUpdateScore()) {
+					Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+				} else if (input.startPressed()) {
+					Logger.getGlobal().info("オプションを変更せずリプレイ");
+				} else {
+					resource.setScoreData(createScoreData());
+					Logger.getGlobal().info("同じ譜面でリプレイ");
+				}
+				resource.reloadBMSFile();
+				main.changeState(MainStateType.PLAY);
+			} else if (main.getNowTime(TIMER_FAILED) > skin.getClose()) {
 				main.getAudioProcessor().setGlobalPitch(1f);
 				if (resource.mediaLoadFinished()) {
 					resource.getBGAManager().stop();
@@ -678,21 +691,6 @@ public class BMSPlayer extends MainState {
 				input.setStartTime(0);
 				if (autoplay == PlayMode.PRACTICE) {
 					state = STATE_PRACTICE;
-				} else if ((input.startPressed() ^ input.isSelectPressed())
-						&& resource.getCourseBMSModels() == null
-						&& !autoplay.isAutoPlayMode()) {
-					main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
-					if (!resource.isUpdateScore()) {
-						resource.getReplayData().pattern = null;
-						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
-					} else if (input.startPressed()) {
-						resource.getReplayData().pattern = null;
-						Logger.getGlobal().info("オプションを変更せずリプレイ");
-					} else {
-						Logger.getGlobal().info("同じ譜面でリプレイ");
-					}
-					resource.reloadBMSFile();
-					main.changeState(MainStateType.PLAY);
 				} else if (resource.getScoreData() != null) {
 					main.changeState(MainStateType.RESULT);
 				} else {


### PR DESCRIPTION
クイックリトライ機能の追加です
プレイ終了時にリザルトを通さずにリトライすることができます(データは保存されません)
スタートボタンを押すとランダムは再配置され、セレクトボタンを押すと先ほどと同じ譜面となります

強制終了を行った場合は、強制終了の操作終了後にスタートもしくはセレクトを押す必要があります
また、リトライ時に暴発して強制的にプレイ終了にならない様に、スタートとセレクト同時押しした場合は反応しないようになっています
動画はノーマルリトライ->クイックリトライの順で実行しております
ご検討いただけますと幸いです。

https://user-images.githubusercontent.com/77520794/105019007-f8229480-5a88-11eb-9635-b119569ca11f.mp4