### PR TITLE
Fix MODIFY_DAMAGE for LR2 Hard Gauge for TotalNotes<1000

### DIFF
--- a/src/bms/player/beatoraja/play/GrooveGauge.java
+++ b/src/bms/player/beatoraja/play/GrooveGauge.java
@@ -287,6 +287,7 @@ public class GrooveGauge {
 				float fix1=1.0f;
 				float fix2=1.0f;
 				if(f < 0) {
+					// トータル補正 (<240)
 					if(model.getTotal()>=240.0){
 						fix1=1.0f;
 					}else if(model.getTotal()>=230.0){
@@ -308,13 +309,26 @@ public class GrooveGauge {
 					}else{
 						fix1=10.0f;
 					}
-					int note=1000;
-					float mod=0.002f;
-					while(note>model.getTotalNotes()||note>1){
-						fix2 += mod * (float)(note - Math.max(model.getTotalNotes(), note/2));
-						note/=2;
-						mod*=2.0f;
+
+					// ノート数補正 (<1000)
+					if(model.getTotalNotes()<=20) {
+						fix2 = 10.0f;
+					}else if(model.getTotalNotes()<30) {
+						fix2 = 8.0f + 0.2f*(30-model.getTotalNotes());
+					}else if(model.getTotalNotes()<60) {
+						fix2 = 5.0f + 0.2f*(60-model.getTotalNotes())/3.0f;
+					}else if(model.getTotalNotes()<125) {
+						fix2 = 4.0f + (125-model.getTotalNotes())/65.0f;
+					}else if(model.getTotalNotes()<250) {
+						fix2 = 3.0f + 0.008f*(250-model.getTotalNotes());
+					}else if(model.getTotalNotes()<500) {
+						fix2 = 2.0f + 0.004f*(500-model.getTotalNotes());
+					}else if(model.getTotalNotes()<1000) {
+						fix2 = 1.0f + 0.002f*(1000-model.getTotalNotes());
+					}else {
+						fix2 = 1.0f;
 					}
+
 					f *= Math.max(fix1, fix2);
 				}
 				return f;


### PR DESCRIPTION
# Issue
In LR2 Hard Gauge, damage is increased when total notes < 1000.
This code is present in beatoraja, but there are some errors.

## Error 1
```java
int note=1000;
float mod=0.002f;
while(note>model.getTotalNotes()||note>1){
    fix2 += mod * (float)(note - Math.max(model.getTotalNotes(), note/2));
    note/=2;
    mod*=2.0f;
}
```
This is the current code. There is a mistake in this line:
```java
while(note>model.getTotalNotes()||note>1)
```
It should be `&&`, not `||`. Currently, because `||` is used, `fix2` is almost always a negative value, so this code will do nothing.

## Error 2
Suppose that we fixed the existing code by using `&&` instead:
```java
int note=1000;
float mod=0.002f;
while(note>model.getTotalNotes()&&note>1){
    fix2 += mod * (float)(note - Math.max(model.getTotalNotes(), note/2));
    note/=2;
    mod*=2.0f;
}
```
This is close to LR2 hard gauge's damage increase, but it is not exactly the same.

The existing code follows the notes written here: https://web.archive.org/web/20190210133959/http://2nd.geocities.jp/yoshi_65c816/bms/LR2.html
```
totalnotesが1000未満のとき補正が入る。
999～500は1ノーツにつき0.02%減少量が増加、
499～250は1ノーツにつき0.04%減少量が増加・・・という補正。説明がめんどいので以下のグラフ参照。
```
However, this rule is only correct for `125 <= totalnotes < 1000`.
For `totalnotes < 125`, the rule changes.

# Correct Damage Algorithm (for totalnotes)
From extensive testing on LR2, I believe these are the correct calculations. Test data and explanations will be given below.

*Note: Damage is also increased when TOTAL<240. But this code is not covered here. Final damage increase is a MAX of the two damage increases.*

Default damage is 1.000x (for totalnotes>=1000).
```
Notes 999~500: +0.002x damage per note
Notes 499~250: +0.004x damage per note
Notes 125~249: +0.008x damage per note
Notes 60~124: +(1/65)x damage per note   (≈0.0153846, not 0.16)
Notes 30~59: +(1/15)x damage per note   (≈0.0666667)
Notes 20~29: +0.2x damage per note
```
Damage values:
```
1000Notes: 1.0x damage
500Notes: 2.0x damage
250Notes: 3.0x damage
125Notes: 4.0x damage
60Notes: 5.0x damage
30Notes: 8.0x damage
20Notes: 10.0x damage
```
For <20 notes, damage is exactly 10.0x (not more).

Final damage calculation formula (Python):
```python
def compute_totalnotes_damage(totalnotes):
    if totalnotes <= 20:
        return 10
    if totalnotes < 30:
        return 8 + 0.2*(30-totalnotes)
    elif totalnotes < 60:
        return 5 + 0.2*(60-totalnotes)/3
    elif totalnotes < 125:
        return 4 + (125-totalnotes)/65
    elif totalnotes < 250:
        return 3 + 0.008*(250-totalnotes)
    elif totalnotes < 500:
        return 2 + 0.004*(500-totalnotes)
    elif totalnotes < 1000:
        return 1 + 0.002*(1000-totalnotes)
    else:
        return 1
```

# LR2 Damage Test Data and Explanations
All experiments were done in LR2, on a chart with TOTAL=240.
- y-axis: Remaining gauge (HARD) after 1 POOR.
- x-axis: Total notes in chart

![image](https://user-images.githubusercontent.com/27341392/126518631-4994d33b-49a4-4f08-a7e3-eb3a8380b842.png)

Below are the raw numbers from the test.
Note: the LR2 Gauge UI only displays remaining HP rounded down to the nearest multiple of 2.
- so remaining gauge 84% means `84% <= hp < 86%`.

TotalNotes | 1POOR Remaining Gauge % Displayed (HARD)
|--|--|
**1000**~ | **90**
900~999 | 88
800~899 | 86
700~799 | 84
600~699 | 82
**500**~599 | **80**
450~499 | 78
400~449 | 76
350~399 | 74
300~349 | 72
**250**~299 | **70**
225~249 | 68
200~224 | 66
175~199 | 64
150~174 | 62
**125**~149 | **60**
112~124 | 58
99~111 | 56
86~98 | 54
73~85 | 52
**60**~72 | **50**
57~59 | 48
54~56 | 46
51~53 | 44
48~50 | 42
45~47 | 40
42~44 | 38
39~41 | 36
36~38 | 34
33~35 | 32
**30**~32 | **30**
29 | 18
28 | 16
27 | 14
26 | 12
25 | 10
24 | 8
23 | 6
22 | 4
21 | 2
1~**20** | **0**

#### Note 1
For `totalnotes<20`, BAD/空POOR judgement was tested.
- For `1<=totalnotes<=20`, BAD always does -60%, and 空POOR always does -20%. So the damage multiplier does not increase beyond 10.0x.

#### Note 2
For `20<=totalnotes<=125`, because the numbers are subtle (1/65 and 1/15 especially), BAD/空POOR damage numbers were also tested and compared to the above algorithm. The damage numbers are consistent, so I believe 1/65 and 1/15 are correct.

#### Note 3
I did some tests with TOTAL<240 charts too. I believe `max(fix1, fix2)` is correct.