### PR TITLE
Add event_index to main_state

### DIFF
--- a/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
+++ b/src/bms/player/beatoraja/skin/lua/MainStateAccessor.java
@@ -31,6 +31,7 @@ public class MainStateAccessor {
 		table.set("time", this.new time());
 		table.set("set_timer", this.new set_timer());
 		table.set("event_exec", this.new event_exec());
+		table.set("event_index", this.new event_index());
 
 		// 具体的な数値の取得・設定など
 		table.set("rate", new ZeroArgFunction() {
@@ -275,4 +276,17 @@ public class MainStateAccessor {
 			return id;
 		}
 	}
+
+	/**
+	 * ID指定でイベント(BUTTON_*)のインデックスを取得する関数
+	 * NOTE: 呼び出しの度にIntegerPropertyを生成しており効率が悪いため非推奨
+	 */
+	private class event_index extends OneArgFunction {
+		@Override
+		public LuaValue call(LuaValue luaValue) {
+			IntegerProperty prop = IntegerPropertyFactory.getImageIndexProperty(luaValue.toint());
+			return LuaNumber.valueOf(prop.get(state));
+		}
+	}
+
 }


### PR DESCRIPTION
luaスキンで呼び出せる`main_state`モジュールに、イベントの現在の状態のインデックスを返す`event_index(id)`関数を追加

例:
ゲージにEXHARDを選択している場合、ゲージのインデックス順は以下の通りなので、main_state.event_index(40)は4を返します。
- 0 ASSITED EASY
- 1 EASY
- 2 NORMAL
- 3 HARD
- 4 EXHARD
- 5 HAZARD