### PR TITLE
Fix key of property map from md5 to sha256 to support bmson

### DIFF
--- a/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -359,10 +359,10 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 				// 楽曲のタグ,FAVORITEの保持
 				for (SongData record : qr.query(conn, "SELECT md5, tag, favorite FROM song", songhandler)) {
 					if (record.getTag().length() > 0) {
-						property.tags.put(record.getMd5(), record.getTag());
+						property.tags.put(record.getSha256(), record.getTag());
 					}
 					if (record.getFavorite() > 0) {
-						property.favorites.put(record.getMd5(), record.getFavorite());
+						property.favorites.put(record.getSha256(), record.getFavorite());
 					}
 				}
 				
@@ -570,8 +570,8 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 					if((sd.getPreview() == null || sd.getPreview().length() == 0) && previewpath != null) {
 						sd.setPreview(previewpath);
 					}
-					final String tag = property.tags.get(sd.getMd5());
-					final Integer favorite = property.favorites.get(sd.getMd5());
+					final String tag = property.tags.get(sd.getSha256());
+					final Integer favorite = property.favorites.get(sd.getSha256());
 					
 					for(SongDatabaseAccessorPlugin plugin : plugins) {
 						plugin.update(model, sd);


### PR DESCRIPTION
bmson譜面を考慮し、タグとFAVORITE保持処理に使用するプロパティマップのキーをmd5からsha256に修正

## 発生していたバグ
bmson譜面のレコードに付与されていたタグとFAVORITE情報が、楽曲読み込み/楽曲全更新時に他のbmson譜面のレコードにコピーされてしまう。

### 再現方法
#### 楽曲読み込み
1. 任意のbmson譜面にFAVORITEを付ける
2. bmson譜面をリソースフォルダ内に追加する
3. 楽曲読み込みをする
4. 2で追加したbmson譜面に1で付与したFAVORITE情報がコピーされる

#### 楽曲全更新
1. 任意のbmson譜面にFAVORITEを付ける
2. 楽曲全更新をする
3. 全てのbmson譜面に1で付与したFAVORITE情報がコピーされる

### 発生原因
タグとFAVORITE保持処理に使用するプロパティマップのキーにmd5を使用していたため、md5が存在しないbmson譜面の保持処理時にキーが全て空文字`""`になり、他の更新対象のbmson譜面に値がコピーされてしまっていた。