### PR TITLE
Fix "NoSuchElementException: Queue is empty." in  MusicSelector

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -429,7 +429,7 @@ public class MusicSelector extends MainState {
 					resource.clear();
 					if (resource.setBMSFile(Paths.get(song.getPath()), play)) {
 						final Queue<DirectoryBar> dir = this.getBarRender().getDirectory();
-						if(!(dir.last() instanceof SameFolderBar)) {
+						if(dir.size > 0 && !(dir.last() instanceof SameFolderBar)) {
 							Array<String> urls = new Array(main.getConfig().getTableURL());
 
 							boolean isdtable = false;
@@ -469,7 +469,7 @@ public class MusicSelector extends MainState {
 				resource.clear();
 				if (resource.setBMSFile(Paths.get(song.getPath()), play)) {
 					final Queue<DirectoryBar> dir = this.getBarRender().getDirectory();
-					if(!(dir.last() instanceof SameFolderBar)) {
+					if(dir.size > 0 && !(dir.last() instanceof SameFolderBar)) {
 						Array<String> urls = new Array(main.getConfig().getTableURL());
 
 						boolean isdtable = false;


### PR DESCRIPTION
選曲画面のルートフォルダから選曲すると、NoSuchElementExceptionでbeatorajaが落ちる問題を修正。

問題発生PullRequest #426

## 再現方法
1. ランチャーのリソースタブのBMS Pathに、BMSファイルを直下に含むフォルダを指定する。
2. beatoraja起動後、選曲画面のルートフォルダから任意のBMSを選曲する。
3. `NoSuchElementException: Queue is empty.`が発生し、beatorajaが落ちる。

発生時ログ
```
Exception in thread "LWJGL Application" java.util.NoSuchElementException: Queue is empty.
at com.badlogic.gdx.utils.Queue.last(Queue.java:277)
at bms.player.beatoraja.select.MusicSelector.render(Unknown Source)
at bms.player.beatoraja.MainController.render(Unknown Source)
at com.badlogic.gdx.backends.lwjgl.LwjglApplication.mainLoop(LwjglApplication.java:232)
at com.badlogic.gdx.backends.lwjgl.LwjglApplication$1.run(LwjglApplication.java:127) 
```