### PR TITLE
SkinConfigurationView: change to save skinHistory by commit()

### DIFF
--- a/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
@@ -241,7 +241,7 @@ public class SkinConfigurationView implements Initializable {
 
     public void commit() {
     	commitSkinType();
-		commitSkinHeader();
+    	commitSkinHeader();
     }
     
     @FXML

--- a/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/SkinConfigurationView.java
@@ -241,6 +241,7 @@ public class SkinConfigurationView implements Initializable {
 
     public void commit() {
     	commitSkinType();
+		commitSkinHeader();
     }
     
     @FXML


### PR DESCRIPTION
ランチャーのスキンタブでのSkinConfigの編集内容を、起動/終了ボタンのクリック時(`commit()`呼び出し時)にskinHistoryに保存するように変更。

これにより、以下のSkinConfigの編集内容が保存されない現象が解消します。

### 現象の再現手順
1. ランチャーのスキンタブでSkinConfigを編集する
2. スキン種類やスキンの切り替えを行わずにbeatorajaを起動する
3. F12でスキンコンフィグ画面を開く
4. スキンコンフィグ画面に1で編集した内容が反映されていない

### 原因
beatoraja内のスキンコンフィグ画面(`SkinConfiguration`)では、SkinConfigはskinHistoryから呼び出す。
ランチャーのスキンタブでは、スキン種類orスキンの切り替えでSkinHistoryが保存される。
しかしランチャーの起動/終了ボタンクリック時にはskinHistoryが保存されない。
そのため、ランチャーでSkinConfig編集後にそのまま起動ボタンでbeatorajaを起動してスキンコンフィグ画面を開くと、ランチャーの編集内容が反映されない。