### PR TITLE
Menu BGM desync fixes

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -279,6 +279,9 @@ public class MainController extends ApplicationAdapter {
 			if(newState.getSkin() != null) {
 				newState.getSkin().prepare(newState);
 			}
+			if (current != null) {
+				current.shutdown();
+			}
 			current = newState;
 			starttime = System.nanoTime();
 			nowmicrotime = ((System.nanoTime() - starttime) / 1000);

--- a/src/bms/player/beatoraja/MainState.java
+++ b/src/bms/player/beatoraja/MainState.java
@@ -47,6 +47,10 @@ public abstract class MainState {
 
 	}
 
+	public void shutdown() {
+
+	}
+
 	public abstract void render();
 
 	public void input() {

--- a/src/bms/player/beatoraja/decide/MusicDecide.java
+++ b/src/bms/player/beatoraja/decide/MusicDecide.java
@@ -25,12 +25,15 @@ public class MusicDecide extends MainState {
 	public void create() {
 		cancel = false;
 		
-		setSound(SOUND_DECIDE, "decide.wav", SoundType.BGM, false);
-		play(SOUND_DECIDE);
-
 		loadSkin(SkinType.DECIDE);
 
 		main.getPlayerResource().setOrgGaugeOption(main.getPlayerResource().getPlayerConfig().getGauge());
+	}
+
+	public void prepare() {
+		super.prepare();
+		setSound(SOUND_DECIDE, "decide.wav", SoundType.BGM, false);
+		play(SOUND_DECIDE);
 	}
 
 	public void render() {

--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -161,6 +161,12 @@ public class CourseResult extends AbstractResult {
 		play(newscore.getClear() != Failed.id ? SOUND_CLEAR : SOUND_FAIL);
 	}
 
+	public void shutdown() {
+		stop(SOUND_CLEAR);
+		stop(SOUND_FAIL);
+		stop(SOUND_CLOSE);
+	}
+
 	public void render() {
 		long time = main.getNowTime();
 		main.switchTimer(TIMER_RESULTGRAPH_BEGIN, true);
@@ -174,9 +180,6 @@ public class CourseResult extends AbstractResult {
 		if (main.isTimerOn(TIMER_FADEOUT)) {
 			if (main.getNowTime(TIMER_FADEOUT) > getSkin().getFadeout()) {
 				main.getPlayerResource().getPlayerConfig().setGauge(main.getPlayerResource().getOrgGaugeOption());
-				stop(SOUND_CLEAR);
-				stop(SOUND_FAIL);
-				stop(SOUND_CLOSE);
 				main.changeState(MainStateType.MUSICSELECT);
 			}
 		} else if (time > getSkin().getScene()) {

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -150,6 +150,12 @@ public class MusicResult extends AbstractResult {
 		play(newscore.getClear() != Failed.id && (cscore == null || cscore.getClear() != Failed.id) ? SOUND_CLEAR : SOUND_FAIL);
 	}
 
+	public void shutdown() {
+		stop(SOUND_CLEAR);
+		stop(SOUND_FAIL);
+		stop(SOUND_CLOSE);
+	}
+
 	public void render() {
 		long time = main.getNowTime();
 		main.switchTimer(TIMER_RESULTGRAPH_BEGIN, true);
@@ -166,9 +172,6 @@ public class MusicResult extends AbstractResult {
 
 		if (main.isTimerOn(TIMER_FADEOUT)) {
 			if (main.getNowTime(TIMER_FADEOUT) > getSkin().getFadeout()) {
-				stop(SOUND_CLEAR);
-				stop(SOUND_FAIL);
-				stop(SOUND_CLOSE);
 				main.getAudioProcessor().stop((Note) null);
 
 				final BMSPlayerInputProcessor input = main.getInputProcessor();

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -361,7 +361,6 @@ public class MusicSelector extends MainState {
 
 		preview = new PreviewMusicProcessor(main.getAudioProcessor(), main.getPlayerResource().getConfig());
 		preview.setDefault(getSound(SOUND_BGM));
-		preview.start(null);
 
 		final BMSPlayerInputProcessor input = main.getInputProcessor();
 		PlayModeConfig pc = (config.getMusicselectinput() == 0 ? config.getMode7()
@@ -383,6 +382,10 @@ public class MusicSelector extends MainState {
 			search = new SearchTextField(this, main.getPlayerResource().getConfig().getResolution());
 			setStage(search);
 		}
+	}
+
+	public void prepare() {
+		preview.start(null);
 	}
 
 	public void render() {
@@ -555,9 +558,12 @@ public class MusicSelector extends MainState {
 
 		musicinput.input();
 	}
+
+	public void shutdown() {
+		preview.stop();
+	}
 	
 	public void changeState(MainStateType type) {
-		preview.stop();
 		main.changeState(type);
 		if (search != null) {
 			search.unfocus(this);


### PR DESCRIPTION
-Introduced the shutdown() method to MainState class. It is called right before the prepare() method on a new state.
-Moved menu BGM playback start and stop to prepare() and shutdown() respectively to minimize audio desync.