### PR TITLE
PracticeConfiguration : change JUDGERANK modifying step from 10 to 1

### DIFF
--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -162,8 +162,8 @@ public class PracticeConfiguration {
 				}
 				break;
 			case 5:
-				if (property.judgerank > 10) {
-					property.judgerank -= 10;
+				if (property.judgerank > 1) {
+					property.judgerank--;
 				}
 				break;
 				case 6:
@@ -234,7 +234,7 @@ public class PracticeConfiguration {
 				break;
 			case 5:
 				if (property.judgerank < 400) {
-					property.judgerank += 10;
+					property.judgerank++;
 				}
 				break;
 				case 6:


### PR DESCRIPTION
PRACTICEモードのJUDGERANKの変更幅を10から1に変更しました。また、これに伴い、設定可能な下限値を10から1に変更しました。これによって、NORMAL判定(75)などの10の倍数ではないJUDGERANKを持つBMSをEASY(100)などに設定できない問題を解決します。

5ではなく1にしたのは、5の倍数ではないJUDGERANKを持つBMSがそれなりに存在するためです。実際に変更する頻度は低いと思われること、操作する際は高速で増減することからそこまで不便にはならないと思います。