### PR TITLE
Fix Non-functioning Analog Scratch Threshold Spinner in Configuration

### DIFF
--- a/src/bms/player/beatoraja/PlayModeConfig.java
+++ b/src/bms/player/beatoraja/PlayModeConfig.java
@@ -469,7 +469,7 @@ public class PlayModeConfig {
         public void setAnalogScratchThreshold(int analogScratchThreshold) {
             this.analogScratchThreshold = 
             	analogScratchThreshold > 0 ? 
-            		analogScratchThreshold <= 100 ? analogScratchThreshold : 100 
+            		analogScratchThreshold <= 1000 ? analogScratchThreshold : 1000 
     			:1;
         }
 

--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.java
@@ -105,7 +105,7 @@ public class InputConfigurationView implements Initializable {
 
 	nameCol.setCellFactory(TextFieldTableCell.forTableColumn());
 	isAnalogCol.setCellFactory(CheckBoxTableCell.forTableColumn(isAnalogCol));
-	analogThresholdCol.setCellFactory(col -> new SpinnerCell(1, 100, 100, 1));
+	analogThresholdCol.setCellFactory(col -> new SpinnerCell(1, 1000, 100, 1));
 	analogModeCol.setCellFactory(ComboBoxTableCell.forTableColumn(new IntegerStringConverter() {
 	    private String v2String = "Ver. 2 (Newest)";
 	    private String v1String = "Ver. 1 (~0.6.9)";

--- a/src/bms/player/beatoraja/launcher/SpinnerCell.java
+++ b/src/bms/player/beatoraja/launcher/SpinnerCell.java
@@ -1,9 +1,8 @@
 package bms.player.beatoraja.launcher;
 
-import javafx.application.Platform;
 import javafx.scene.control.SpinnerValueFactory;
 import javafx.scene.control.TableCell;
-import javafx.scene.input.KeyCode;
+import javafx.beans.value.WritableValue;
 
 /**
  * TableCell用 NumericSpinner
@@ -14,51 +13,21 @@ public final class SpinnerCell extends TableCell<ControllerConfigViewModel, Inte
     SpinnerCell(int min, int max, int initial, int step) {
         spinner = new NumericSpinner<>();
         spinner.setValueFactory(new SpinnerValueFactory.IntegerSpinnerValueFactory(min, max, initial, step));
-        setEditable(true);
+        spinner.setEditable(true);
+        spinner.valueProperty().addListener((o, oldValue, newValue) -> {
+            WritableValue<Integer> cellProperty = (WritableValue<Integer>)getTableColumn().getCellObservableValue((ControllerConfigViewModel)getTableRow().getItem());
+            cellProperty.setValue(newValue);
+        });
     }
 
     @Override
-    public void startEdit() {
-        if (!isEmpty()) {
-    	super.startEdit();
-    	spinner.getValueFactory().setValue(getItem());
-
-    	setOnKeyPressed(event -> {
-    	    if (event.getCode() == KeyCode.ENTER) {
-    		Platform.runLater(() -> {
-    		    commitEdit(spinner.getValue());
-    		});
-    	    }
-    	});
-
-    	setText(null);
-    	setGraphic(spinner);
-        }
-    }
-
-    @Override
-    public void cancelEdit() {
-        super.cancelEdit();
-
-        setText(getItem().toString());
-        setGraphic(null);
-    }
-
-    @Override
-    public void updateItem(Integer item, boolean empty) {
+    protected void updateItem(Integer item, boolean empty) {
         super.updateItem(item, empty);
-
         if (empty) {
-    	setText(null);
-    	setGraphic(null);
+            setGraphic(null);
         } else {
-    	if (isEditing()) {
-    	    setText(null);
-    	    setGraphic(spinner);
-    	} else {
-    	    setText(getItem().toString());
-    	    setGraphic(null);
-    	}
+            spinner.getValueFactory().setValue(item);
+            setGraphic(spinner);
         }
     }
 }


### PR DESCRIPTION
This is regarding the analog scratch threshold spinner in the configuration.

![image](https://user-images.githubusercontent.com/27341392/137623034-1d2c1d2a-d708-4126-b3e3-c2782959e737.png)

# Issues fixed
### 1. Spinner value does not update unless you press enter.
 - If you change the value by pressing up/down, but don't press enter, the value will not save.
### 2. Spinner value cannot be typed into the box.
 - The only way to change the value is by pressing the up/down arrows, which is slow.

Now the spinner value should always update reliably, and can also be typed into the box.

I think the new code also simplifies the TableSpinner class.

@SackMagiclight requesting review (because I deleted some of your code)

## Additional
Changed maximum analog scratch threshold to 1000.
- max = 100 doesn't make sense when the default value is also 100.