### PR TITLE
Display which paths led to "Illegal BMS Songs" error

### DIFF
--- a/src/bms/player/beatoraja/BMSResource.java
+++ b/src/bms/player/beatoraja/BMSResource.java
@@ -99,7 +99,7 @@ public class BMSResource {
 		while(!bgaloaders.isEmpty() && !bgaloaders.getFirst().isAlive()) {
 			bgaloaders.removeFirst();
 		}
-		
+
 		if(MainLoader.getIllegalSongCount() == 0) {
 			// Audio, BGAともキャッシュがあるため、何があっても全リロードする
 			BGALoaderThread bgaloader = new BGALoaderThread(
@@ -108,7 +108,7 @@ public class BMSResource {
 			bgaloader.start();
 			AudioLoaderThread audioloader = new AudioLoaderThread(model);
 			audioloaders.addLast(audioloader);
-			audioloader.start();			
+			audioloader.start();
 		}
 		return true;
 	}

--- a/src/bms/player/beatoraja/BMSResource.java
+++ b/src/bms/player/beatoraja/BMSResource.java
@@ -1,15 +1,15 @@
 package bms.player.beatoraja;
 
-import java.nio.file.Path;
-import java.util.ArrayDeque;
-import java.util.logging.Logger;
-
 import bms.model.BMSModel;
 import bms.player.beatoraja.audio.AudioDriver;
 import bms.player.beatoraja.play.bga.BGAProcessor;
 import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.Texture;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
+
+import java.nio.file.Path;
+import java.util.ArrayDeque;
+import java.util.logging.Logger;
 
 /**
  * BMSの音源、BGAリソースを管理するクラス
@@ -100,16 +100,14 @@ public class BMSResource {
 			bgaloaders.removeFirst();
 		}
 
-		if(MainLoader.getIllegalSongCount() == 0) {
-			// Audio, BGAともキャッシュがあるため、何があっても全リロードする
-			BGALoaderThread bgaloader = new BGALoaderThread(
-					config.getBga() == Config.BGA_ON || (config.getBga() == Config.BGA_AUTO && (mode.mode == BMSPlayerMode.Mode.AUTOPLAY || mode.mode == BMSPlayerMode.Mode.REPLAY)) ? model : null);
-			bgaloaders.addLast(bgaloader);
-			bgaloader.start();
-			AudioLoaderThread audioloader = new AudioLoaderThread(model);
-			audioloaders.addLast(audioloader);
-			audioloader.start();
-		}
+		// Audio, BGAともキャッシュがあるため、何があっても全リロードする
+		BGALoaderThread bgaloader = new BGALoaderThread(
+				config.getBga() == Config.BGA_ON || (config.getBga() == Config.BGA_AUTO && (mode.mode == BMSPlayerMode.Mode.AUTOPLAY || mode.mode == BMSPlayerMode.Mode.REPLAY)) ? model : null);
+		bgaloaders.addLast(bgaloader);
+		bgaloader.start();
+		AudioLoaderThread audioloader = new AudioLoaderThread(model);
+		audioloaders.addLast(audioloader);
+		audioloader.start();
 		return true;
 	}
 

--- a/src/bms/player/beatoraja/MainLoader.java
+++ b/src/bms/player/beatoraja/MainLoader.java
@@ -102,9 +102,7 @@ public class MainLoader extends Application {
 			}
 		}
 
-
-
-		if (Files.exists(MainController.configpath) && (bmsPath != null || auto != null)) {
+		if(Files.exists(MainController.configpath) && (bmsPath != null || auto != null)) {
 			IRConnectionManager.getAllAvailableIRConnectionName();
 			play(bmsPath, auto, true, null, null, bmsPath != null);
 		} else {

--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -860,9 +860,7 @@ public class BarRenderer {
 		boolean showInvisibleCharts = false;
 		boolean isSortable = true;
 
-		if (MainLoader.getIllegalSongCount() > 0) {
-			l.addAll(SongBar.toSongBarArray(select.getSongDatabase().getSongDatas(MainLoader.getIllegalSongs())));
-		} else if (bar == null) {
+		if (bar == null) {
 			if (dir.size > 0) {
 				prevbar = dir.first();
 			}

--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -126,7 +126,7 @@ public class BarRenderer {
 
 		TableData[] unsortedtables = tdaccessor.readAll();
 		Array<TableData> sortedtables = new Array<TableData>(unsortedtables.length);
-		
+
 		for(String url : select.main.getConfig().getTableURL()) {
 			for(int i = 0;i < unsortedtables.length;i++) {
 				final TableData td = unsortedtables[i];
@@ -137,7 +137,7 @@ public class BarRenderer {
 				}
 			}
 		}
-		
+
 		for(TableData td : unsortedtables) {
 			if(td != null) {
 				sortedtables.add(td);
@@ -184,7 +184,7 @@ public class BarRenderer {
 							song.setUrl(chart.url);
 							song.setAppendurl(chart.appendurl);
 							if(chart.mode != null) {
-								song.setMode(chart.mode.id);								
+								song.setMode(chart.mode.id);
 							}
 							songs[j] = song;
 						}
@@ -208,7 +208,7 @@ public class BarRenderer {
 							song.setUrl(chart.url);
 							song.setAppendurl(chart.appendurl);
 							if(chart.mode != null) {
-								song.setMode(chart.mode.id);								
+								song.setMode(chart.mode.id);
 							}
 							songs[j] = song;
 						}
@@ -229,7 +229,7 @@ public class BarRenderer {
 					}
 					td.setCourse(course);
 					if(td.validate()) {
-						table.add(new TableBar(select, td, new TableDataAccessor.DifficultyTableAccessor(main.getConfig().getTablepath(), td.getUrl())));						
+						table.add(new TableBar(select, td, new TableDataAccessor.DifficultyTableAccessor(main.getConfig().getTablepath(), td.getUrl())));
 					}
 				}
 			} else {
@@ -464,17 +464,15 @@ public class BarRenderer {
 	}
 
 	private long time;
-	
+
 	public void prepare(MusicSelectSkin skin, SkinBar baro, long time) {
-		this.time = time;		
-		final long timeMillis = System.currentTimeMillis();
+		this.time = time;final long timeMillis = System.currentTimeMillis();
 		boolean applyMovement = duration != 0 && duration > timeMillis;
 		float angleLerp = 0;
 		if (applyMovement) {
 			angleLerp = angle < 0 ? ((float) (timeMillis - duration)) / angle
 				: ((float) (duration - timeMillis)) / angle;
 		}
-
 		for (int i = 0; i < barlength; i++) {
 			// calcurate song bar position
 			final BarArea ba = bararea[i];
@@ -579,11 +577,11 @@ public class BarRenderer {
 			for (char c : charset) {
 				chars[i++] = c;
 			}
-			
+
 			for(int index = 0;index < SkinBar.BARTEXT_COUNT;index++) {
 				if(baro.getText(index) != null) {
-					baro.getText(index).prepareFont(String.valueOf(chars));				
-				}				
+					baro.getText(index).prepareFont(String.valueOf(chars));
+				}
 			}
 		}
 
@@ -635,7 +633,7 @@ public class BarRenderer {
 			final SkinText text = baro.getText(ba.text);
 			if(text != null) {
 				text.setText(ba.sd.getTitle());
-				text.draw(sprite, ba.x, ba.y);				
+				text.draw(sprite, ba.x, ba.y);
 			}
 		}
 
@@ -652,7 +650,7 @@ public class BarRenderer {
 						if (TROPHY[j].equals(trophy.getName())) {
 							final SkinImage trophyImage = baro.getTrophy(j);
 							if(trophyImage != null) {
-								trophyImage.draw(sprite, ba.x, ba.y);								
+								trophyImage.draw(sprite, ba.x, ba.y);
 							}
 							break;
 						}


### PR DESCRIPTION
Currently, if a user would have any illegal BMS files or the detection system would react on any false positives, there is no way to tell which BMS files cause the error.

This PR adds paths to the error message displayed, so it's easier for the user to identify which song packs should be deleted or included in an issue about false positives.
![screenshot](https://user-images.githubusercontent.com/9805596/128579457-d061ea5f-b0e7-4b3e-bc90-a64142e23cbc.png)

The paths displayed are capped at 30 lines to limit the dialog window potential size.

---
Detected charts are not stored in a variable in MainLoader anymore, and two unreachable checks were also removed - they cannot happen if the application won't start anyway.

Part of this PR just removes unneeded whitespace, but it's split in separate commits. Main commit that represents the main logic change can be viewed here: https://github.com/exch-bms2/beatoraja/pull/631/commits/3517fc0a80dd4f72d71f6af159be539709579ba7