### PR TITLE
Analog Scroll Hotfix 1 : Reversed Direction

### DIFF
--- a/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
@@ -210,7 +210,7 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
     private float getAnalogValue(int button) {
         // assume isAnalog(button) == true.
         int axis_index = (button - BMKeys.AXIS1_PLUS)/2;
-        boolean plus = (button - BMKeys.AXIS1_PLUS)%2 == 1;
+        boolean plus = (button - BMKeys.AXIS1_PLUS)%2 == 0;
         float value = controller.getAxis(axis_index);
         return plus ? value : -value;
     }


### PR DESCRIPTION
Analog Scroll turntable direction is reversed.

Analog Scroll ON and Analog Scroll OFF makes the turntable go in opposite directions.
Analog Scroll OFF direction is correct. So we flip Analog Scroll ON's direction.