### PR TITLE
Fix cycling through rivals on rival event

### DIFF
--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -79,17 +79,17 @@ public class MusicSelector extends MainState {
 	 * 楽曲が選択されてからプレビュー曲を再生するまでの時間(ms)
 	 */
 	private final int previewDuration = 400;
-	
+
 	private final int rankingDuration = 5000;
 	private final int rankingReloadDuration = 10 * 60 * 1000;
-	
+
 	private long currentRankingDuration = -1;
 
 	private boolean showNoteGraph = false;
 
 	private ScoreDataCache scorecache;
 	private ScoreDataCache rivalcache;
-	
+
 	private RankingData currentir;
 	private RankingDataCache ircache = new RankingDataCache();
 	/**
@@ -152,16 +152,16 @@ public class MusicSelector extends MainState {
 						Logger.getGlobal().info("IRからのスコアインポート完了");
 					} else {
 						Logger.getGlobal().warning("IRからのスコアインポート失敗 : " + scores.getMessage());
-					}					
+					}
 				} catch (Throwable e) {
 					e.printStackTrace();
 				}
 			}
-			
+
 			IRResponse<IRPlayerData[]> response = main.getIRStatus()[0].connection.getRivals();
 			if(response.isSucceeded()) {
 				try {
-					
+
 					// ライバルスコアデータベース作成
 					// TODO 別のクラスに移動
 					if(!Files.exists(Paths.get("rival"))) {
@@ -171,7 +171,7 @@ public class MusicSelector extends MainState {
 					// ライバルキャッシュ作成
 					Array<PlayerInformation> rivals = new Array();
 					Array<ScoreDataCache> rivalcaches = new Array();
-					
+
 					if(main.getIRStatus()[0].config.isImportrival()) {
 						for(IRPlayerData irplayer : response.getData()) {
 							final PlayerInformation rival = new PlayerInformation();
@@ -179,7 +179,7 @@ public class MusicSelector extends MainState {
 							rival.setName(irplayer.name);
 							rival.setRank(irplayer.rank);
 							final ScoreDatabaseAccessor scoredb = new ScoreDatabaseAccessor("rival/" + main.getIRStatus()[0].config.getIrname() + rival.getId() + ".db");
-							
+
 							rivals.add(rival);
 							rivalcaches.add(new ScoreDataCache() {
 
@@ -205,7 +205,7 @@ public class MusicSelector extends MainState {
 							}).start();
 						}
 					}
-					
+
 					try (DirectoryStream<Path> paths = Files.newDirectoryStream(Paths.get("rival"))) {
 						for (Path p : paths) {
 							boolean exists = false;
@@ -218,7 +218,7 @@ public class MusicSelector extends MainState {
 							if(exists) {
 								continue;
 							}
-							
+
 							if(p.toString().endsWith(".db")) {
 								final ScoreDatabaseAccessor scoredb = new ScoreDatabaseAccessor(p.toString());
 								PlayerInformation info = scoredb.getInformation();
@@ -267,7 +267,7 @@ public class MusicSelector extends MainState {
 			main.updateSong(null);
 		}
 	}
-	
+
 	private ScoreData[] convert(IRScoreData[] irscores) {
 		ScoreData[] scores = new ScoreData[irscores.length];
 		for(int i = 0;i < scores.length;i++) {
@@ -276,7 +276,7 @@ public class MusicSelector extends MainState {
 			score.setSha256(irscore.sha256);
 			score.setMode(irscore.lntype);
 			score.setPlayer(irscore.player);
-			score.setClear(irscore.clear.id); 
+			score.setClear(irscore.clear.id);
 			score.setDate(irscore.date);
 			score.setEpg(irscore.epg);
 			score.setLpg(irscore.lpg);
@@ -299,7 +299,7 @@ public class MusicSelector extends MainState {
 			score.setAssist(irscore.assist);
 			score.setGauge(irscore.gauge);
 			score.setDeviceType(irscore.deviceType);
-			
+
 			scores[i] = score;
 		}
 		return scores;
@@ -433,7 +433,7 @@ public class MusicSelector extends MainState {
 				}
 				irc.load(this, song);
 	            currentir = irc;
-			}				
+			}
 			if (current instanceof GradeBar && ((GradeBar) current).existsAllSongs() && play == null) {
 				CourseData course = ((GradeBar) current).getCourseData();
 				RankingData irc = ircache.get(course, config.getLnmode());
@@ -443,7 +443,7 @@ public class MusicSelector extends MainState {
 				}
 				irc.load(this, course);
 	            currentir = irc;
-			}				
+			}
 		}
 		final int irstate = currentir != null ? currentir.getState() : -1;
 		main.switchTimer(TIMER_IR_CONNECT_BEGIN, irstate == RankingData.ACCESS);
@@ -481,7 +481,7 @@ public class MusicSelector extends MainState {
 						}
 						resource.setRankingData(currentir);
 						resource.setRivalScoreData(current.getRivalScore());
-						
+
 						playedsong = song;
 						changeState(MainStateType.DECIDE);
 					} else {
@@ -567,7 +567,7 @@ public class MusicSelector extends MainState {
 	public void shutdown() {
 		preview.stop();
 	}
-	
+
 	public void changeState(MainStateType type) {
 		main.changeState(type);
 		if (search != null) {
@@ -800,11 +800,11 @@ public class MusicSelector extends MainState {
 				currentRankingDuration = (currentir != null ? Math.max(rankingReloadDuration - (System.currentTimeMillis() - currentir.getLastUpdateTime()) ,0) : 0) + rankingDuration;
 			} else {
 				currentir = null;
-				currentRankingDuration = -1;			
+				currentRankingDuration = -1;
 			}
 		} else {
 			currentir = null;
-			currentRankingDuration = -1;			
+			currentRankingDuration = -1;
 		}
 	}
 
@@ -845,24 +845,24 @@ public class MusicSelector extends MainState {
 		}
 		return pc;
 	}
-	
+
 	public RankingData getCurrentRankingData() {
 		return currentir;
 	}
-	
+
 	public long getCurrentRankingDuration() {
 		return currentRankingDuration;
 	}
-	
+
 	public int getRankingOffset() {
 		return rankingOffset;
 	}
-	
+
 	public float getRankingPosition() {
 		final int rankingMax = currentir != null ? Math.max(1, currentir.getTotalPlayer()) : 1;
-		return (float)rankingOffset / rankingMax;		
+		return (float)rankingOffset / rankingMax;
 	}
-	
+
 	public void setRankingPosition(float value) {
 		if (value >= 0 && value < 1) {
 			final int rankingMax = currentir != null ? Math.max(1, currentir.getTotalPlayer()) : 1;
@@ -924,7 +924,7 @@ public class MusicSelector extends MainState {
 	        final int cacheindex = song.hasUndefinedLongNote() ? lnmode : 3;
 	        scorecache[cacheindex].put(song.getSha256(), iras);
 	    }
-	    
+
 	    public void put(CourseData course, int lnmode, RankingData iras) {
 	        int cacheindex = 3;
 	        for(SongData song : course.getSong()) {
@@ -934,7 +934,7 @@ public class MusicSelector extends MainState {
 	        }
 	        cscorecache[cacheindex].put(createCourseHash(course), iras);
 	    }
-	    
+
 		private String createCourseHash(CourseData course) {
 			StringBuilder sb = new StringBuilder();
 			for(SongData song : course.getSong()) {

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -8,6 +8,8 @@ import java.security.NoSuchAlgorithmException;
 import java.io.File;
 import java.lang.StringBuilder;
 import java.nio.file.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.logging.Logger;
 
 import bms.player.beatoraja.ir.IRPlayerData;
@@ -15,7 +17,6 @@ import bms.player.beatoraja.ir.IRPlayerData;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.utils.*;
-import com.badlogic.gdx.utils.ObjectMap.Keys;
 
 import bms.model.BMSDecoder;
 import bms.model.Mode;
@@ -98,7 +99,7 @@ public class MusicSelector extends MainState {
 	protected int rankingOffset = 0;
 
 	private PlayerInformation rival;
-	private PlayerInformation[] rivals = new PlayerInformation[0];
+	private List<PlayerInformation> rivals = new ArrayList<>();
 	private ScoreDataCache[] rivalcaches = new ScoreDataCache[0];
 
 	private int panelstate;
@@ -169,10 +170,10 @@ public class MusicSelector extends MainState {
 					}
 
 					// ライバルキャッシュ作成
-					Array<PlayerInformation> rivals = new Array();
+					List<PlayerInformation> rivals = new ArrayList<>();
 					Array<ScoreDataCache> rivalcaches = new Array();
 
-					if(main.getIRStatus()[0].config.isImportrival()) {
+					if (main.getIRStatus()[0].config.isImportrival()) {
 						for(IRPlayerData irplayer : response.getData()) {
 							final PlayerInformation rival = new PlayerInformation();
 							rival.setId(irplayer.id);
@@ -247,7 +248,7 @@ public class MusicSelector extends MainState {
 					} catch (Throwable e) {
 						e.printStackTrace();
 					}
-					this.rivals = rivals.toArray(PlayerInformation.class);
+					this.rivals = rivals;
 					this.rivalcaches = rivalcaches.toArray(ScoreDataCache.class);
 
 				} catch (Throwable e) {
@@ -306,14 +307,8 @@ public class MusicSelector extends MainState {
 	}
 
 	public void setRival(PlayerInformation rival) {
-		int index = -1;
-		for(int i = 0;i < rivals.length;i++) {
-			if(rival == rivals[i]) {
-				index = i;
-				break;
-			}
-		}
-		this.rival = index != -1 ? rivals[index] : null;
+		int index = rivals.indexOf(rival);
+		this.rival = index != -1 ? rivals.get(index) : null;
 		rivalcache = index != -1 ? rivalcaches[index] : null;
 		bar.updateBar();
 		Logger.getGlobal().info("Rival変更:" + (rival != null ? rival.getName() : "なし"));
@@ -323,7 +318,7 @@ public class MusicSelector extends MainState {
 		return rival;
 	}
 
-	public PlayerInformation[] getRivals() {
+	public List<PlayerInformation> getRivals() {
 		return rivals;
 	}
 

--- a/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -33,14 +33,14 @@ import java.util.function.*;
 
 /**
  * EventのFactoryクラス
- * 
+ *
  * @author excln
  */
 public class EventFactory {
 
 	/**
 	 * ID指定によるイベント取得(組み込みまたはカスタムイベントとして登録したもの)
-	 * 
+	 *
 	 * @param eventId イベントID
 	 * @return イベントオブジェクト
 	 */
@@ -57,7 +57,7 @@ public class EventFactory {
 
 	/**
 	 * name指定によるイベント取得(組み込みまたはカスタムイベントとして登録したもの)
-	 * 
+	 *
 	 * @param eventName イベント名称
 	 * @return イベントオブジェクト
 	 */
@@ -112,22 +112,22 @@ public class EventFactory {
 		skinconfig(14, (state) -> {
 			if(state instanceof MusicSelector) {
 				((MusicSelector) state).changeState(MainStateType.SKINCONFIG);
-			}			
+			}
 		}),
 		play(15, (state) -> {
 			if(state instanceof MusicSelector) {
 				((MusicSelector) state).selectSong(BMSPlayerMode.PLAY);
-			}						
+			}
 		}),
 		autoplay(16, (state) -> {
 			if(state instanceof MusicSelector) {
 				((MusicSelector) state).selectSong(BMSPlayerMode.AUTOPLAY);
-			}						
+			}
 		}),
 		practice(315, (state) -> {
 			if(state instanceof MusicSelector) {
 				((MusicSelector) state).selectSong(BMSPlayerMode.PRACTICE);
-			}						
+			}
 		}),
 		/**
 		 * 楽曲ファイルのドキュメントをOS既定のドキュメントビューアーで開く
@@ -155,7 +155,7 @@ public class EventFactory {
 				}
 			}
 		}),
-		
+
 	    /**
 	     * ゲージオプションの変更
 	     */
@@ -163,7 +163,7 @@ public class EventFactory {
 			if(state instanceof MusicSelector) {
 	            PlayerConfig config = state.main.getPlayerConfig();
 	            config.setGauge((config.getGauge() + (arg1 >= 0 ? 1 : 5)) % 6);
-	            state.play(SOUND_OPTIONCHANGE);				
+	            state.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 	    /**
@@ -173,7 +173,7 @@ public class EventFactory {
 			if(state instanceof MusicSelector) {
 	            PlayerConfig config = state.main.getPlayerConfig();
 	            config.setRandom((config.getRandom() + (arg1 >= 0 ? 1 : 9)) % 10);
-	            state.play(SOUND_OPTIONCHANGE);				
+	            state.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 	    /**
@@ -205,7 +205,7 @@ public class EventFactory {
 	            if (pc != null) {
 	                pc.setFixhispeed((pc.getFixhispeed() + (arg1 >= 0 ? 1 : 4)) % 5);
 	                state.play(SOUND_OPTIONCHANGE);
-	            }				
+	            }
 			}
 		}),
 	    /**
@@ -214,12 +214,12 @@ public class EventFactory {
 		hispeed1p(57, (state, arg1) -> {
 			if(state instanceof MusicSelector) {
 				final MusicSelector selector = (MusicSelector) state;
-	            PlayConfig pc = selector.getSelectedBarPlayConfig();	            
+	            PlayConfig pc = selector.getSelectedBarPlayConfig();
             	float hispeed = pc.getHispeed() + (arg1 >= 0 ? pc.getHispeedMargin() : -pc.getHispeedMargin());
             	hispeed = MathUtils.clamp(hispeed, PlayConfig.HISPEED_MIN, PlayConfig.HISPEED_MAX);
             	if(hispeed != pc.getHispeed()) {
             		pc.setHispeed(hispeed);
-	                state.play(SOUND_OPTIONCHANGE);		        	
+	                state.play(SOUND_OPTIONCHANGE);
             	}
 			}
 		}),
@@ -229,14 +229,14 @@ public class EventFactory {
 		duration1p(59, (state, arg1, arg2) -> {
 			if(state instanceof MusicSelector) {
 				final MusicSelector selector = (MusicSelector) state;
-	            PlayConfig pc = selector.getSelectedBarPlayConfig();	            
+	            PlayConfig pc = selector.getSelectedBarPlayConfig();
             	final int inc = arg2 > 0 ? arg2 : 1;
             	int duration = pc.getDuration() + (arg1 >= 0 ? inc : -inc);
         		duration = MathUtils.clamp(duration, PlayConfig.DURATION_MIN, PlayConfig.DURATION_MAX);
 		        if(duration != pc.getDuration()) {
 		        	pc.setDuration(duration);
-	                state.play(SOUND_OPTIONCHANGE);		        	
-		        }	            	
+	                state.play(SOUND_OPTIONCHANGE);
+		        }
 			}
 		}),
 		hispeedautoadjust(342, (state) -> {
@@ -286,13 +286,13 @@ public class EventFactory {
 		bga(72, (state, arg1) -> {
 			if(state instanceof MusicSelector) {
 				state.main.getConfig().setBga((state.main.getConfig().getBga() + (arg1 >= 0 ? 1 : 2)) % 3);
-				state.play(SOUND_OPTIONCHANGE);				
+				state.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 		bgaexpand(73, (state, arg1) -> {
 			if(state instanceof MusicSelector) {
 				state.main.getConfig().setBgaExpand((state.main.getConfig().getBgaExpand() + (arg1 >= 0 ? 1 : 2)) % 3);
-				state.play(SOUND_OPTIONCHANGE);				
+				state.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 		notesdisplaytiming(74, (state, arg1) -> {
@@ -300,11 +300,11 @@ public class EventFactory {
 
 	        int inc = arg1 >= 0 ? (config.getJudgetiming() < PlayerConfig.JUDGETIMING_MAX ? 1 : 0)
 	        		: (config.getJudgetiming() > PlayerConfig.JUDGETIMING_MIN ? -1 : 0);
-	        
+
 	        if(inc != 0) {
                 config.setJudgetiming(config.getJudgetiming() + inc);
     			if(state instanceof MusicSelector) {
-                    state.play(SOUND_OPTIONCHANGE);		        	
+                    state.play(SOUND_OPTIONCHANGE);
     			}
 	        }
 		}),
@@ -312,7 +312,7 @@ public class EventFactory {
 	        final PlayerConfig config = state.main.getPlayerConfig();
             config.setNotesDisplayTimingAutoAdjust(!config.isNotesDisplayTimingAutoAdjust());
 			if(state instanceof MusicSelector) {
-                state.play(SOUND_OPTIONCHANGE);		        	
+                state.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 		target(77, (state, arg1) -> {
@@ -347,7 +347,7 @@ public class EventFactory {
 	            		index = i;
 	            		break;
 	            	}
-	            }	            
+	            }
 	            index = (index + (arg1 >= 0 ? 2 : 0)) % (selector.getRivals().length + 1) - 1;
 	            selector.setRival(index != -1 ? selector.getRivals()[index] : null);
 	            selector.play(SOUND_OPTIONCHANGE);
@@ -361,7 +361,7 @@ public class EventFactory {
 					type = 2;
 				} else if((sd.getFavorite() & SongData.FAVORITE_CHART) != 0) {
 					type = 1;
-				}				
+				}
 				type = (type + (next ? 1 : 2)) % 3;
 				int favorite = sd.getFavorite();
 				switch (type) {
@@ -392,7 +392,7 @@ public class EventFactory {
 						} else if ((sd.getFavorite() & SongData.INVISIBLE_CHART) != 0) {
 							message = next ? "Removed from Invisible Chart" : "Added to Favorite Chart";
 						}
-						
+
 						changeFav.accept(sd);
 
 						selector.main.getMessageRenderer().addMessage(message, 1200, Color.GREEN, 1);
@@ -404,7 +404,7 @@ public class EventFactory {
 			if(state instanceof MusicResult) {
 				final SongData sd = state.main.getPlayerResource().getSongdata();
 				if(sd != null) {
-					changeFav.accept(sd);					
+					changeFav.accept(sd);
 				}
 			}
 		}),
@@ -416,7 +416,7 @@ public class EventFactory {
 					type = 2;
 				} else if((sd.getFavorite() & SongData.FAVORITE_SONG) != 0) {
 					type = 1;
-				}				
+				}
 				type = (type + (next ? 1 : 2)) % 3;
 				SongData[] songs = state.main.getSongDatabase().getSongDatas("folder", sd.getFolder());
 				for(SongData song : songs) {
@@ -450,7 +450,7 @@ public class EventFactory {
 						} else if((sd.getFavorite() & SongData.INVISIBLE_SONG) != 0) {
 							message =next ?  "Removed from Invisible Song" : "Added to Favorite Song";
 						}
-						changeFav.accept(sd);					
+						changeFav.accept(sd);
 						selector.main.getMessageRenderer().addMessage(message, 1200, Color.GREEN, 1);
 						selector.getBarRender().updateBar();
 						selector.play(SOUND_OPTIONCHANGE);
@@ -460,7 +460,7 @@ public class EventFactory {
 			if(state instanceof MusicResult) {
 				final SongData sd = state.main.getPlayerResource().getSongdata();
 				if(sd != null) {
-					changeFav.accept(sd);					
+					changeFav.accept(sd);
 				}
 			}
 		}),
@@ -598,12 +598,12 @@ public class EventFactory {
 			this.id = id;
 			this.event = createOneArgEvent(action, id);
 		}
-		
+
 		private EventType(int id, TriConsumer<MainState, Integer, Integer> action) {
 			this.id = id;
 			this.event = createTwoArgEvent(action, id);
 		}
-		
+
 	    private static BiConsumer<MainState, Integer> changeAutoSaveReplay(int index) {
 	    	return (state, arg1) -> {
 	    		if(state instanceof MusicSelector) {
@@ -616,7 +616,7 @@ public class EventFactory {
 	    		}
 	    	};
 	    }
-	    
+
 		private static Consumer<MainState> getReplayEventConsumer(int index) {
 			return (state) -> {
 				if(state instanceof MusicSelector) {
@@ -631,7 +631,7 @@ public class EventFactory {
 			};
 		}
 	}
-	
+
 	@FunctionalInterface
 	public interface TriConsumer<T, U, V> {
 		void accept(T t, U u, V v);

--- a/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -1,9 +1,6 @@
 package bms.player.beatoraja.skin.property;
 
-import bms.player.beatoraja.MainState;
-import bms.player.beatoraja.PlayConfig;
-import bms.player.beatoraja.BMSPlayerMode;
-import bms.player.beatoraja.PlayerConfig;
+import bms.player.beatoraja.*;
 import bms.player.beatoraja.MainState.MainStateType;
 import bms.player.beatoraja.ir.IRChartData;
 import bms.player.beatoraja.ir.IRConnection;
@@ -29,6 +26,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.function.*;
 
 /**
@@ -339,18 +337,23 @@ public class EventFactory {
 			}
 		}),
 		rival(79, (state, arg1) -> {
-			if(state instanceof MusicSelector) {
+			if (state instanceof MusicSelector) {
 				final MusicSelector selector = (MusicSelector) state;
-	            int index = -1;
-	            for(int i = 0;i < selector.getRivals().length;i++) {
-	            	if(selector.getRival() == selector.getRivals()[i]) {
-	            		index = i;
-	            		break;
-	            	}
-	            }
-	            index = (index + (arg1 >= 0 ? 2 : 0)) % (selector.getRivals().length + 1) - 1;
-	            selector.setRival(index != -1 ? selector.getRivals()[index] : null);
-	            selector.play(SOUND_OPTIONCHANGE);
+				List<PlayerInformation> rivals = selector.getRivals();
+				int index = rivals.indexOf(selector.getRival());
+
+				if (index == -1) {
+					index = arg1 >= 0 ? 0 : rivals.size() - 1;
+				} else {
+					index = arg1 >= 0 ? index + 1 : index - 1;
+				}
+
+				if (index < 0 || index >= rivals.size()) {
+					selector.setRival(null);
+				} else {
+					selector.setRival(rivals.get(index));
+				}
+				selector.play(SOUND_OPTIONCHANGE);
 			}
 		}),
 		favorite_chart(90, (state, arg1) -> {


### PR DESCRIPTION
Fixes issue: https://github.com/exch-bms2/beatoraja/issues/671

Previously, if rival wasn't set and user wanted to choose a previous rival, event handler would look for player information on array index -2.
This PR implements correct cycling through a list of rivals: choosing next or previous user if one exists, unsetting (to null) chosen rival if you reach one end of the list and starting from the end if rival isn't set and previous one is picked.

Additionally, previously it was impossible to unset a rival while going forward through the array, it's resolved here.