### PR TITLE
Fix NullPointerException from missing songPreview ComboBox

### DIFF
--- a/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/MusicSelectConfigurationView.fxml
@@ -61,7 +61,10 @@
 	<CheckBox fx:id="useSongInfo" mnemonicParsing="false" prefHeight="18.0" text="%USE_SONGINFO" />
 	<CheckBox fx:id="folderlamp" mnemonicParsing="false" prefHeight="25.0" text="%FOLDER_LAMP" />
     <CheckBox fx:id="shownoexistingbar" mnemonicParsing="false" prefHeight="25.0" text="%SHOW_NO_SONG_EXISTING_BAR" />
-    <CheckBox fx:id="playPreview" mnemonicParsing="false" prefHeight="25.0" text="%PLAY_PREVIEW" />
+    <HBox spacing="10" prefHeight="30.0">
+        <Label text="%PLAY_PREVIEW" prefHeight="25.0"/>
+        <ComboBox fx:id="songPreview" prefHeight="25.0"/>
+    </HBox>
 	<CheckBox fx:id="randomselect" mnemonicParsing="false" text="%RANDOM_SELECT" />
 	<HBox prefHeight="40.0" prefWidth="730.0">
 		<Label prefHeight="25.0" prefWidth="150.0"


### PR DESCRIPTION
In commit 283060b5c6e294b7dde0274122a089d2c4d6cde9, `CheckBox playPreview` is replaced with `ComboBox<SongPreview> songPreview` in **MusicSelectConfigurationView.java**, but it is not replaced in **MusicSelectConfigurationView.fxml**.

This will cause a NullPointerException in MusicSelectConfigurationView when the beatoraja config is opened.

This pull request adds the ComboBox to MusicSelectConfigurationView.fxml. Please modify as appropriate.