### PR TITLE
Fix NullPointerException in BMControllerInputProcessor

### DIFF
--- a/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
@@ -96,7 +96,7 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
 		this.setConfig(controllerConfig);
 	}
 
-	public void setConfig(ControllerConfig controllerConfig) {
+	public synchronized void setConfig(ControllerConfig controllerConfig) {
 		this.buttons = controllerConfig.getKeyAssign().clone();
 		this.start = controllerConfig.getStart();
 		this.select = controllerConfig.getSelect();
@@ -133,7 +133,7 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
 		lastPressedButton = -1;
 	}
 
-	public void poll(final long presstime) {
+	public synchronized void poll(final long presstime) {
 		// AXISの更新
 		for (int i = 0; i < AXIS_LENGTH ; i++) {
 			axis[i] = controller.getAxis(i);


### PR DESCRIPTION
This is a bug that seems to have appeared after my recent changes to the analog scratch code.

# Bug Description
When returning to the Music Select menu after a song, there is a small probability that this error will occur:
```
Exception in thread "Thread-16" java.lang.NullPointerException
        at bms.player.beatoraja.input.BMControllerInputProcessor.scratchInput(Unknown Source)
        at bms.player.beatoraja.input.BMControllerInputProcessor.poll(Unknown Source)
        at bms.player.beatoraja.input.BMSPlayerInputProcessor.poll(Unknown Source)
        at bms.player.beatoraja.MainController.lambda$create$0(Unknown Source)
        at java.lang.Thread.run(Unknown Source)
```
When this error happens, beatoraja will become unresponsive to player input, and will need to be restarted.

# How to replicate
This bug happens randomly; it is difficult to replicate. The bug explanation is in the next section.
- To replicate this bug, start and exit a song over and over again until this bug happens.
- Alternate method: Open key config menu and exit over and over again

# Why this bug happens
The bug is in this line of code:
```java
private boolean scratchInput(int axisIndex, boolean plus) { //int button) {
    if (analogScratchAlgorithm == null) {
        // アナログ皿を使わない
        if (plus) {
            return axis[axisIndex] > 0.9;
        } else {
            return axis[axisIndex] < -0.9;
        }
    } else {
        // アナログ皿
        return analogScratchAlgorithm[axisIndex].analogScratchInput(axis[axisIndex], plus);   <---- BUG HERE
    }
}
```
`scratchInput()` is called by `poll()` every frame. If `analogScratchAlgorithm != null`, it will run the analog scratch code.

And we get a NullPointerException because `analogScratchAlgorithm[axisIndex]` is null.

How can this happen? It is due to parallel execution of threads.

Specifically, `poll()` is called while `setConfig()` is in the middle of execution.

## Here is proof:
We add print statements:
- in poll()
- at the start of setConfig()
- at the end of setConfig()

![image](https://user-images.githubusercontent.com/27341392/105566634-9441e980-5d70-11eb-88d8-c05628e56e61.png)

![image](https://user-images.githubusercontent.com/27341392/105566637-97d57080-5d70-11eb-9058-2fce2b583362.png)

#### If you start and exit a song, you will sometimes see this result:
![image](https://user-images.githubusercontent.com/27341392/105566668-c3f0f180-5d70-11eb-9738-00ba1f7b03fc.png)

This means `poll()` can be called while `setConfig()` is still executing.

See the section labeled **(A)** in the `setConfig()` code image. If `poll() ---> scratchInput()` is called in the middle of executing **(A)**, the NullPointerException bug will occur.


# Why didn't this bug happen in the old version of beatoraja? (0.8.1)
In the new analog scratch code, `analogScratchAlgorithm` is changed from a single object to an array `AnalogScratchAlgorithm[]`. So initialization of `analogScratchAlgorithm` and `analogScratchAlgorithm[i]` are now on different lines of code, which makes it vulnerable to parallel executing threads.

# What is the Fix?
**Current fix:** Add "synchronized" property to `setConfig()` and `poll()`, so they cannot run at the same time.

I think there are many possible ways to fix this bug. I do not know if this is the best fix.
