### PR TITLE
Fix playing timing of mine explotion sound

### DIFF
--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -282,7 +282,8 @@ public class JudgeManager {
 					final MineNote mnote = (MineNote) note;
 					// 地雷ノート判定
 					main.getGauge().addValue((float) -mnote.getDamage());
-					System.out.println("Mine Damage : " + mnote.getWav());
+					System.out.println("Mine Damage : " + (float) mnote.getDamage());
+					keysound.play(note, config.getAudioConfig().getKeyvolume(), 0);
 				}
 
 				if (autoplay) {
@@ -515,7 +516,7 @@ public class JudgeManager {
 							}
 						}
 
-						if (n != null && passing[lane] == null) {
+						if (n != null && passing[lane] == null && !(n instanceof MineNote)) {
 							keysound.play(n, config.getAudioConfig().getKeyvolume(), 0);
 						}
 					}


### PR DESCRIPTION
地雷ノートを踏んだ時に地雷爆発音が再生されるよう修正

### 修正前の動作
- 地雷ノートの爆発音の再生タイミングは、通常ノートや不可視ノートなどと同じだった
- そのため、地雷ノートを踏んだ時(地雷ノートが判定ラインを通過するタイミングで、該当するキーを押下している時)は爆発音が再生されなかった