### PR TITLE
Fix Zero sample audio play

### DIFF
--- a/src/bms/player/beatoraja/play/TargetProperty.java
+++ b/src/bms/player/beatoraja/play/TargetProperty.java
@@ -82,6 +82,11 @@ public abstract class TargetProperty {
     }
     
     public static TargetProperty getTargetProperty(String id) {
+		// Fix infinite recursion error
+		if (properties.isEmpty()) {
+			getTargetProperties();
+		}
+
     	TargetProperty target = properties.get(id);
     	if(target == null) {
     		target = InternetRankingTargetProperty.getTargetProperty(id);


### PR DESCRIPTION
https://hitkey.nekokan.dyndns.info/diary2012.php#D201219

PortAudio利用時に下記条件を満たすと、PortAudioDriverがクラッシュし、以降無音となります。
* オーディオファイルのサンプリングレート ＞ デバイスのサンプリングレート
* オーディオファイルのサンプル数が0
* オーディオファイルのサンプルあたりのビット数が16

PortAudioDriverをクラッシュさせないように、サンプル数チェックと防衛的に例外制御を追加しました。

https://github.com/exch-bms2/beatoraja/commit/8f1ec69b65b12390e43bb78e375fa832eb8014ca
に関しては、PRとは別に入れておいたほうが良さそうなのでチェリーピックしました。

***
適用されるまでは
「PortAudioを利用しない or デバイスのサンプリングレートを48000Hz以上」
で、だいたい回避できると思います