### PR TITLE
Fix compilation error: EventType.notesdisplaytiming

### DIFF
--- a/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -289,7 +289,7 @@ public class EventFactory {
 				state.play(SOUND_OPTIONCHANGE);				
 			}
 		}),
-		judgetiming(74, (state, arg1) -> {
+		notesdisplaytiming(74, (state, arg1) -> {
 	        final PlayerConfig config = state.main.getPlayerConfig();
 
 	        int inc = arg1 >= 0 ? (config.getJudgetiming() < PlayerConfig.JUDGETIMING_MAX ? 1 : 0)


### PR DESCRIPTION
In commit 1311e61099ef34acdc9be30c31490f17081b55ca, `EventType.judgetiming` was renamed to `EventType.notesdisplaytiming`.
However, it was not renamed in [EventFactory.java](https://github.com/exch-bms2/beatoraja/blob/87a86fcf14fc815df60e5f31bd2f12b7dc4f0a58/src/bms/player/beatoraja/skin/property/EventFactory.java#L292), causing a compilation error.