### PR TITLE
Add string properties for VERSION and IR_NAME

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -243,6 +243,8 @@ public class SkinProperty {
 	public static final int STRING_TABLE_NAME = 1001;
 	public static final int STRING_TABLE_LEVEL = 1002;
 	public static final int STRING_TABLE_FULL = 1003;
+	public static final int STRING_VERSION = 1010;
+	public static final int STRING_IR_NAME = 1020;
 
 	public static final int NUMBER_HISPEED_LR2 = 10;
 	public static final int NUMBER_HISPEED = 310;

--- a/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.skin.property;
 
 import bms.player.beatoraja.CourseData;
+import bms.player.beatoraja.IRConfig;
 import bms.player.beatoraja.PlayerInformation;
 import bms.player.beatoraja.ScoreData;
 import bms.player.beatoraja.config.SkinConfiguration;
@@ -172,6 +173,14 @@ public class StringPropertyFactory {
 		tablename(1001, (state) -> (state.main.getPlayerResource().getTablename())),
 		tablelevel(1002, (state) -> (state.main.getPlayerResource().getTablelevel())),
 		tablefull(1003, (state) -> (state.main.getPlayerResource().getTableFullname())),
+		version(1010, (state) -> (state.main.getVersion())),
+		irname(1020, (state) -> {
+			final IRConfig[] irconfig = state.main.getPlayerResource().getPlayerConfig().getIrconfig();
+			if (irconfig.length > 0) {
+				return irconfig[0].getIrname();
+			}
+			return "";
+		}),
 		;
 		
 		/**


### PR DESCRIPTION
以下の2つのString Propertyを追加
- STRING_VERSION: beatorajaのバージョンを表示 (例: "beatorja 0.8.3")
- STRING_IR_NAME: プライマリIRの名前を表示 (例: "mocha", "MinIR")

懸念点
- STRING_VERSIONで返される文字列の"beatoraja "部分は含むべきか
- STRING_IR_NAMEは開発環境だとIRに繋げないので正式にはテストできていません
- プロパティ番号は適切か(とりあえず少し離した番号を割り当てました)