### PR TITLE
StreamRequestCommand : fix Java 8 compatibility

### DIFF
--- a/src/bms/player/beatoraja/stream/command/StreamRequestCommand.java
+++ b/src/bms/player/beatoraja/stream/command/StreamRequestCommand.java
@@ -83,7 +83,7 @@ public class StreamRequestCommand extends StreamCommand {
                     }
 
                     if (songDatas.size() > 0) {
-                        bar.setElements(songDatas.toArray(SongData[]::new));
+                        bar.setElements(songDatas.toArray(new SongData[0]));
                         try {
                             selector.getBarRender().setAppendDirectoryBar("Stream Request", bar);
                             selector.getBarRender().updateBar();


### PR DESCRIPTION
`.toArray(SongData[]::new)` does not compile in Java 8. (only works for Java 11+)