### PR TITLE
Save newscore data even if the score have no update

### DIFF
--- a/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/ScoreDataLogDatabaseAccessor.java
@@ -1,0 +1,90 @@
+package bms.player.beatoraja;
+
+import java.sql.*;
+import java.util.*;
+import java.util.logging.Logger;
+
+import org.apache.commons.dbutils.QueryRunner;
+import org.apache.commons.dbutils.ResultSetHandler;
+import org.apache.commons.dbutils.handlers.BeanListHandler;
+import org.sqlite.SQLiteConfig;
+import org.sqlite.SQLiteDataSource;
+import org.sqlite.SQLiteConfig.SynchronousMode;
+
+/**
+ * スコアデータログデータベースアクセサ
+ * 
+ * @author omi
+ */
+public class ScoreDataLogDatabaseAccessor extends SQLiteDatabaseAccessor {
+
+	private SQLiteDataSource ds;
+	private final ResultSetHandler<List<ScoreData>> scoreHandler = new BeanListHandler<ScoreData>(ScoreData.class);
+
+	private final QueryRunner qr;
+
+	public ScoreDataLogDatabaseAccessor(String path) throws ClassNotFoundException {
+		super(	new Table("scoredatalog",
+						new Column("sha256", "TEXT", 1, 1),
+						new Column("mode", "INTEGER",0,1),
+						new Column("clear", "INTEGER"),
+						new Column("epg", "INTEGER"),
+						new Column("lpg", "INTEGER"),
+						new Column("egr", "INTEGER"),
+						new Column("lgr", "INTEGER"),
+						new Column("egd", "INTEGER"),
+						new Column("lgd", "INTEGER"),
+						new Column("ebd", "INTEGER"),
+						new Column("lbd", "INTEGER"),
+						new Column("epr", "INTEGER"),
+						new Column("lpr", "INTEGER"),
+						new Column("ems", "INTEGER"),
+						new Column("lms", "INTEGER"),
+						new Column("notes", "INTEGER"),
+						new Column("combo", "INTEGER"),
+						new Column("minbp", "INTEGER"),
+						new Column("avgjudge", "INTEGER", 1, 0, String.valueOf(Integer.MAX_VALUE)),
+						new Column("playcount", "INTEGER"),
+						new Column("clearcount", "INTEGER"),
+						new Column("trophy", "TEXT"),
+						new Column("ghost", "TEXT"),
+						new Column("option", "INTEGER"),
+						new Column("seed", "INTEGER"),
+						new Column("random", "INTEGER"),
+						new Column("date", "INTEGER"),
+						new Column("state", "INTEGER"),
+						new Column("scorehash", "TEXT")
+						));
+
+		Class.forName("org.sqlite.JDBC");
+		SQLiteConfig conf = new SQLiteConfig();
+		conf.setSharedCache(true);
+		conf.setSynchronous(SynchronousMode.OFF);
+		// conf.setJournalMode(JournalMode.MEMORY);
+		ds = new SQLiteDataSource(conf);
+		ds.setUrl("jdbc:sqlite:" + path);
+		qr = new QueryRunner(ds);
+		
+		try {
+			this.validate(qr);
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+	}
+
+	public void setScoreDataLog(ScoreData score) {
+		setScoreDataLog(new ScoreData[] { score });
+	}
+
+	public void setScoreDataLog(ScoreData[] scores) {
+		try (Connection con = qr.getDataSource().getConnection()) {
+			con.setAutoCommit(false);
+			for (ScoreData score : scores) {
+				this.insert(qr, con, "scoredatalog", score);
+			}
+			con.commit();
+		} catch (Exception e) {
+			Logger.getGlobal().severe("スコア更新時の例外:" + e.getMessage());
+		}
+	}
+}

--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -272,7 +272,7 @@ public class CourseResult extends AbstractResult {
 				Arrays.asList(resource.getCourseData().getSong()).stream().mapToInt(sd -> sd.getNotes()).sum());
 		getScoreDataProperty().update(newscore);
 
-		main.getPlayDataAccessor().writeScoreDara(newscore, models, config.getLnmode(),
+		main.getPlayDataAccessor().writeScoreData(newscore, models, config.getLnmode(),
 				random, resource.getConstraint(), resource.isUpdateCourseScore());
 
 

--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -438,7 +438,7 @@ public class MusicResult extends AbstractResult {
 		}
 
 		if (resource.getPlayMode().mode == BMSPlayerMode.Mode.PLAY) {
-			main.getPlayDataAccessor().writeScoreDara(resource.getScoreData(), resource.getBMSModel(),
+			main.getPlayDataAccessor().writeScoreData(resource.getScoreData(), resource.getBMSModel(),
 					resource.getPlayerConfig().getLnmode(), resource.isUpdateScore());
 		} else {
 			Logger.getGlobal().info("プレイモードが" + resource.getPlayMode().mode.name() + "のため、スコア登録はされません");


### PR DESCRIPTION
## Outline

Previously, the `scoreLog` was only updated and stored if there were **updates** compared to the old score. In other words, the result information of `newscore` was usually discarded within the `writeScoreData` function.
This PR modifies `writeScoreData` to save every result of BMS play.

## Changes

- create `scoredatalogdb`
- fill in any missing values from `score` and the SongTrophies
- insert `newscore` into `scoredatalogdb`
- fix typos

## Benefits

This log will be a useful analytic resource for players within the beatoraja ecosystem.
It will be a helpful companion for AIR -GOD- KNOCK in particular.