### PR TITLE
Fixed table editor not displaying chart details when double-clicking on table column headers

### DIFF
--- a/src/bms/player/beatoraja/launcher/CourseEditorView.java
+++ b/src/bms/player/beatoraja/launcher/CourseEditorView.java
@@ -13,7 +13,6 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.TextFieldListCell;
-import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.layout.GridPane;
 
 public class CourseEditorView implements Initializable {
@@ -93,13 +92,13 @@ public class CourseEditorView implements Initializable {
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
 		searchSongs.setOnMouseClicked((click) -> {
-			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			boolean isHeader = JavaFXUtils.findParentByClassSimpleName(click.getPickResult().getIntersectedNode(), "TableColumnHeader").isPresent();
 			if (click.getClickCount() == 2 && !isHeader) {
 				TableEditorView.displayChartDetailsDialog(songdb, searchSongs.getSelectionModel().getSelectedItem());
 			}
 		});
 		courseSongs.setOnMouseClicked((click) -> {
-			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			boolean isHeader = JavaFXUtils.findParentByClassSimpleName(click.getPickResult().getIntersectedNode(), "TableColumnHeader").isPresent();
 			if (click.getClickCount() == 2 && !isHeader) {
 				TableEditorView.displayChartDetailsDialog(songdb, courseSongs.getSelectionModel().getSelectedItem());
 			}

--- a/src/bms/player/beatoraja/launcher/CourseEditorView.java
+++ b/src/bms/player/beatoraja/launcher/CourseEditorView.java
@@ -13,6 +13,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.TextFieldListCell;
+import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.layout.GridPane;
 
 public class CourseEditorView implements Initializable {
@@ -92,12 +93,14 @@ public class CourseEditorView implements Initializable {
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 
 		searchSongs.setOnMouseClicked((click) -> {
-			if (click.getClickCount() == 2) {
+			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			if (click.getClickCount() == 2 && !isHeader) {
 				TableEditorView.displayChartDetailsDialog(songdb, searchSongs.getSelectionModel().getSelectedItem());
 			}
 		});
 		courseSongs.setOnMouseClicked((click) -> {
-			if (click.getClickCount() == 2) {
+			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			if (click.getClickCount() == 2 && !isHeader) {
 				TableEditorView.displayChartDetailsDialog(songdb, courseSongs.getSelectionModel().getSelectedItem());
 			}
 		});

--- a/src/bms/player/beatoraja/launcher/FolderEditorView.java
+++ b/src/bms/player/beatoraja/launcher/FolderEditorView.java
@@ -12,6 +12,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.TextFieldListCell;
+import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.layout.GridPane;
 
 public class FolderEditorView implements Initializable {
@@ -63,12 +64,14 @@ public class FolderEditorView implements Initializable {
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 		
 		searchSongs.setOnMouseClicked((click) -> {
-			if (click.getClickCount() == 2) {
+			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			if (click.getClickCount() == 2 && !isHeader) {
 				displayChartDetailsDialog(searchSongs.getSelectionModel().getSelectedItem());
 			}
 		});
 		folderSongs.setOnMouseClicked((click) -> {
-			if (click.getClickCount() == 2) {
+			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			if (click.getClickCount() == 2 && !isHeader) {
 				displayChartDetailsDialog(folderSongs.getSelectionModel().getSelectedItem());
 			}
 		});

--- a/src/bms/player/beatoraja/launcher/FolderEditorView.java
+++ b/src/bms/player/beatoraja/launcher/FolderEditorView.java
@@ -12,7 +12,6 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.TextFieldListCell;
-import javafx.scene.control.skin.TableColumnHeader;
 import javafx.scene.layout.GridPane;
 
 public class FolderEditorView implements Initializable {
@@ -64,13 +63,13 @@ public class FolderEditorView implements Initializable {
 		searchSongs.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
 		
 		searchSongs.setOnMouseClicked((click) -> {
-			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			boolean isHeader = JavaFXUtils.findParentByClassSimpleName(click.getPickResult().getIntersectedNode(), "TableColumnHeader").isPresent();
 			if (click.getClickCount() == 2 && !isHeader) {
 				displayChartDetailsDialog(searchSongs.getSelectionModel().getSelectedItem());
 			}
 		});
 		folderSongs.setOnMouseClicked((click) -> {
-			boolean isHeader = JavaFXUtils.findParentByClass(click.getPickResult().getIntersectedNode(), TableColumnHeader.class).isPresent();
+			boolean isHeader = JavaFXUtils.findParentByClassSimpleName(click.getPickResult().getIntersectedNode(), "TableColumnHeader").isPresent();
 			if (click.getClickCount() == 2 && !isHeader) {
 				displayChartDetailsDialog(folderSongs.getSelectionModel().getSelectedItem());
 			}

--- a/src/bms/player/beatoraja/launcher/JavaFXUtils.java
+++ b/src/bms/player/beatoraja/launcher/JavaFXUtils.java
@@ -3,29 +3,25 @@ package bms.player.beatoraja.launcher;
 import javafx.scene.Node;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
 public class JavaFXUtils {
     /**
-     * 自身または再帰的に探索した親ノードが {@code clazz} のインスタンスなら、
+     * 自身または再帰的に探索した親ノードのクラスの単純名が {@code className} と同じなら、
      * そのノードを {@code Optional} にラップして返します。
      * 見つからなかった場合は空の {@code Optional} を返します。
      *
      * @param node 探索するノード
-     * @param clazz クラス
-     * @param <T> クラスの型
-     * @return 見つかったノードが入った、または空のOptional
      */
-    public static <T extends Node> Optional<T> findParentByClass(final Node node, final Class<T> clazz) {
+    public static <T extends Node> Optional<T> findParentByClassSimpleName(final Node node, final String className) {
         // 無限ループ対策
         final List<Node> parentList = new ArrayList<>();
         Node targetNode = node;
 
         while (targetNode != null && !parentList.contains(targetNode)) {
-            if (clazz.isInstance(targetNode)) {
-                return Optional.ofNullable((T) targetNode);
+            if (targetNode.getClass().getSimpleName().equals(className)) {
+                return Optional.of((T) targetNode);
             }
             parentList.add(targetNode);
             targetNode = targetNode.getParent();

--- a/src/bms/player/beatoraja/launcher/JavaFXUtils.java
+++ b/src/bms/player/beatoraja/launcher/JavaFXUtils.java
@@ -1,0 +1,35 @@
+package bms.player.beatoraja.launcher;
+
+import javafx.scene.Node;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+public class JavaFXUtils {
+    /**
+     * 自身または再帰的に探索した親ノードが {@code clazz} のインスタンスなら、
+     * そのノードを {@code Optional} にラップして返します。
+     * 見つからなかった場合は空の {@code Optional} を返します。
+     *
+     * @param node 探索するノード
+     * @param clazz クラス
+     * @param <T> クラスの型
+     * @return 見つかったノードが入った、または空のOptional
+     */
+    public static <T extends Node> Optional<T> findParentByClass(final Node node, final Class<T> clazz) {
+        // 無限ループ対策
+        final List<Node> parentList = new ArrayList<>();
+        Node targetNode = node;
+
+        while (targetNode != null && !parentList.contains(targetNode)) {
+            if (clazz.isInstance(targetNode)) {
+                return Optional.ofNullable((T) targetNode);
+            }
+            parentList.add(targetNode);
+            targetNode = targetNode.getParent();
+        }
+        return Optional.empty();
+    }
+}


### PR DESCRIPTION
#703 で実装された、設定画面のテーブルエディタで譜面をダブルクリックすると譜面詳細ダイアログが表示される機能において、テーブルのカラムヘッダーをダブルクリックした際には表示しないように修正（変更）しました。

実装の話ですが、ヘッダーの文字部分をクリックした場合、クリックイベントのターゲットがヘッダーではなくその子ノードのテキストになるので、単純な比較ではなくノードを探索するメソッドを生やして利用しています。

![GIF 2022-07-01 15-22-05](https://user-images.githubusercontent.com/2842142/176836364-a16c5962-f2af-4a83-ae3f-411f6187038d.gif)

