### PR TITLE
Add RandomCourse

### DIFF
--- a/src/bms/player/beatoraja/RandomCourseData.java
+++ b/src/bms/player/beatoraja/RandomCourseData.java
@@ -1,0 +1,172 @@
+package bms.player.beatoraja;
+
+import bms.player.beatoraja.song.SongData;
+
+import java.io.File;
+import java.text.SimpleDateFormat;
+import java.util.*;
+
+/**
+ * SQL問い合わせ結果から曲を抽選するコースのデータ
+ */
+public class RandomCourseData {
+
+	public static final RandomCourseData[] EMPTY = new RandomCourseData[0];
+
+	/**
+	 * コース名
+	 */
+	private String name;
+	/**
+	 * ステージ情報
+	 */
+	private RandomStageData[] stage = RandomStageData.EMPTY;
+	/**
+	 * コースの制約
+	 */
+	private CourseData.CourseDataConstraint[] constraint = CourseData.CourseDataConstraint.EMPTY;
+	/**
+	 * ランダムコースの制約
+	 */
+	private RandomCourseDataConstraint[] rconstraint = RandomCourseDataConstraint.EMPTY;
+	/**
+	 * トロフィー条件
+	 */
+	private CourseData.TrophyData[] trophy = CourseData.TrophyData.EMPTY;
+
+	/**
+	 * 各ステージの抽選結果の楽曲
+	 */
+	private SongData[] songDatas = SongData.EMPTY;
+
+	private final java.util.Random random = new java.util.Random();
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public RandomStageData[] getStage() { return stage; }
+
+	public void setStage(RandomStageData[] stage) { this.stage = stage; }
+
+	public SongData[] getSongDatas() { return songDatas; }
+
+	public void setSongDatas(SongData[] songDatas) { this.songDatas = songDatas; }
+
+	public CourseData.CourseDataConstraint[] getConstraint() { return constraint; }
+
+	public void setConstraint(CourseData.CourseDataConstraint[] constraint) { this.constraint = constraint; }
+
+	public CourseData.TrophyData[] getTrophy() {
+		return trophy;
+	}
+
+	public void setTrophy(CourseData.TrophyData[] trophy) {
+		this.trophy = trophy;
+	}
+
+	public boolean isRelease() { return false; }
+
+	public CourseData createCourseData() {
+		CourseData courseData = new CourseData();
+		final SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd_HHmmss");
+		courseData.setName(name + " " + sdf.format(new Date()));
+		courseData.setSong(songDatas);
+		courseData.setConstraint(constraint);
+		courseData.setTrophy(trophy);
+		courseData.setRelease(false);
+		return courseData;
+	}
+
+	public void lotterySongDatas(final MainController main) {
+		boolean isDistinct = false;
+		for(RandomCourseDataConstraint rcon : rconstraint) {
+			if(rcon == RandomCourseDataConstraint.DISTINCT) {
+				isDistinct = true;
+			}
+		}
+
+		songDatas = new SongData[stage.length];
+		SongData[] lots = SongData.EMPTY;
+		for (int i = 0; i < stage.length; i++) {
+			String sql = stage[i].getSql();
+			if (sql == null || sql.isEmpty()) {
+				if (i > 0) {
+					lotterySongData(i, songDatas, lots, isDistinct);
+					continue;
+				} else {
+					sql = "1";
+				}
+			}
+			lots = main.getSongDatabase().getSongDatas(sql ,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/score.db"
+					,main.getConfig().getPlayerpath() + File.separatorChar + main.getConfig().getPlayername() + "/scorelog.db",main.getInfoDatabase() != null ? "songinfo.db" : null);
+			lotterySongData(i, songDatas, lots, isDistinct);
+		}
+	}
+
+	private void lotterySongData(int i, SongData[] songDatas, SongData[] lots, boolean isDistinct) {
+		if (lots.length == 0) {
+			return;
+		}
+		if (!isDistinct) {
+			songDatas[i] = lots[random.nextInt(lots.length)];
+			return;
+		}
+
+		// 曲を抽選し、以前のステージと曲が重複したら再抽選する。再抽選できなくなったら重複を許容する。
+		List<SongData> tempLots = new ArrayList(Arrays.asList(lots));
+		while (tempLots.size() > 0) {
+			int ri = random.nextInt(tempLots.size());
+			songDatas[i] = tempLots.get(ri);
+			boolean isDuplicate = false;
+			for (int j = 0; j < i; j++) {
+				if (songDatas[j] == null) {
+					break;
+				}
+				if (Objects.equals(songDatas[i].getSha256(), songDatas[j].getSha256())) {
+					tempLots.remove(ri);
+					isDuplicate = true;
+					break;
+				}
+			}
+			if (!isDuplicate) {
+				return;
+			}
+		}
+		songDatas[i] = lots[random.nextInt(lots.length)];
+		return;
+	}
+
+	/**
+	 * ランダムコースの制約
+	 */
+	public enum RandomCourseDataConstraint {
+		/**
+		 * 曲の重複なし
+		 */
+		DISTINCT("distinct", 0);
+
+		public static final RandomCourseDataConstraint[] EMPTY = new RandomCourseDataConstraint[0];
+
+		public final String name;
+		public final int type;
+
+		RandomCourseDataConstraint(String name, int type) {
+			this.name = name;
+			this.type = type;
+		}
+
+		public static RandomCourseDataConstraint getValue(String name) {
+			for(RandomCourseDataConstraint constraint : RandomCourseDataConstraint.values()) {
+				if(constraint.name.equals(name)) {
+					return constraint;
+				}
+			}
+			return null;
+		}
+	}
+}

--- a/src/bms/player/beatoraja/RandomStageData.java
+++ b/src/bms/player/beatoraja/RandomStageData.java
@@ -1,0 +1,34 @@
+package bms.player.beatoraja;
+
+/**
+ * ランダムコースのステージデータ
+ */
+public class RandomStageData {
+
+	public static final RandomStageData[] EMPTY = new RandomStageData[0];
+
+	/**
+	 * ステージタイトル
+	 */
+	private String title;
+	/**
+	 * DBに対するSQL
+	 */
+	private String sql;
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public String getSql() {
+		return sql;
+	}
+
+	public void setSql(String sql) {
+		this.sql = sql;
+	}
+}

--- a/src/bms/player/beatoraja/select/bar/RandomCourseBar.java
+++ b/src/bms/player/beatoraja/select/bar/RandomCourseBar.java
@@ -1,0 +1,51 @@
+package bms.player.beatoraja.select.bar;
+
+import bms.player.beatoraja.RandomCourseData;
+import bms.player.beatoraja.RandomStageData;
+import bms.player.beatoraja.song.SongData;
+
+/**
+ * ランダムコース選択用バー
+ */
+public class RandomCourseBar extends SelectableBar {
+
+	private RandomCourseData course;
+
+	public RandomCourseBar(RandomCourseData course) {
+		this.course = course;
+	}
+
+	public RandomCourseData getCourseData() {
+		return course;
+	}
+
+	@Override
+	public String getTitle() {
+		return course.getName();
+	}
+
+	@Override
+	public String getArtist() {
+		return null;
+	}
+
+	public SongData[] getSongDatas() {
+		return course.getSongDatas();
+	}
+
+	public boolean existsAllSongs() {
+		if (course.getStage().length == 0) {
+			return false;
+		}
+		for (RandomStageData stage : course.getStage()) {
+			if (stage == null) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	public int getLamp(boolean isPlayer) {
+		return 0;
+	}
+}

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -529,6 +529,7 @@ public class SkinProperty {
 	public static final int OPTION_GRADEBAR_CN = 1016;
 	public static final int OPTION_GRADEBAR_HCN = 1017;
 	public static final int OPTION_RANDOMSELECTBAR = 1030;
+	public static final int OPTION_RANDOMCOURSEBAR = 1031;
 
 	public static final int OPTION_PLAYABLEBAR = 5;
 

--- a/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -409,6 +409,9 @@ public class BooleanPropertyFactory {
 		case OPTION_RANDOMSELECTBAR:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
 					(state) -> ((state instanceof MusicSelector) ? ((MusicSelector) state).getSelectedBar() instanceof ExecutableBar : false));
+		case OPTION_RANDOMCOURSEBAR:
+			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
+					(state) -> ((state instanceof MusicSelector) ? ((MusicSelector) state).getSelectedBar() instanceof RandomCourseBar : false));
 		case OPTION_PLAYABLEBAR:
 			return new DrawProperty(DrawProperty.TYPE_NO_STATIC,
 					(state) -> {
@@ -416,6 +419,7 @@ public class BooleanPropertyFactory {
 							Bar selected = ((MusicSelector) state).getSelectedBar();
 							return ((selected instanceof SongBar) && ((SongBar)selected).getSongData().getPath() != null) ||
 									((selected instanceof GradeBar) && ((GradeBar)selected).existsAllSongs()) ||
+									((selected instanceof RandomCourseBar) && ((RandomCourseBar)selected).existsAllSongs()) ||
 									(selected instanceof ExecutableBar);
 						}
 						return false;

--- a/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -1,9 +1,6 @@
 package bms.player.beatoraja.skin.property;
 
-import bms.player.beatoraja.CourseData;
-import bms.player.beatoraja.IRConfig;
-import bms.player.beatoraja.PlayerInformation;
-import bms.player.beatoraja.ScoreData;
+import bms.player.beatoraja.*;
 import bms.player.beatoraja.config.SkinConfiguration;
 import bms.player.beatoraja.decide.MusicDecide;
 import bms.player.beatoraja.ir.IRScoreData;
@@ -15,6 +12,7 @@ import bms.player.beatoraja.select.MusicSelector;
 import bms.player.beatoraja.select.bar.Bar;
 import bms.player.beatoraja.select.bar.DirectoryBar;
 import bms.player.beatoraja.select.bar.GradeBar;
+import bms.player.beatoraja.select.bar.RandomCourseBar;
 import bms.player.beatoraja.song.SongData;
 
 /**
@@ -243,6 +241,13 @@ public class StringPropertyFactory {
 							final String songname = song != null && song.getTitle() != null ? song.getTitle()
 									: "----";
 							return song != null && song.getPath() != null ? songname : "(no song) " + songname;
+						}
+					} else if (bar instanceof RandomCourseBar) {
+						if (((RandomCourseBar) bar).getCourseData().getStage().length > index) {
+							RandomStageData stage = ((RandomCourseBar) bar).getCourseData().getStage()[index];
+							final String stagename = stage != null && stage.getTitle() != null ? stage.getTitle()
+									: "----";
+							return stage != null ? stagename : "(no song) " + stagename;
 						}
 					}
 				} else {


### PR DESCRIPTION
## 概要
ランダムコースを実装しました。ステージの曲を指定した検索条件でランダムに決定するコースです。
動作としてはLR2のRANDOM MIX(NONSTOPなし)のイメージです。RANDOM MIXと違い、ステージ毎に曲の検索条件を設定できます。
コース定義はカスタムフォルダ(`folder/default.json`)に記述し、曲の検索条件もカスタムフォルダと同様の形式のsqlで書きます。

## 記述例
folder/default.json
```json
{
  "name":"Folder Name",
  "rcourse":[
    {
      "name": "RandomCourse Name",
      "stage": [
        {
          "title": "Stage 1",
          "sql": "sql": "song.mode = 7 AND level = 9"
        },
        {
          "title": "Stage 2",
          "sql": "sql": "song.mode = 7 AND level = 10"
        },
        {
          "title": "Stage 3",
          "sql": "sql": "song.mode = 7 AND level = 11"
        },
        {
          "title": "Stage 4",
          "sql": "sql": "song.mode = 7 AND level = 12"
        },
      ],
      "constraint": [
        "MIRROR",
        "GAUGE_LR2",
      ],
      "rconstraint": [
        "DISTINCT",
      ],
      "trophy": [
        {
          "name": "bronzemedal",
          "missrate": 7.5,
          "scorerate": 55
        },
        {
          "name": "silvermedal",
          "missrate": 5,
          "scorerate": 70
        },
        {
          "name": "goldmedal",
          "missrate": 2.5,
          "scorerate": 85
        }
      ]
    },
    {
      "name": "All Stage Random",
      "stage": [
        {},
        {},
        {},
        {}
      ],
      "constraint": [
        "MIRROR",
        "GAUGE_LR2",
      ],
    },
    {
      "name": "soflan 7keys",
      "stage": [
        {"sql": "song.mode = 7 AND song.maxbpm != song.minbpm"},
        {},
        {},
        {}
      ],
      "constraint": [
        "MIRROR",
        "GAUGE_LR2",
      ],
      "rconstraint": [
        "DISTINCT",
      ],
    }
  ]
}
```

## フォーマット
ランダムコースはカスタムフォルダのフォルダの中に記述する。キー名は`rcourse`

### rcourse
- name: ランダムコース名
- stage: ステージ情報
- constraint: コース制約。通常のコースと同じ。
- rconstraint: ランダムコース制約
- trophy: トロフィー条件。通常のコースと同じ。

### stage
- title: ステージタイトル
- sql: 曲検索条件。カスタムフォルダと同じ書式。
  sqlが未指定または空の場合、1ステージ目なら全曲から検索、2ステージ目以降なら1ステージ前のsqlの結果をそのまま再利用する。
  もし同じsqlで毎回結果を変えたい場合(random()やstrftime()使用時)は、sqlを空にせず記述する。

### rconstraint
- DISTINCT: ステージ間の曲の重複をなるべく無くします。無理な場合は重複を許容します。
  DISTINCTを指定しないと重複ありになる。

## その他の仕様・実装
- ランダムコースバーを選曲するとsqlクエリの実行と曲の抽選が行われ、その結果を元にコースを生成する。
- 生成されたコースは常にIR送信不可。releaseは指定できず、常にfalse。
- 生成されたコースは100件まで残り、元のランダムステージのあるフォルダ内に表示される。
- 生成されたコースはbeatorajaを終了すると消える。コーススコアやリプレイは残る。
- 曲検索結果が0レコードだった場合、画面上部にエラーメッセージが表示され、コースは生成されない。
- コースの曲が全て存在するかは事前に確認されない。random()やdate()の影響で結果に違いが生じるため。
- 曲の検索条件は、選曲画面のキーモードの影響を受けない。
- ランダムコースを持つフォルダは、フォルダ自体のsqlが無効になる。
- stageが空のランダムコースは選曲不可になる。

## その他の変更
- SkinPropertyの追加・変更
  - `OPTION_RANDOMCOURSEBAR`を追加
  - `OPTION_PLAYABLEBAR`の条件にランダムコースバーを追加
  - `OPTION_GRADEBAR_*`と`STRING_COURSE*_TITLE`はコースのものをそのまま使用可能

## 懸念事項
- 曲の抽選処理がかなり適当で遅いかも?(RandomCourseData.java lotterySongDatas())
  - 結果が10000レコード以上のsqlを持つ100ステージのコースだと、処理に200秒くらいかかる
  - sql空欄による検索結果の使いまわしをすればミリ秒以内で終わる