### PR TITLE
BarSorter :Sort by Difficulty

### DIFF
--- a/src/bms/player/beatoraja/select/BarSorter.java
+++ b/src/bms/player/beatoraja/select/BarSorter.java
@@ -120,8 +120,6 @@ public enum BarSorter implements Comparator<Bar> {
 				return -1;
 			}
 
-//			return ((SongBar) o1).getSongData().getLevel() - ((SongBar) o2).getSongData().getLevel();
-
 			//levelが同じ場合はDifficultyでソート
 			int revelSort=((SongBar) o1).getSongData().getLevel() - ((SongBar) o2).getSongData().getLevel();
 			if(revelSort==0){


### PR DESCRIPTION
#624 のIssueに対する変更です。

NAMEソートで、楽曲の「TITLE」が完全一致しているときにDifficultyが低い順番にソートします。(#TITLE には曲名だけ入れていて、#SUBTITLE に難易度情報が入っている曲など)
TITLEに曲名と難易度情報が書かれている場合(「#TITLE hogehoge[HARD]」といった場合)は曲名が一致しているとはみなされずdifficultyによるソートは行われません。

同様に、LEVELソートの時、同じLEVELの際にDifficultyによるソートを行います。