### PR TITLE
Display chart details on double-click in custom tables/courses tab in configuration.

### DIFF
--- a/src/bms/player/beatoraja/launcher/CourseEditorView.java
+++ b/src/bms/player/beatoraja/launcher/CourseEditorView.java
@@ -91,6 +91,17 @@ public class CourseEditorView implements Initializable {
 
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
+		searchSongs.setOnMouseClicked((click) -> {
+			if (click.getClickCount() == 2) {
+				TableEditorView.displayChartDetailsDialog(songdb, searchSongs.getSelectionModel().getSelectedItem());
+			}
+		});
+		courseSongs.setOnMouseClicked((click) -> {
+			if (click.getClickCount() == 2) {
+				TableEditorView.displayChartDetailsDialog(songdb, courseSongs.getSelectionModel().getSelectedItem());
+			}
+		});
+
 		updateCourse(null);
 	}
 	

--- a/src/bms/player/beatoraja/launcher/FolderEditorView.java
+++ b/src/bms/player/beatoraja/launcher/FolderEditorView.java
@@ -62,6 +62,17 @@ public class FolderEditorView implements Initializable {
 
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 		
+		searchSongs.setOnMouseClicked((click) -> {
+			if (click.getClickCount() == 2) {
+				displayChartDetailsDialog(searchSongs.getSelectionModel().getSelectedItem());
+			}
+		});
+		folderSongs.setOnMouseClicked((click) -> {
+			if (click.getClickCount() == 2) {
+				displayChartDetailsDialog(folderSongs.getSelectionModel().getSelectedItem());
+			}
+		});
+
 		updateFolder(null);
 	}
 	
@@ -179,5 +190,34 @@ public class FolderEditorView implements Initializable {
 	
 	public void setTableFolder(TableFolder[] folder) {
 		folders.getItems().setAll(folder);
+	}
+
+	private static String getFoldersContainingSong(TableFolder[] folders, SongData song) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < folders.length; i++) {
+			SongData[] songs = folders[i].getSong();
+			for (int j = 0; j < songs.length; j++) {
+				SongData ts = songs[j];
+				if((ts.getMd5().length() != 0 && song.getMd5().length() != 0 && ts.getMd5().equals(song.getMd5())) ||
+						(ts.getMd5().length() != 0 && song.getMd5().length() != 0 && ts.getSha256().equals(song.getSha256()))) {
+					if (sb.length() > 0) {
+						sb.append(", ");
+					}
+					sb.append(folders[i].getName());
+					continue;
+				}
+			}
+		}
+		if (sb.length() == 0) {
+			return "None";
+		} else {
+			return sb.toString();
+		}
+	}
+
+	private void displayChartDetailsDialog(SongData song) {
+		if (song == null) return;
+		TableEditorView.displayChartDetailsDialog(songdb, song, "In custom folder(s):\n" + 
+				getFoldersContainingSong(folders.getItems().toArray(new TableFolder[0]), song));
 	}
 }

--- a/src/bms/player/beatoraja/launcher/TableEditorView.java
+++ b/src/bms/player/beatoraja/launcher/TableEditorView.java
@@ -1,14 +1,29 @@
 package bms.player.beatoraja.launcher;
 
+import java.awt.Desktop;
+import java.io.IOException;
+
 import java.net.URL;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ResourceBundle;
 
 import bms.player.beatoraja.TableData;
+import bms.player.beatoraja.TableData.TableFolder;
 import bms.player.beatoraja.song.SongDatabaseAccessor;
+import bms.player.beatoraja.song.SongData;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.geometry.Pos;
+import javafx.scene.control.Button;
+import javafx.scene.control.ButtonBar.ButtonData;
+import javafx.scene.control.ButtonType;
+import javafx.scene.control.Dialog;
+import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.ColumnConstraints;
+import javafx.scene.layout.GridPane;
+
 
 public class TableEditorView implements Initializable {
 
@@ -52,5 +67,110 @@ public class TableEditorView implements Initializable {
 		td.setFolder(folderController.getTableFolder());
 		
 		TableData.write(filepath, td);
+	}
+
+	private static void dialogAddCopiableRow(GridPane gridPane, int row, String labelText, String dataText) {
+		Label label = new Label(labelText + ": ");
+		TextField textField = new TextField(dataText);
+		textField.setEditable(false);
+		gridPane.add(label, 0, row, 1, 1);
+		gridPane.add(textField, 1, row, 2, 1);
+	}
+
+	protected static void displayChartDetailsDialog(SongDatabaseAccessor songdb, SongData song, String... extraData) {
+		if (song == null) return;
+
+		GridPane gridPane = new GridPane();
+		gridPane.getColumnConstraints().addAll(
+			new ColumnConstraints(90),
+			new ColumnConstraints(300),
+			new ColumnConstraints(85)
+		);
+		gridPane.setMaxWidth(Double.MAX_VALUE);
+
+		dialogAddCopiableRow(gridPane, 0, "Title", song.getFullTitle());
+		dialogAddCopiableRow(gridPane, 1, "Artist", song.getFullArtist());
+		dialogAddCopiableRow(gridPane, 2, "Genre", song.getGenre());
+
+		dialogAddCopiableRow(gridPane, 3, "MD5 Hash", song.getMd5());
+		dialogAddCopiableRow(gridPane, 4, "SHA256 Hash", song.getSha256());
+
+		if (song.getPath() == null && songdb != null) {
+			// Try to find actual song in songdb, if songdata was not retrieved from songdb
+			SongData[] foundSongs = songdb.getSongDatas(new String[]{song.getSha256()});
+			if (foundSongs.length != 0) {
+				song = foundSongs[0];
+			} else {
+				foundSongs = songdb.getSongDatas(new String[]{song.getMd5()});
+				if (foundSongs.length != 0) {
+					song = foundSongs[0];
+				}
+			}
+		}
+
+		if (song.getPath() != null) {
+			// Display song details, if song can be found in songdb (otherwise details are inaccessible)
+			String levelString = "UNKNOWN";
+			switch(song.getDifficulty()) {
+				case 1: {levelString = "BEGINNER"; break;}
+				case 2: {levelString = "NORMAL"; break;}
+				case 3: {levelString = "HYPER"; break;}
+				case 4: {levelString = "ANOTHER"; break;}
+				case 5: {levelString = "INSANE"; break;}
+			}
+
+			String judgeString;
+			int judgeRank = song.getJudge();
+			if (judgeRank <= 25) {judgeString = "VERY HARD";}
+			else if (judgeRank <= 50) {judgeString = "HARD";}
+			else if (judgeRank <= 75) {judgeString = "NORMAL";}
+			else if (judgeRank <= 100) {judgeString = "EASY";}
+			else {judgeString = "VERY EASY";}
+
+			String bpmString;
+			if (song.getMinbpm() == song.getMaxbpm()) {
+				bpmString = String.format("%dbpm", song.getMaxbpm());
+			} else {
+				bpmString = String.format("%d-%dbpm", song.getMinbpm(), song.getMaxbpm());
+			}
+
+			String timeString = String.format("%d:%02d", song.getLength()/60000, (song.getLength()/1000)%60);
+
+
+			Label detailsLabel = new Label(String.format("%dkeys / %s %d / %d notes / %s / %s / %s",
+					song.getMode(), levelString, song.getLevel(), song.getNotes(), timeString, bpmString, judgeString));
+			detailsLabel.setAlignment(Pos.CENTER);
+			detailsLabel.setMaxWidth(Double.MAX_VALUE);
+			gridPane.add(detailsLabel, 0, 5, 2, 1);
+
+			Button openFolderButton = new Button("Open Folder");
+			openFolderButton.setMaxWidth(Double.MAX_VALUE);
+			String songPath = song.getPath();
+			openFolderButton.setOnAction((actionEvent) -> {
+				try {
+					if (Desktop.isDesktopSupported()) {
+						Desktop.getDesktop().open(Paths.get(songPath).getParent().toFile());
+					}
+				} catch (IOException|IllegalArgumentException e) {
+					e.printStackTrace();
+				}
+			});
+			gridPane.add(openFolderButton, 2, 5, 1, 1);
+		}
+
+		for (int i = 0; i < extraData.length; i++) {
+			Label extraLabel = new Label(extraData[i]);
+			extraLabel.setAlignment(Pos.CENTER);
+			extraLabel.setMaxWidth(Double.MAX_VALUE);
+			gridPane.add(extraLabel, 0, 6+i, 3, 1);
+		}
+
+		Dialog dialog = new Dialog();
+		dialog.setTitle("Chart Details");
+		dialog.getDialogPane().setMinWidth(500);
+		dialog.getDialogPane().setMaxWidth(500);
+		dialog.getDialogPane().setContent(gridPane);
+		dialog.getDialogPane().getButtonTypes().add(new ButtonType("OK", ButtonData.CANCEL_CLOSE));
+		dialog.show();
 	}
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/27341392/172178700-1373d827-e5e9-4e67-8f83-41182ee1e5c3.png)

# Summary
This only affects the custom tables / custom courses tab in the beatoraja configuration.
Double-clicking a song in the search bar, custom course or custom table will open a dialog box that displays details of the chart/song. The details can be selected and copied with ctrl+c.

# Applications
1. It was previously not possible to copy (ctrl+c) song titles and hashes out of custom courses and tables. This details panel allows easy copying of the chart hash and metadata. (this makes it easier to transfer a chart from one folder to another)
2. The "Open Folder" button can be used to open the song in explorer (similar to F3 in game)
3. At the bottom of the dialog, the custom table folders that the chart is in are listed. Now you can check if a chart is already in the custom table before adding it. It makes it easier to manage large custom tables because it would be otherwise impossible to check for duplicates.