### PR TITLE
Fix the default mine explotion sound not playing when replaying

### DIFF
--- a/src/bms/player/beatoraja/PlayerResource.java
+++ b/src/bms/player/beatoraja/PlayerResource.java
@@ -192,6 +192,21 @@ public class PlayerResource {
 
 		marginTime = BMSModelUtils.setStartNoteTime(model, 1000);
 		BMSPlayerRule.validate(model);
+
+		// 地雷ノートに爆発音が定義されていない場合、デフォルト爆発音をセットする
+		final int lanes = model.getMode().key;
+		final int wavcount = model.getWavList().length;
+		for (TimeLine tl : model.getAllTimeLines()) {
+			for (int i = 0; i < lanes; i++) {
+				final Note n = tl.getNote(i);
+				if (n != null) {
+					if (n instanceof MineNote && n.getWav() < 0) {
+						n.setWav(wavcount);
+					}
+				}
+			}
+		}
+
 		return model;
 	}
 

--- a/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
+++ b/src/bms/player/beatoraja/audio/AbstractAudioDriver.java
@@ -258,8 +258,7 @@ public abstract class AbstractAudioDriver<T> implements AudioDriver {
 				final Note n = tl.getNote(i);
 				if (n != null) {
 					// 地雷ノートに音が定義されていない場合のみ、本体側で音の定義を追加
-					if (n instanceof MineNote && n.getWav() < 0) {
-						n.setWav(wavcount);
+					if (!use_defaultsound && n instanceof MineNote && n.getWav() == wavcount) {
 						use_defaultsound = true;
 					}
 					addNoteList(notemap, n);


### PR DESCRIPTION
デフォルト地雷爆発音(defaultsound/landmine.wav)が再プレイ時に再生されない問題を修正

発生タイミング
- プラクティスモードでの再プレイ時
- クイックリトライ時 