### PR TITLE
Analog Scroll Hotfix 2 : Multiple Controllers

### DIFF
--- a/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMControllerInputProcessor.java
@@ -23,6 +23,10 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
 	 */
 	private final String name;
 	/**
+	 * コントローラー使用してる
+	 */
+	private boolean enabled = false;
+	/**
 	 * ボタンキーアサイン
 	 */
 	private int[] buttons = new int[] { BMKeys.BUTTON_4, BMKeys.BUTTON_7, BMKeys.BUTTON_3, BMKeys.BUTTON_8,
@@ -137,6 +141,8 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
 	}
 
 	public void poll(final long presstime) {
+		if (!enabled) return;
+
 		// AXISの更新
 		for (int i = 0; i < AXIS_LENGTH ; i++) {
 			axis[i] = controller.getAxis(i);
@@ -199,6 +205,7 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
         boolean isAnalog = !mouseScratch && !jkoc && (analogScratchAlgorithm != null);
         for (int i = 0; i < buttons.length; i++) {
             final int button = buttons[i];
+            if (button < 0 || button >= BMKeys.MAXID) continue;
             if (isAnalog && button >= BMKeys.AXIS1_PLUS) {
                 this.bmsPlayerInputProcessor.setAnalogState(i, true, getAnalogValue(button));
             } else {
@@ -247,6 +254,10 @@ public class BMControllerInputProcessor extends BMSPlayerInputDevice {
 
 	public void setLastPressedButton(int lastPressedButton) {
 		this.lastPressedButton = lastPressedButton;
+	}
+
+	public void setEnable(boolean enabled) {
+		this.enabled = enabled;
 	}
 
 	public static class BMKeys {

--- a/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -154,6 +154,7 @@ public class BMSPlayerInputProcessor {
 	public void setControllerConfig(ControllerConfig[] configs) {
 		boolean[] b = new boolean[configs.length];
 		for (BMControllerInputProcessor controller : bminput) {
+			controller.setEnable(false);
 			for(int i = 0;i < configs.length;i++) {
 				if(b[i]) {
 					continue;
@@ -163,6 +164,7 @@ public class BMSPlayerInputProcessor {
 				}
 				if(controller.getName().equals(configs[i].getName())) {
 					controller.setConfig(configs[i]);
+					controller.setEnable(true);
 					b[i] = true;
 					break;
 				}

--- a/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
+++ b/src/bms/player/beatoraja/input/KeyBoardInputProcesseor.java
@@ -118,6 +118,7 @@ public class KeyBoardInputProcesseor extends BMSPlayerInputDevice implements Inp
 					keystate[keys[i]] = pressed;
 					keytime[keys[i]] = presstime;
 					this.bmsPlayerInputProcessor.keyChanged(this, presstime, i, pressed);
+					this.bmsPlayerInputProcessor.setAnalogState(i, false, 0);
 				}
 			}
 

--- a/src/bms/player/beatoraja/input/MidiInputProcessor.java
+++ b/src/bms/player/beatoraja/input/MidiInputProcessor.java
@@ -75,6 +75,7 @@ public class MidiInputProcessor extends BMSPlayerInputDevice implements AutoClos
 			final int key = i;
 			setHandler(keys[i], (Boolean pressed) -> {
 				bmsPlayerInputProcessor.keyChanged(this, currentTime(), key, pressed);
+				bmsPlayerInputProcessor.setAnalogState(key, false, 0);
 			});
 		}
 


### PR DESCRIPTION
There have been many reports recently of strange behavior in beatoraja when multiple controllers are detected.

There are two main problems, and there are 3 effects. Both problems contribute to both effects.

#### Testing help is appreciated.
**Current testers:** me (using YuanCon + 2x vjoy virtual joystick), Telperion (using DAO Real Edition Double)

### Effect 1:
Plugging in an additional controller may turn off Analog Scroll (For example, Controller 2 may turn off Analog Scroll for Controller 1)

Video: https://clips.twitch.tv/FreezingBelovedWombatNerfRedBlaster-NrJxFc0o1VVLSYGC

##### How to replicate
- Turn on analog scroll and analog scratch.
- Have two controllers plugged in. Controller 2 can be any type of controller (e.g. xbox 360 controller).
- Now try to turn the turntable during music select.

### Effect 2:
Plugging in an additional controller may cause weird "jumping" behavior in the MUSIC SELECT wheel. Jumping effect happens even if player is not doing anything.

Video (0:27, 0:43): https://clips.twitch.tv/FreezingBelovedWombatNerfRedBlaster-NrJxFc0o1VVLSYGC 

##### How to replicate
- Turn on analog scroll and analog scratch.
- Have two controllers plugged in. Controller 2 can be any type of controller (e.g. xbox 360 controller).
- Wait in music select and song wheel will jump.

### Effect 3:
Unassigned controllers can send input into beatoraja.

##### How to replicate
- Have two controllers plugged in, start beatoraja while key config is set to iidx_sp. Controller 2 can be any type of controller (e.g. xbox 360 controller).
- Now press buttons on controller 2.
- **Alternative method**: Start beatoraja with 3 controllers plugged while key config is set to iidx_dp, press buttons on controller 3.

Detailed explanation in Problem 2 below.


# Problem 1

### Cause of bug
In this part of the code: https://github.com/exch-bms2/beatoraja/blob/174bb7be0076c2e9123e244e7c4d60da73799b55/src/bms/player/beatoraja/input/BMControllerInputProcessor.java#L205

Current Behavior (Wrong):
- If `buttons[i] == -1`, we call `this.bmsPlayerInputProcessor.setAnalogState(i, false, 0)`.
- this is wrong, we should not set analogState of input [i] to false.
- We should do nothing because button [i] is unassigned.

### Illustration of Problem

**Controller A**
- CON-A: button[7] (F-SCR) == AXIS1_PLUS
- CON-A: button[8] (R-SCR) == AXIS1_MINUS
    
**Controller B** (Does not use button [7], [8])
- CON-B: button[7] (F-SCR) == -1
- CON-B: button[8] (R-SCR) == -1

call CON-A.poll() and CON-B.poll().

**Controller A: CON-A.poll():**
- set analogState of [7] to true.
    
**Controller B: CON-B.poll()**
- set analogState of [7] to false.  <--- Wrong! Should not set analogState of [7] at all.

**Result:** analogState of [7] is false. Player cannot use analog scratch.

Correct Behavior:
- CON-B should not set analogState of [7] or [8].

### Fix
- If button[i] == -1, do not set analogState.

But this can cause another bug for keyboard play. Replication instructions of new bug:
1. In Key Config, assign F-SCR/R-SCR to controller turntable, with analog scroll on.
2. Exit Key Config, scroll in MUSIC SELECT with turntable.
3. Open Key Config again, assign F-SCR/R-SCR to keyboard keys
4. Exit Key Config again. Now keyboard keys cannot scroll music select.

Cause: After step 3, analogState for button[7] and button[8] is still true.

Solution: Make keyboard (and MIDI) input set analogState for the buttons to false.


# Problem 2:
Disabled controllers are sending input into beatoraja.

### Illustration of Problem
Imagine we have 3 controllers plugged in.
- CON-A, CON-B, UNUSED-CON

We are using 2dx-dp input for music select.
- Controller 1 is CON-A.
- Controller 2 is CON-B.
- UNUSED-CON is not assigned.

Start beatoraja. Initialize the three controllers.
- CON-A.buttons = `{3,6,2,7,1,4,34,32,33}`
- CON-B.buttons = `{3,6,2,7,1,4,34,32,33}`
- UNUSED-CON.buttons = `{3,6,2,7,1,4,34,32,33}`

Apply Key Configuration:
- CON-A.buttons = `{0,1,2,3,4,5,6,34,35,  -1,-1,-1,-1,-1,-1,-1,-1,-1}`
- CON-B.buttons = `{-1,-1,-1,-1,-1,-1,-1,-1,-1,  0,1,2,3,4,5,6,34,35}`
- UNUSED-CON.buttons = `{3,6,2,7,1,4,34,32,33}`   <--- NOT CHANGED!

UNUSED-CON.buttons is not changed because it is not assigned.

So UNUSED-CON can still send input to beatoraja.

For example, when you press Key 3 on UNUSED-CON, it will activate button[0].

### Fix
I think the correct fix is to disable `poll()` for controllers that are not assigned.

So I added the `boolean enabled` property to all controllers.