### PR TITLE
Fix BGA + thread leak issue when audio track is incompatible in BGA

### DIFF
--- a/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -229,7 +229,7 @@ public class FFmpegProcessor implements MovieProcessor {
 		private void restart() throws Exception {
 			pixmap = null;
 			grabber.restart();
-			grabber.grabFrame();
+			grabber.grabImage();
 			eof = false;
 			offset = grabber.getTimestamp() - time * 1000;
 			framecount = 1;


### PR DESCRIPTION
# Issue
When a BGA file has an incompatible audio track, the BGA will not play.
It can also cause a thread leak issue (which makes beatoraja create many threads that will never be closed, causing the game to slow down significantly).

# How to Reproduce
This happens with the BGA for [Shiny☆Strike!!!](http://manbow.nothing.sh/event/event.cgi?action=More_def&num=6&event=133) from BOFXVI.
However, the BGA has been fixed by the artist in the newest version of the song download.
The old version of the BGA (which causes the issue) can be downloaded here: [shinystrike_bga.zip](https://github.com/exch-bms2/beatoraja/files/6526779/shinystrike_bga.zip)
- **Note:** The BGA has been trimmed to only the first 15 seconds. This is enough to reproduce the issue.

Codec information:
```
Input #0, asf, from '_bga.wmv':
  Metadata:
    WMFSDKNeeded    : 0.0.0.0000
    DeviceConformanceTemplate: M0
    WMFSDKVersion   : 12.0.18362.1139
    IsVBR           : 1
    Buffer Average  : 3
    encoder         : Lavf58.29.100
  Duration: 00:02:33.37, start: 0.000000, bitrate: 3066 kb/s
    Stream #0:0(jpn): Video: vc1 (Advanced) (WVC1 / 0x31435657), yuv420p, 512x512 [SAR 1:1 DAR 1:1], 3000 kb/s, 30 tbr, 1k tbn, 60 tbc
    Stream #0:1(jpn): Audio: wmapro (b[1][0][0] / 0x0162), 32000 Hz, stereo, fltp, 32 kb/s
```
This BGA cannot play in the current version of beatoraja.

However, if the audio channel is removed or if the codec of the audio channel is changed, the BGA will play properly.
- BGA (15s trim) with audio removed / codec changed: [shinystrike_bga_fixed.zip](https://github.com/exch-bms2/beatoraja/files/6526847/shinystrike_bga_fixed.zip)

# Reproducing the Thread Leak Issue
1. Download Shiny☆Strike!!! with faulty BGA file above.
2. Download another song (probably with BGA)
3. Repeat many times:
  a. Play Shiny☆Strike!!!, exit after BGA "starts" playing.
  b. Play a different song (it is okay to exit anytime).

Each time Shiny☆Strike!!! is started, a new FFmpegProcessor thread is created, but is never closed because it gets stuck. After doing this 3-4 times, beatoraja will slow down significantly.

# Cause of Issue
In FFmpegFrameGrabber, `grabFrame()` grabs both the audio and video track. `grabImage()` grabs only the video track. [FFmpegFrameGrabber.java source](https://github.com/bytedeco/javacv/blob/master/src/main/java/org/bytedeco/javacv/FFmpegFrameGrabber.java)
If the audio track has issues, calling `grabFrame()` before `grabImage()` will cause the thread to freeze forever.

Minimal code example:
```java
import org.bytedeco.javacv.FFmpegFrameGrabber;

public class Test {
    public static void main(String[] args) throws Exception {
        FFmpegFrameGrabber grabber = new FFmpegFrameGrabber("_bga.wmv");
        grabber.start();
        grabber.grabFrame();
        grabber.grabImage();    //   <---- This will never finish execution
    }
}
```

Calling this is okay:
```
grabber.grabImage();
grabber.grabImage();
```

Calling this is also okay:
```
grabber.grabFrame();
grabber.grabFrame();
```

But calling this will cause the thread to freeze:
```
grabber.grabFrame();
grabber.grabImage();
```

In FFmpegProcessor, `grabFrame()` is called in `restart()` when the command "PLAY" is sent.
https://github.com/exch-bms2/beatoraja/blob/0194a5441c0aed3dd27ad0ef5c15f58b982e0eff/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java#L231
When the BGA starts to play, `grabImage()` causes the thread to freeze
https://github.com/exch-bms2/beatoraja/blob/0194a5441c0aed3dd27ad0ef5c15f58b982e0eff/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java#L150

Now this thread is unresponsive. The BGA will not play, and the thread will not be killed when a different BGA is loaded. This causes a thread leak.

# Fix
Replace `grabber.grabFrame()` with `grabber.grabImage()` in `MovieSeekThread.restart()`.
I do not know if this is the best solution.


#### P.S. she is very cute
![cute](https://user-images.githubusercontent.com/27341392/119236280-7abf7b80-bb71-11eb-9e7e-a836e976a1bd.png)
