### PR TITLE
Fix: 24KEY cannot be selected by default SKIN SELECT skin

### DIFF
--- a/skin/default/skinselect/skinselectmain.lua
+++ b/skin/default/skinselect/skinselectmain.lua
@@ -112,9 +112,9 @@ local function main()
 		{id = "type-13" , images = {"type-off-13", "type-on-13"}, act = 183, ref = 183},
 		{id = "type-14" , images = {"type-off-14", "type-on-14"}, act = 184, ref = 184},
 		{id = "type-15" , images = {"type-off-15", "type-on-15"}, act = 185, ref = 185},
-		{id = "type-16" , images = {"type-off-16", "type-on-16"}, act = 186, ref = 186},
-		{id = "type-17" , images = {"type-off-17", "type-on-17"}, act = 187, ref = 187},
-		{id = "type-18" , images = {"type-off-18", "type-on-18"}, act = 188, ref = 188},
+		{id = "type-16" , images = {"type-off-16", "type-on-16"}, act = 386, ref = 386},
+		{id = "type-17" , images = {"type-off-17", "type-on-17"}, act = 387, ref = 387},
+		{id = "type-18" , images = {"type-off-18", "type-on-18"}, act = 388, ref = 388},
 	}
 	skin.value = {}
 	skin.text = {


### PR DESCRIPTION
デフォルトのSKIN SELECTスキン(`beatoraja default (lua)`)で24KEY(と2つのバリエーション)が選択できない問題を修正しました。選択後に各項目が変更できることを確認済みです。

参考：

https://github.com/exch-bms2/beatoraja/blob/89e6ab145468461cffe1cf7a3b3a336c3c9d8dd8/src/bms/player/beatoraja/skin/SkinProperty.java#L899-L901

https://github.com/exch-bms2/beatoraja/blob/89e6ab145468461cffe1cf7a3b3a336c3c9d8dd8/src/bms/player/beatoraja/skin/SkinProperty.java#L928-L930

※スキンのみの不具合なので起動前の設定画面では正常に選択できます