### PR TITLE
[WIP] VeryEasy・Easy・Normal・Hard・VeryHard判定で別々のExpand Judge設定を適用する

### DIFF
--- a/src/bms/player/beatoraja/PlayerConfig.java
+++ b/src/bms/player/beatoraja/PlayerConfig.java
@@ -28,13 +28,13 @@ import com.badlogic.gdx.utils.SerializationException;
 public class PlayerConfig {
 
 	static final Path configpath_old = Paths.get("config.json");
-	static final Path configpath = Paths.get("config_player.json");	
+	static final Path configpath = Paths.get("config_player.json");
 
 	private String id;
-    /**
-     * プレイヤーネーム
-     */
-    private String name = "NO NAME";
+	/**
+	 * プレイヤーネーム
+	 */
+	private String name = "NO NAME";
 
 	/**
 	 * ゲージの種類
@@ -57,24 +57,26 @@ public class PlayerConfig {
 	 * スコアターゲット
 	 */
 	private String targetid = "MAX";
-	
-	private String[] targetlist = new String[] {"RATE_A-","RATE_A", "RATE_A+","RATE_AA-","RATE_AA", "RATE_AA+", "RATE_AAA-", "RATE_AAA", "RATE_AAA+", "MAX"
-			,"RANK_NEXT", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3", "IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10"
-			, "IR_RANK_1", "IR_RANK_5", "IR_RANK_10", "IR_RANK_20", "IR_RANK_30", "IR_RANK_40", "IR_RANK_50"
-			, "IR_RANKRATE_5", "IR_RANKRATE_10", "IR_RANKRATE_15", "IR_RANKRATE_20", "IR_RANKRATE_25", "IR_RANKRATE_30", "IR_RANKRATE_35", "IR_RANKRATE_40", "IR_RANKRATE_45","IR_RANKRATE_50"};
+
+	private String[] targetlist = new String[] { "RATE_A-", "RATE_A", "RATE_A+", "RATE_AA-", "RATE_AA", "RATE_AA+",
+			"RATE_AAA-", "RATE_AAA", "RATE_AAA+", "MAX", "RANK_NEXT", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3",
+			"IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10", "IR_RANK_1", "IR_RANK_5", "IR_RANK_10", "IR_RANK_20", "IR_RANK_30",
+			"IR_RANK_40", "IR_RANK_50", "IR_RANKRATE_5", "IR_RANKRATE_10", "IR_RANKRATE_15", "IR_RANKRATE_20",
+			"IR_RANKRATE_25", "IR_RANKRATE_30", "IR_RANKRATE_35", "IR_RANKRATE_40", "IR_RANKRATE_45",
+			"IR_RANKRATE_50" };
 	/**
 	 * 判定タイミング
 	 */
 	private int judgetiming = 0;
-	
+
 	public static final int JUDGETIMING_MAX = 500;
 	public static final int JUDGETIMING_MIN = -500;
-	
+
 	private boolean notesDisplayTimingAutoAdjust = false;
 
-    /**
-     * 選曲時のモードフィルター
-     */
+	/**
+	 * 選曲時のモードフィルター
+	 */
 	private Mode mode = null;
 	/**
 	 * 指定がない場合のミスレイヤー表示時間(ms)
@@ -88,25 +90,49 @@ public class PlayerConfig {
 	/**
 	 * スクロール追加/削除モード
 	 */
-    private int scrollMode = 0;
-    private int scrollSection = 4;
-    private double scrollRate = 0.5;
+	private int scrollMode = 0;
+	private int scrollSection = 4;
+	private double scrollRate = 0.5;
 	/**
 	 * ロングノート追加/削除モード
 	 */
-    private int longnoteMode = 0;
-    private double longnoteRate = 1.0;
+	private int longnoteMode = 0;
+	private double longnoteRate = 1.0;
 	/**
 	 * アシストオプション:判定拡大
 	 */
 	private boolean customJudge = false;
+	private int customJudgeKind;
 	private int keyJudgeWindowRatePerfectGreat = 400;
 	private int keyJudgeWindowRateGreat = 400;
 	private int keyJudgeWindowRateGood = 100;
 	private int scratchJudgeWindowRatePerfectGreat = 400;
 	private int scratchJudgeWindowRateGreat = 400;
 	private int scratchJudgeWindowRateGood = 100;
-
+	private int keyEasyJudgeWindowRatePerfectGreat = 400;
+	private int keyEasyJudgeWindowRateGreat = 400;
+	private int keyEasyJudgeWindowRateGood = 100;
+	private int scratchEasyJudgeWindowRatePerfectGreat = 400;
+	private int scratchEasyJudgeWindowRateGreat = 400;
+	private int scratchEasyJudgeWindowRateGood = 100;
+	private int keyNormalJudgeWindowRatePerfectGreat = 400;
+	private int keyNormalJudgeWindowRateGreat = 400;
+	private int keyNormalJudgeWindowRateGood = 100;
+	private int scratchNormalJudgeWindowRatePerfectGreat = 400;
+	private int scratchNormalJudgeWindowRateGreat = 400;
+	private int scratchNormalJudgeWindowRateGood = 100;
+	private int keyHardJudgeWindowRatePerfectGreat = 400;
+	private int keyHardJudgeWindowRateGreat = 400;
+	private int keyHardJudgeWindowRateGood = 100;
+	private int scratchHardJudgeWindowRatePerfectGreat = 400;
+	private int scratchHardJudgeWindowRateGreat = 400;
+	private int scratchHardJudgeWindowRateGood = 100;
+	private int keyVeryHardJudgeWindowRatePerfectGreat = 400;
+	private int keyVeryHardJudgeWindowRateGreat = 400;
+	private int keyVeryHardJudgeWindowRateGood = 100;
+	private int scratchVeryHardJudgeWindowRatePerfectGreat = 400;
+	private int scratchVeryHardJudgeWindowRateGreat = 400;
+	private int scratchVeryHardJudgeWindowRateGood = 100;
 	/**
 	 * 地雷モード
 	 */
@@ -133,7 +159,7 @@ public class PlayerConfig {
 	 */
 	private int gaugeAutoShift = GAUGEAUTOSHIFT_NONE;
 	/**
-	 * GASで遷移可能なゲージの下限  ASSIST EASY, EASY, NORMALから選択
+	 * GASで遷移可能なゲージの下限 ASSIST EASY, EASY, NORMALから選択
 	 */
 	private int bottomShiftableGauge = GrooveGauge.ASSISTEASY;
 
@@ -149,7 +175,8 @@ public class PlayerConfig {
 	private static Config config;
 
 	/**
-	 * 7to9 スクラッチ鍵盤位置関係 0:OFF 1:SC1KEY2~8 2:SC1KEY3~9 3:SC2KEY3~9 4:SC8KEY1~7 5:SC9KEY1~7 6:SC9KEY2~8
+	 * 7to9 スクラッチ鍵盤位置関係 0:OFF 1:SC1KEY2~8 2:SC1KEY3~9 3:SC2KEY3~9 4:SC8KEY1~7
+	 * 5:SC9KEY1~7 6:SC9KEY2~8
 	 */
 	private int sevenToNinePattern = 0;
 
@@ -172,7 +199,7 @@ public class PlayerConfig {
 	 * Window Hold
 	 */
 	private boolean isWindowHold = false;
-	
+
 	/**
 	 * Enable folder random select bar
 	 */
@@ -202,7 +229,7 @@ public class PlayerConfig {
 	 * 通過ノートを表示するかどうか
 	 */
 	private boolean showpastnote = false;
-	
+
 	/**
 	 * 選択中の選曲時ソート
 	 */
@@ -214,7 +241,7 @@ public class PlayerConfig {
 	private int musicselectinput = 0;
 
 	private IRConfig[] irconfig;
-	
+
 	private String twitterConsumerKey;
 
 	private String twitterConsumerSecret;
@@ -232,13 +259,13 @@ public class PlayerConfig {
 		validate();
 	}
 
-    public String getName() {
-        return name;
-    }
+	public String getName() {
+		return name;
+	}
 
-    public void setName(String name) {
-        this.name = name;
-    }
+	public void setName(String name) {
+		this.name = name;
+	}
 
 	public int getGauge() {
 		return gauge;
@@ -362,43 +389,43 @@ public class PlayerConfig {
 
 	public PlayModeConfig getPlayConfig(Mode modeId) {
 		switch (modeId != null ? modeId : Mode.BEAT_7K) {
-		case BEAT_5K:
-			return getMode5();
-		case BEAT_7K:
-			return getMode7();
-		case BEAT_10K:
-			return getMode10();
-		case BEAT_14K:
-			return getMode14();
-		case POPN_9K:
-			return getMode9();
-		case KEYBOARD_24K:
-			return getMode24();
-		case KEYBOARD_24K_DOUBLE:
-			return getMode24double();
-		default:
-			return getMode7();
+			case BEAT_5K:
+				return getMode5();
+			case BEAT_7K:
+				return getMode7();
+			case BEAT_10K:
+				return getMode10();
+			case BEAT_14K:
+				return getMode14();
+			case POPN_9K:
+				return getMode9();
+			case KEYBOARD_24K:
+				return getMode24();
+			case KEYBOARD_24K_DOUBLE:
+				return getMode24double();
+			default:
+				return getMode7();
 		}
 	}
 
 	public PlayModeConfig getPlayConfig(int modeId) {
 		switch (modeId) {
-		case 7:
-			return getMode7();
-		case 5:
-			return getMode5();
-		case 14:
-			return getMode14();
-		case 10:
-			return getMode10();
-		case 9:
-			return getMode9();
-		case 25:
-			return getMode24();
-		case 50:
-			return getMode24double();
-		default:
-			return getMode7();
+			case 7:
+				return getMode7();
+			case 5:
+				return getMode5();
+			case 14:
+				return getMode14();
+			case 10:
+				return getMode10();
+			case 9:
+				return getMode9();
+			case 25:
+				return getMode24();
+			case 50:
+				return getMode24double();
+			default:
+				return getMode7();
 		}
 	}
 
@@ -419,7 +446,7 @@ public class PlayerConfig {
 	}
 
 	public PlayModeConfig getMode10() {
-		if(mode10 == null || mode10.getController().length < 2) {
+		if (mode10 == null || mode10.getController().length < 2) {
 			mode10 = new PlayModeConfig(Mode.BEAT_10K);
 			Logger.getGlobal().warning("mode10のPlayConfigを再構成");
 		}
@@ -431,7 +458,7 @@ public class PlayerConfig {
 	}
 
 	public PlayModeConfig getMode14() {
-		if(mode14 == null || mode14.getController().length < 2) {
+		if (mode14 == null || mode14.getController().length < 2) {
 			mode14 = new PlayModeConfig(Mode.BEAT_14K);
 			Logger.getGlobal().warning("mode14のPlayConfigを再構成");
 		}
@@ -459,7 +486,7 @@ public class PlayerConfig {
 	}
 
 	public PlayModeConfig getMode24double() {
-		if(mode24double == null || mode24double.getController().length < 2) {
+		if (mode24double == null || mode24double.getController().length < 2) {
 			mode24double = new PlayModeConfig(Mode.KEYBOARD_24K_DOUBLE);
 			Logger.getGlobal().warning("mode24doubleのPlayConfigを再構成");
 		}
@@ -470,16 +497,16 @@ public class PlayerConfig {
 		this.mode24double = mode24double;
 	}
 
-	public void setMode(Mode m)  {
+	public void setMode(Mode m) {
 		this.mode = m;
 	}
 
-	public Mode getMode()  {
+	public Mode getMode() {
 		return mode;
 	}
-	
+
 	public int getSort() {
-		return this.sort ;
+		return this.sort;
 	}
 
 	public void setSort(int sort) {
@@ -495,7 +522,7 @@ public class PlayerConfig {
 	}
 
 	public SkinConfig[] getSkin() {
-		if(skin.length <= SkinType.getMaxSkinTypeID()) {
+		if (skin.length <= SkinType.getMaxSkinTypeID()) {
 			skin = Arrays.copyOf(skin, SkinType.getMaxSkinTypeID() + 1);
 			Logger.getGlobal().warning("skinを再構成");
 		}
@@ -539,7 +566,7 @@ public class PlayerConfig {
 	}
 
 	public int getMisslayerDuration() {
-		if(misslayerDuration < 0) {
+		if (misslayerDuration < 0) {
 			misslayerDuration = 0;
 		}
 		return misslayerDuration;
@@ -555,6 +582,14 @@ public class PlayerConfig {
 
 	public void setCustomJudge(boolean customJudge) {
 		this.customJudge = customJudge;
+	}
+
+	public int getCustomJudgeKind() {
+		return customJudgeKind;
+	}
+
+	public void setCustomJudgeKind(int customJudgeKind) {
+		this.customJudgeKind = customJudgeKind;
 	}
 
 	public int getKeyJudgeWindowRatePerfectGreat() {
@@ -605,6 +640,198 @@ public class PlayerConfig {
 		this.scratchJudgeWindowRateGood = judgeWindowRateGood;
 	}
 
+	public int getKeyEasyJudgeWindowRatePerfectGreat() {
+		return keyEasyJudgeWindowRatePerfectGreat;
+	}
+
+	public void setKeyEasyJudgeWindowRatePerfectGreat(int keyEasyJudgeWindowRatePerfectGreat) {
+		this.keyEasyJudgeWindowRatePerfectGreat = keyEasyJudgeWindowRatePerfectGreat;
+	}
+
+	public int getKeyEasyJudgeWindowRateGreat() {
+		return keyEasyJudgeWindowRateGreat;
+	}
+
+	public void setKeyEasyJudgeWindowRateGreat(int keyEasyJudgeWindowRateGreat) {
+		this.keyEasyJudgeWindowRateGreat = keyEasyJudgeWindowRateGreat;
+	}
+
+	public int getKeyEasyJudgeWindowRateGood() {
+		return keyEasyJudgeWindowRateGood;
+	}
+
+	public void setKeyEasyJudgeWindowRateGood(int keyEasyJudgeWindowRateGood) {
+		this.keyEasyJudgeWindowRateGood = keyEasyJudgeWindowRateGood;
+	}
+
+	public int getScratchEasyJudgeWindowRatePerfectGreat() {
+		return scratchEasyJudgeWindowRatePerfectGreat;
+	}
+
+	public void setScratchEasyJudgeWindowRatePerfectGreat(int scratchEasyJudgeWindowRatePerfectGreat) {
+		this.scratchEasyJudgeWindowRatePerfectGreat = scratchEasyJudgeWindowRatePerfectGreat;
+	}
+
+	public int getScratchEasyJudgeWindowRateGreat() {
+		return scratchEasyJudgeWindowRateGreat;
+	}
+
+	public void setScratchEasyJudgeWindowRateGreat(int scratchEasyJudgeWindowRateGreat) {
+		this.scratchEasyJudgeWindowRateGreat = scratchEasyJudgeWindowRateGreat;
+	}
+
+	public int getScratchEasyJudgeWindowRateGood() {
+		return scratchEasyJudgeWindowRateGood;
+	}
+
+	public void setScratchEasyJudgeWindowRateGood(int scratchEasyJudgeWindowRateGood) {
+		this.scratchEasyJudgeWindowRateGood = scratchEasyJudgeWindowRateGood;
+	}
+
+	public int getKeyNormalJudgeWindowRatePerfectGreat() {
+		return keyNormalJudgeWindowRatePerfectGreat;
+	}
+
+	public void setKeyNormalJudgeWindowRatePerfectGreat(int keyNormalJudgeWindowRatePerfectGreat) {
+		this.keyNormalJudgeWindowRatePerfectGreat = keyNormalJudgeWindowRatePerfectGreat;
+	}
+
+	public int getKeyNormalJudgeWindowRateGreat() {
+		return keyNormalJudgeWindowRateGreat;
+	}
+
+	public void setKeyNormalJudgeWindowRateGreat(int keyNormalJudgeWindowRateGreat) {
+		this.keyNormalJudgeWindowRateGreat = keyNormalJudgeWindowRateGreat;
+	}
+
+	public int getKeyNormalJudgeWindowRateGood() {
+		return keyNormalJudgeWindowRateGood;
+	}
+
+	public void setKeyNormalJudgeWindowRateGood(int keyNormalJudgeWindowRateGood) {
+		this.keyNormalJudgeWindowRateGood = keyNormalJudgeWindowRateGood;
+	}
+
+	public int getScratchNormalJudgeWindowRatePerfectGreat() {
+		return scratchNormalJudgeWindowRatePerfectGreat;
+	}
+
+	public void setScratchNormalJudgeWindowRatePerfectGreat(int scratchNormalJudgeWindowRatePerfectGreat) {
+		this.scratchNormalJudgeWindowRatePerfectGreat = scratchNormalJudgeWindowRatePerfectGreat;
+	}
+
+	public int getScratchNormalJudgeWindowRateGreat() {
+		return scratchNormalJudgeWindowRateGreat;
+	}
+
+	public void setScratchNormalJudgeWindowRateGreat(int scratchNormalJudgeWindowRateGreat) {
+		this.scratchNormalJudgeWindowRateGreat = scratchNormalJudgeWindowRateGreat;
+	}
+
+	public int getScratchNormalJudgeWindowRateGood() {
+		return scratchNormalJudgeWindowRateGood;
+	}
+
+	public void setScratchNormalJudgeWindowRateGood(int scratchNormalJudgeWindowRateGood) {
+		this.scratchNormalJudgeWindowRateGood = scratchNormalJudgeWindowRateGood;
+	}
+
+	public int getKeyHardJudgeWindowRatePerfectGreat() {
+		return keyHardJudgeWindowRatePerfectGreat;
+	}
+
+	public void setKeyHardJudgeWindowRatePerfectGreat(int keyHardJudgeWindowRatePerfectGreat) {
+		this.keyHardJudgeWindowRatePerfectGreat = keyHardJudgeWindowRatePerfectGreat;
+	}
+
+	public int getKeyHardJudgeWindowRateGreat() {
+		return keyHardJudgeWindowRateGreat;
+	}
+
+	public void setKeyHardJudgeWindowRateGreat(int keyHardJudgeWindowRateGreat) {
+		this.keyHardJudgeWindowRateGreat = keyHardJudgeWindowRateGreat;
+	}
+
+	public int getKeyHardJudgeWindowRateGood() {
+		return keyHardJudgeWindowRateGood;
+	}
+
+	public void setKeyHardJudgeWindowRateGood(int keyHardJudgeWindowRateGood) {
+		this.keyHardJudgeWindowRateGood = keyHardJudgeWindowRateGood;
+	}
+
+	public int getScratchHardJudgeWindowRatePerfectGreat() {
+		return scratchHardJudgeWindowRatePerfectGreat;
+	}
+
+	public void setScratchHardJudgeWindowRatePerfectGreat(int scratchHardJudgeWindowRatePerfectGreat) {
+		this.scratchHardJudgeWindowRatePerfectGreat = scratchHardJudgeWindowRatePerfectGreat;
+	}
+
+	public int getScratchHardJudgeWindowRateGreat() {
+		return scratchHardJudgeWindowRateGreat;
+	}
+
+	public void setScratchHardJudgeWindowRateGreat(int scratchHardJudgeWindowRateGreat) {
+		this.scratchHardJudgeWindowRateGreat = scratchHardJudgeWindowRateGreat;
+	}
+
+	public int getScratchHardJudgeWindowRateGood() {
+		return scratchHardJudgeWindowRateGood;
+	}
+
+	public void setScratchHardJudgeWindowRateGood(int scratchHardJudgeWindowRateGood) {
+		this.scratchHardJudgeWindowRateGood = scratchHardJudgeWindowRateGood;
+	}
+
+	public int getKeyVeryHardJudgeWindowRatePerfectGreat() {
+		return keyVeryHardJudgeWindowRatePerfectGreat;
+	}
+
+	public void setKeyVeryHardJudgeWindowRatePerfectGreat(int keyVeryHardJudgeWindowRatePerfectGreat) {
+		this.keyVeryHardJudgeWindowRatePerfectGreat = keyVeryHardJudgeWindowRatePerfectGreat;
+	}
+
+	public int getKeyVeryHardJudgeWindowRateGreat() {
+		return keyVeryHardJudgeWindowRateGreat;
+	}
+
+	public void setKeyVeryHardJudgeWindowRateGreat(int keyVeryHardJudgeWindowRateGreat) {
+		this.keyVeryHardJudgeWindowRateGreat = keyVeryHardJudgeWindowRateGreat;
+	}
+
+	public int getKeyVeryHardJudgeWindowRateGood() {
+		return keyVeryHardJudgeWindowRateGood;
+	}
+
+	public void setKeyVeryHardJudgeWindowRateGood(int keyVeryHardJudgeWindowRateGood) {
+		this.keyVeryHardJudgeWindowRateGood = keyVeryHardJudgeWindowRateGood;
+	}
+
+	public int getScratchVeryHardJudgeWindowRatePerfectGreat() {
+		return scratchVeryHardJudgeWindowRatePerfectGreat;
+	}
+
+	public void setScratchVeryHardJudgeWindowRatePerfectGreat(int scratchVeryHardJudgeWindowRatePerfectGreat) {
+		this.scratchVeryHardJudgeWindowRatePerfectGreat = scratchVeryHardJudgeWindowRatePerfectGreat;
+	}
+
+	public int getScratchVeryHardJudgeWindowRateGreat() {
+		return scratchVeryHardJudgeWindowRateGreat;
+	}
+
+	public void setScratchVeryHardJudgeWindowRateGreat(int scratchVeryHardJudgeWindowRateGreat) {
+		this.scratchVeryHardJudgeWindowRateGreat = scratchVeryHardJudgeWindowRateGreat;
+	}
+
+	public int getScratchVeryHardJudgeWindowRateGood() {
+		return scratchVeryHardJudgeWindowRateGood;
+	}
+
+	public void setScratchVeryHardJudgeWindowRateGood(int scratchVeryHardJudgeWindowRateGood) {
+		this.scratchVeryHardJudgeWindowRateGood = scratchVeryHardJudgeWindowRateGood;
+	}
+
 	public int getHranThresholdBPM() {
 		return hranThresholdBPM;
 	}
@@ -652,11 +879,11 @@ public class PlayerConfig {
 	public void setWindowHold(boolean isWindowHold) {
 		this.isWindowHold = isWindowHold;
 	}
-	
+
 	public boolean isRandomSelect() {
 		return isRandomSelect;
 	}
-	
+
 	public void setRandomSelect(boolean isRandomSelect) {
 		this.isRandomSelect = isRandomSelect;
 	}
@@ -669,11 +896,11 @@ public class PlayerConfig {
 		this.id = id;
 	}
 
-	public void setAutoSaveReplay(int autoSaveReplay[]){
+	public void setAutoSaveReplay(int autoSaveReplay[]) {
 		this.autosavereplay = autoSaveReplay;
 	}
 
-	public int[] getAutoSaveReplay(){
+	public int[] getAutoSaveReplay() {
 		return autosavereplay;
 	}
 
@@ -724,69 +951,69 @@ public class PlayerConfig {
 	public void setTwitterAccessTokenSecret(String twitterAccessTokenSecret) {
 		this.twitterAccessTokenSecret = twitterAccessTokenSecret;
 	}
-	
+
 	// --Stream
 	public boolean getRequestEnable() {
-        return enableRequest;
-    }
+		return enableRequest;
+	}
 
 	public boolean getRequestNotify() {
-        return notifyRequest;
-    }
+		return notifyRequest;
+	}
 
-    public void setRequestEnable(boolean requestEnable) {
-        this.enableRequest = requestEnable;
-    }
+	public void setRequestEnable(boolean requestEnable) {
+		this.enableRequest = requestEnable;
+	}
 
-    public void setRequestNotify(boolean notifyEnable) {
-        this.notifyRequest = notifyEnable;
-    }
+	public void setRequestNotify(boolean notifyEnable) {
+		this.notifyRequest = notifyEnable;
+	}
 
-    public int getMaxRequestCount() {
-        return maxRequestCount;
-    }
+	public int getMaxRequestCount() {
+		return maxRequestCount;
+	}
 
-    public void setMaxRequestCount(int maxRequestCount) {
-        this.maxRequestCount = maxRequestCount;
-    }
+	public void setMaxRequestCount(int maxRequestCount) {
+		this.maxRequestCount = maxRequestCount;
+	}
 
 	public void validate() {
-		if(skin == null) {
+		if (skin == null) {
 			skin = new SkinConfig[SkinType.getMaxSkinTypeID() + 1];
 		}
-		if(skinHistory == null) {
+		if (skinHistory == null) {
 			skinHistory = new SkinConfig[0];
 		}
-		if(skin.length != SkinType.getMaxSkinTypeID() + 1) {
+		if (skin.length != SkinType.getMaxSkinTypeID() + 1) {
 			skin = Arrays.copyOf(skin, SkinType.getMaxSkinTypeID() + 1);
 		}
-		for(int i = 0;i < skin.length;i++) {
-			if(skin[i] == null) {
+		for (int i = 0; i < skin.length; i++) {
+			if (skin[i] == null) {
 				skin[i] = SkinConfig.getDefault(i);
 			}
 			skin[i].validate();
 		}
 
-		if(mode5 == null) {
+		if (mode5 == null) {
 			mode5 = new PlayModeConfig(Mode.BEAT_5K);
 		}
 
-		if(mode7 == null) {
+		if (mode7 == null) {
 			mode7 = new PlayModeConfig(Mode.BEAT_7K);
 		}
-		if(mode14 == null) {
+		if (mode14 == null) {
 			mode14 = new PlayModeConfig(Mode.BEAT_14K);
 		}
-		if(mode10 == null) {
+		if (mode10 == null) {
 			mode10 = new PlayModeConfig(Mode.BEAT_10K);
 		}
-		if(mode9 == null) {
+		if (mode9 == null) {
 			mode9 = new PlayModeConfig(Mode.POPN_9K);
 		}
-		if(mode24 == null) {
+		if (mode24 == null) {
 			mode24 = new PlayModeConfig(Mode.KEYBOARD_24K);
 		}
-		if(mode24double == null) {
+		if (mode24double == null) {
 			mode24double = new PlayModeConfig(Mode.KEYBOARD_24K_DOUBLE);
 		}
 		mode5.validate(7);
@@ -796,14 +1023,14 @@ public class PlayerConfig {
 		mode9.validate(9);
 		mode24.validate(26);
 		mode24double.validate(52);
-		
-		sort = MathUtils.clamp(sort, 0 , BarSorter.values().length - 1);
+
+		sort = MathUtils.clamp(sort, 0, BarSorter.values().length - 1);
 
 		gauge = MathUtils.clamp(gauge, 0, 5);
 		random = MathUtils.clamp(random, 0, 9);
 		random2 = MathUtils.clamp(random2, 0, 9);
 		doubleoption = MathUtils.clamp(doubleoption, 0, 3);
-		targetid = targetid!= null ? targetid : "MAX";
+		targetid = targetid != null ? targetid : "MAX";
 		targetlist = targetlist != null ? targetlist : new String[0];
 		judgetiming = MathUtils.clamp(judgetiming, JUDGETIMING_MIN, JUDGETIMING_MAX);
 		misslayerDuration = MathUtils.clamp(misslayerDuration, 0, 5000);
@@ -815,11 +1042,11 @@ public class PlayerConfig {
 		scratchJudgeWindowRateGreat = MathUtils.clamp(scratchJudgeWindowRateGreat, 0, 400);
 		scratchJudgeWindowRateGood = MathUtils.clamp(scratchJudgeWindowRateGood, 0, 400);
 		hranThresholdBPM = MathUtils.clamp(hranThresholdBPM, 1, 1000);
-		
-		if(autosavereplay == null) {
+
+		if (autosavereplay == null) {
 			autosavereplay = config.autosavereplay != null ? config.autosavereplay.clone() : new int[4];
 		}
-		if(autosavereplay.length != 4) {
+		if (autosavereplay.length != 4) {
 			autosavereplay = Arrays.copyOf(autosavereplay, 4);
 		}
 		sevenToNinePattern = MathUtils.clamp(sevenToNinePattern, 0, 6);
@@ -834,23 +1061,23 @@ public class PlayerConfig {
 		mineMode = MathUtils.clamp(mineMode, 0, MineNoteModifier.Mode.values().length);
 		extranoteDepth = MathUtils.clamp(extranoteDepth, 0, 100);
 
-		if(irconfig == null || irconfig.length == 0) {
+		if (irconfig == null || irconfig.length == 0) {
 			String[] irnames = IRConnectionManager.getAllAvailableIRConnectionName();
 			irconfig = new IRConfig[irnames.length];
-			for(int i = 0;i < irnames.length;i++) {
+			for (int i = 0; i < irnames.length; i++) {
 				irconfig[i] = new IRConfig();
 				irconfig[i].setIrname(irnames[i]);
 			}
 		}
-		
-		for(int i = 0;i < irconfig.length;i++) {
-			if(irconfig[i] == null || irconfig[i].getIrname() == null) {
+
+		for (int i = 0; i < irconfig.length; i++) {
+			if (irconfig[i] == null || irconfig[i].getIrname() == null) {
 				continue;
 			}
-			for(int j = i + 1;j < irconfig.length;j++) {
-				if(irconfig[j] != null && irconfig[i].getIrname().equals(irconfig[j].getIrname())) {
+			for (int j = i + 1; j < irconfig.length; j++) {
+				if (irconfig[j] != null && irconfig[i].getIrname().equals(irconfig[j].getIrname())) {
 					irconfig[j].setIrname(null);
-				}				
+				}
 			}
 		}
 		irconfig = Validatable.removeInvalidElements(irconfig);
@@ -863,24 +1090,26 @@ public class PlayerConfig {
 		PlayerConfig.config = config;
 		// TODO プレイヤーアカウント検証
 		try {
-			if(!Files.exists(Paths.get(config.getPlayerpath()))) {
+			if (!Files.exists(Paths.get(config.getPlayerpath()))) {
 				Files.createDirectory(Paths.get(config.getPlayerpath()));
 			}
-			if(readAllPlayerID(config.getPlayerpath()).length == 0 || readPlayerConfig(config.getPlayerpath(), config.getPlayername()) == null) {
+			if (readAllPlayerID(config.getPlayerpath()).length == 0
+					|| readPlayerConfig(config.getPlayerpath(), config.getPlayername()) == null) {
 				PlayerConfig pc = new PlayerConfig();
 				create(config.getPlayerpath(), "player1");
 				// スコアデータコピー
-				if(Files.exists(Paths.get("playerscore.db"))) {
+				if (Files.exists(Paths.get("playerscore.db"))) {
 					Files.copy(Paths.get("playerscore.db"), Paths.get(config.getPlayerpath() + "/player1/score.db"));
 				}
 				// リプレイデータコピー
 				Files.createDirectory(Paths.get(config.getPlayerpath() + "/player1/replay"));
-				if(Files.exists(Paths.get("replay"))) {
+				if (Files.exists(Paths.get("replay"))) {
 					try (DirectoryStream<Path> paths = Files.newDirectoryStream(Paths.get("replay"))) {
 						for (Path p : paths) {
-							Files.copy(p, Paths.get(config.getPlayerpath() + "/player1/replay").resolve(p.getFileName()));
+							Files.copy(p,
+									Paths.get(config.getPlayerpath() + "/player1/replay").resolve(p.getFileName()));
 						}
-					} catch(Throwable e) {
+					} catch (Throwable e) {
 						e.printStackTrace();
 					}
 				}
@@ -896,7 +1125,7 @@ public class PlayerConfig {
 	public static void create(String playerpath, String playerid) {
 		try {
 			Path p = Paths.get(playerpath + "/" + playerid);
-			if(Files.exists(p)) {
+			if (Files.exists(p)) {
 				return;
 			}
 			Files.createDirectory(p);
@@ -912,11 +1141,11 @@ public class PlayerConfig {
 		List<String> l = new ArrayList<>();
 		try (DirectoryStream<Path> paths = Files.newDirectoryStream(Paths.get(playerpath))) {
 			for (Path p : paths) {
-				if(Files.isDirectory(p)) {
+				if (Files.isDirectory(p)) {
 					l.add(p.getFileName().toString());
 				}
 			}
-		} catch(Throwable e) {
+		} catch (Throwable e) {
 			e.printStackTrace();
 		}
 		return l.toArray(new String[l.size()]);
@@ -932,21 +1161,22 @@ public class PlayerConfig {
 				json.setIgnoreUnknownFields(true);
 				player = json.fromJson(PlayerConfig.class, reader);
 			} catch (SerializationException e) {
-				Logger.getGlobal().warning("PlayerConfigの読み込み失敗 - Path : " + path.toString() + " , Log : " + e.getMessage());
+				Logger.getGlobal()
+						.warning("PlayerConfigの読み込み失敗 - Path : " + path.toString() + " , Log : " + e.getMessage());
 				try {
 					Files.copy(path, Paths.get(playerpath + "/" + playerid + "/config_backup.json"));
 				} catch (IOException e1) {
-//					e1.printStackTrace();
+					// e1.printStackTrace();
 				}
-			} catch(Throwable e) {
+			} catch (Throwable e) {
 				e.printStackTrace();
-			}			
-		} else if(Files.exists(path_old)) {
+			}
+		} else if (Files.exists(path_old)) {
 			try (FileReader reader = new FileReader(path_old.toFile())) {
 				Json json = new Json();
 				json.setIgnoreUnknownFields(true);
 				player = json.fromJson(PlayerConfig.class, reader);
-			} catch(Throwable e) {
+			} catch (Throwable e) {
 				e.printStackTrace();
 			}
 		}
@@ -957,7 +1187,8 @@ public class PlayerConfig {
 
 	public static void write(String playerpath, PlayerConfig player) {
 		try (Writer writer = new OutputStreamWriter(
-				new FileOutputStream(Paths.get(playerpath + "/" + player.getId() + "/" + configpath).toFile()), StandardCharsets.UTF_8)) {
+				new FileOutputStream(Paths.get(playerpath + "/" + player.getId() + "/" + configpath).toFile()),
+				StandardCharsets.UTF_8)) {
 			Json json = new Json();
 			json.setOutputType(JsonWriter.OutputType.json);
 			json.setUsePrototypes(false);
@@ -976,14 +1207,14 @@ public class PlayerConfig {
 		this.mineMode = mineMode;
 	}
 
-    public int getScrollMode() {
-        return scrollMode;
-    }
+	public int getScrollMode() {
+		return scrollMode;
+	}
 
-    public void setScrollMode(int scrollMode) {
-        this.scrollMode = scrollMode;
-    }
-    
+	public void setScrollMode(int scrollMode) {
+		this.scrollMode = scrollMode;
+	}
+
 	public int getScrollSection() {
 		return scrollSection;
 	}
@@ -1000,19 +1231,19 @@ public class PlayerConfig {
 		this.scrollRate = scrollRate;
 	}
 
-    public int getLongnoteMode() {
-        return longnoteMode;
-    }
+	public int getLongnoteMode() {
+		return longnoteMode;
+	}
 
-    public void setLongnoteMode(int longnoteMode) {
-        this.longnoteMode = longnoteMode;
-    }
+	public void setLongnoteMode(int longnoteMode) {
+		this.longnoteMode = longnoteMode;
+	}
 
-    public double getLongnoteRate() {
-        return longnoteRate;
-    }
+	public double getLongnoteRate() {
+		return longnoteRate;
+	}
 
-    public void setLongnoteRate(double longnoteRate) {
-        this.longnoteRate = longnoteRate;
-    }
+	public void setLongnoteRate(double longnoteRate) {
+		this.longnoteRate = longnoteRate;
+	}
 }

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -188,201 +188,201 @@
                                          <Label text="%LNTYPE" GridPane.rowIndex="8" />
                                          <ComboBox fx:id="lntype" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
                                          <CheckBox fx:id="customjudge" mnemonicParsing="false" text="%EXPAND_JUDGE" GridPane.columnIndex="0" GridPane.rowIndex="10" />
-                                         <ComboBox fx:id="customjudgekind" prefWidth="150.0" GridPane.columnIndex="0" GridPane.rowIndex="11" />
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="10" GridPane.columnSpan="3">
-                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <ComboBox fx:id="customjudgekind" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="10" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="11" GridPane.columnSpan="3">
+                                         <Label text="KEY ALL PG" prefWidth="120.0"/>
                                          <NumericSpinner fx:id="njudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <Label text="KEY ALL GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="njudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <Label text="KEY ALL GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="njudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="11" GridPane.columnSpan="3">
-                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="12" GridPane.columnSpan="3">
+                                         <Label text="SCR ALL PG" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <Label text="SCR ALL GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <Label text="SCR ALL GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="12" GridPane.columnSpan="3">
-                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="13" GridPane.columnSpan="3">
+                                         <Label text="KEY EASY PG" prefWidth="120.0"/>
                                          <NumericSpinner fx:id="nejudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <Label text="KEY EASY GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nejudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <Label text="KEY EASY GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nejudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="13" GridPane.columnSpan="3">
-                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="14" GridPane.columnSpan="3">
+                                         <Label text="SCR EASY PG" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sejudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <Label text="SCR EASY GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sejudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <Label text="SCR EASY GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="sejudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="14" GridPane.columnSpan="3">
-                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="15" GridPane.columnSpan="3">
+                                         <Label text="KEY NORMAL PG" prefWidth="120.0"/>
                                          <NumericSpinner fx:id="nnjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <Label text="KEY NORMAL GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nnjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <Label text="KEY NORMAL GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nnjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="15" GridPane.columnSpan="3">
-                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="16" GridPane.columnSpan="3">
+                                         <Label text="SCR NORMAL PG" prefWidth="120.0" />
                                          <NumericSpinner fx:id="snjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <Label text="SCR NORMAL GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="snjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <Label text="SCR NORMAL GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="snjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="16" GridPane.columnSpan="3">
-                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="17" GridPane.columnSpan="3">
+                                         <Label text="KEY HARD PG" prefWidth="120.0"/>
                                          <NumericSpinner fx:id="nhjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <Label text="KEY HARD GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nhjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <Label text="KEY HARD GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nhjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="17" GridPane.columnSpan="3">
-                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="18" GridPane.columnSpan="3">
+                                         <Label text="SCR HARD PG" prefWidth="120.0" />
                                          <NumericSpinner fx:id="shjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <Label text="SCR HARD GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="shjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <Label text="SCR HARD GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="shjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="18" GridPane.columnSpan="3">
-                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="19" GridPane.columnSpan="3">
+                                         <Label text="KEY VERYHARD PG" prefWidth="120.0"/>
                                          <NumericSpinner fx:id="nvjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <Label text="KEY VERYHARD GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nvjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <Label text="KEY VERYHARD GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="nvjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="19" GridPane.columnSpan="3">
-                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="20" GridPane.columnSpan="3">
+                                         <Label text="SCR VERYHARD PG" prefWidth="120.0" />
                                          <NumericSpinner fx:id="svjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <Label text="SCR VERYHARD GR" prefWidth="120.0" />
                                          <NumericSpinner fx:id="svjudgegr" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>
                                          </NumericSpinner>
-                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <Label text="SCR VERYHARD GD" prefWidth="120.0" />
                                          <NumericSpinner fx:id="svjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -188,6 +188,7 @@
                                          <Label text="%LNTYPE" GridPane.rowIndex="8" />
                                          <ComboBox fx:id="lntype" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
                                          <CheckBox fx:id="customjudge" mnemonicParsing="false" text="%EXPAND_JUDGE" GridPane.columnIndex="0" GridPane.rowIndex="10" />
+                                         <ComboBox fx:id="customjudgekind" prefWidth="150.0" GridPane.columnIndex="0" GridPane.rowIndex="11" />
                                          <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="10" GridPane.columnSpan="3">
                                          <Label text="KEY PG" prefWidth="60.0"/>
                                          <NumericSpinner fx:id="njudgepg" editable="true" prefWidth="100.0">
@@ -223,6 +224,166 @@
                                          </NumericSpinner>
                                          <Label text="SCR GD" prefWidth="60.0" />
                                          <NumericSpinner fx:id="sjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="12" GridPane.columnSpan="3">
+                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <NumericSpinner fx:id="nejudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nejudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nejudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="13" GridPane.columnSpan="3">
+                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="sejudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="sejudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="sejudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="14" GridPane.columnSpan="3">
+                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <NumericSpinner fx:id="nnjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nnjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nnjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="15" GridPane.columnSpan="3">
+                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="snjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="snjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="snjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="16" GridPane.columnSpan="3">
+                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <NumericSpinner fx:id="nhjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nhjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nhjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="17" GridPane.columnSpan="3">
+                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="shjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="shjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="shjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="18" GridPane.columnSpan="3">
+                                         <Label text="KEY PG" prefWidth="60.0"/>
+                                         <NumericSpinner fx:id="nvjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nvjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="KEY GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="nvjudgegd" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         </HBox>
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="19" GridPane.columnSpan="3">
+                                         <Label text="SCR PG" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="svjudgepg" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="25" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GR" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="svjudgegr" editable="true" prefWidth="100.0">
+                                             <valueFactory>
+                                                 <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
+                                             </valueFactory>
+                                         </NumericSpinner>
+                                         <Label text="SCR GD" prefWidth="60.0" />
+                                         <NumericSpinner fx:id="svjudgegd" editable="true" prefWidth="100.0">
                                              <valueFactory>
                                                  <SpinnerValueFactory.IntegerSpinnerValueFactory amountToStepBy="25" initialValue="100" max="400" min="0" />
                                              </valueFactory>

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -45,7 +45,6 @@ import twitter4j.conf.ConfigurationBuilder;
  */
 public class PlayConfigurationView implements Initializable {
 
-
 	// TODO スキンプレビュー機能
 
 	@FXML
@@ -76,7 +75,7 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private Tab courseTab;
 	@FXML
-    private Tab streamTab;
+	private Tab streamTab;
 	@FXML
 	private HBox controlPanel;
 
@@ -153,6 +152,8 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private CheckBox customjudge;
 	@FXML
+	private ComboBox<Integer> customjudgekind;
+	@FXML
 	private Spinner<Integer> njudgepg;
 	@FXML
 	private Spinner<Integer> njudgegr;
@@ -164,6 +165,54 @@ public class PlayConfigurationView implements Initializable {
 	private Spinner<Integer> sjudgegr;
 	@FXML
 	private Spinner<Integer> sjudgegd;
+	@FXML
+	private Spinner<Integer> nejudgepg;
+	@FXML
+	private Spinner<Integer> nejudgegr;
+	@FXML
+	private Spinner<Integer> nejudgegd;
+	@FXML
+	private Spinner<Integer> sejudgepg;
+	@FXML
+	private Spinner<Integer> sejudgegr;
+	@FXML
+	private Spinner<Integer> sejudgegd;
+	@FXML
+	private Spinner<Integer> nnjudgepg;
+	@FXML
+	private Spinner<Integer> nnjudgegr;
+	@FXML
+	private Spinner<Integer> nnjudgegd;
+	@FXML
+	private Spinner<Integer> snjudgepg;
+	@FXML
+	private Spinner<Integer> snjudgegr;
+	@FXML
+	private Spinner<Integer> snjudgegd;
+	@FXML
+	private Spinner<Integer> nhjudgepg;
+	@FXML
+	private Spinner<Integer> nhjudgegr;
+	@FXML
+	private Spinner<Integer> nhjudgegd;
+	@FXML
+	private Spinner<Integer> shjudgepg;
+	@FXML
+	private Spinner<Integer> shjudgegr;
+	@FXML
+	private Spinner<Integer> shjudgegd;
+	@FXML
+	private Spinner<Integer> nvjudgepg;
+	@FXML
+	private Spinner<Integer> nvjudgegr;
+	@FXML
+	private Spinner<Integer> nvjudgegd;
+	@FXML
+	private Spinner<Integer> svjudgepg;
+	@FXML
+	private Spinner<Integer> svjudgegr;
+	@FXML
+	private Spinner<Integer> svjudgegd;
 	@FXML
 	private ComboBox<Integer> minemode;
 	@FXML
@@ -199,7 +248,7 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private ComboBox<Integer> judgealgorithm;
 
-    @FXML
+	@FXML
 	private ComboBox<Integer> autosavereplay1;
 	@FXML
 	private ComboBox<Integer> autosavereplay2;
@@ -208,22 +257,22 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private ComboBox<Integer> autosavereplay4;
 
-    @FXML
-    private CheckBox usecim;
+	@FXML
+	private CheckBox usecim;
 
-    @FXML
+	@FXML
 	private TextField txtTwitterConsumerKey;
-    @FXML
+	@FXML
 	private PasswordField txtTwitterConsumerSecret;
 
-    @FXML
-    private Button twitterAuthButton;
-    @FXML
-    private Label txtTwitterAuthenticated;
-    @FXML
-    private TextField txtTwitterPIN;
-    @FXML
-    private Button twitterPINButton;
+	@FXML
+	private Button twitterAuthButton;
+	@FXML
+	private Label txtTwitterAuthenticated;
+	@FXML
+	private TextField txtTwitterPIN;
+	@FXML
+	private Button twitterPINButton;
 
 	@FXML
 	private CheckBox enableIpfs;
@@ -249,7 +298,7 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private TableEditorView tableController;
 	@FXML
-    private StreamEditorView streamController;
+	private StreamEditorView streamController;
 
 	private Config config;
 	private PlayerConfig player;
@@ -278,29 +327,36 @@ public class PlayConfigurationView implements Initializable {
 		lr2configurationassist.setHgap(25);
 		lr2configurationassist.setVgap(4);
 
-
 		String[] scoreOptions = new String[] { "OFF", "MIRROR", "RANDOM", "R-RANDOM", "S-RANDOM", "SPIRAL", "H-RANDOM",
 				"ALL-SCR", "RANDOM-EX", "S-RANDOM-EX" };
 		initComboBox(scoreop, scoreOptions);
 		initComboBox(scoreop2, scoreOptions);
 		initComboBox(doubleop, new String[] { "OFF", "FLIP", "BATTLE", "BATTLE AS" });
-		initComboBox(seventoninepattern, new String[] { "OFF", "SC1KEY2~8", "SC1KEY3~9", "SC2KEY3~9", "SC8KEY1~7", "SC9KEY1~7", "SC9KEY2~8" });
-		String[] seventoninestring = new String[]{arg1.getString("SEVEN_TO_NINE_OFF"),arg1.getString("SEVEN_TO_NINE_NO_MASHING"),arg1.getString("SEVEN_TO_NINE_ALTERNATION")};
+		initComboBox(seventoninepattern,
+				new String[] { "OFF", "SC1KEY2~8", "SC1KEY3~9", "SC2KEY3~9", "SC8KEY1~7", "SC9KEY1~7", "SC9KEY2~8" });
+		String[] seventoninestring = new String[] { arg1.getString("SEVEN_TO_NINE_OFF"),
+				arg1.getString("SEVEN_TO_NINE_NO_MASHING"), arg1.getString("SEVEN_TO_NINE_ALTERNATION") };
 		initComboBox(seventoninetype, seventoninestring);
 		initComboBox(gaugeop, new String[] { "ASSIST EASY", "EASY", "NORMAL", "HARD", "EX-HARD", "HAZARD" });
 		initComboBox(fixhispeed, new String[] { "OFF", "START BPM", "MAX BPM", "MAIN BPM", "MIN BPM" });
 		playconfig.getItems().setAll(PlayMode.values());
 		initComboBox(lntype, new String[] { "LONG NOTE", "CHARGE NOTE", "HELL CHARGE NOTE" });
-		initComboBox(gaugeautoshift, new String[] { "NONE", "CONTINUE", "SURVIVAL TO GROOVE","BEST CLEAR","SELECT TO UNDER" });
+		initComboBox(gaugeautoshift,
+				new String[] { "NONE", "CONTINUE", "SURVIVAL TO GROOVE", "BEST CLEAR", "SELECT TO UNDER" });
 		initComboBox(bottomshiftablegauge, new String[] { "ASSIST EASY", "EASY", "NORMAL" });
 		initComboBox(minemode, new String[] { "OFF", "REMOVE", "ADD RANDOM", "ADD NEAR", "ADD ALL" });
 		initComboBox(scrollmode, new String[] { "OFF", "REMOVE", "ADD" });
+		initComboBox(customjudgekind, new String[] { "%(all)", "%(each)" });
 		initComboBox(longnotemode, new String[] { "OFF", "REMOVE", "ADD LN", "ADD CN", "ADD HCN", "ADD ALL" });
 
-		initComboBox(judgealgorithm, new String[] { arg1.getString("JUDGEALG_LR2"), arg1.getString("JUDGEALG_AC"), arg1.getString("JUDGEALG_BOTTOM_PRIORITY") });
-		String[] autosaves = new String[]{arg1.getString("NONE"),arg1.getString("BETTER_SCORE"),arg1.getString("BETTER_OR_SAME_SCORE"),arg1.getString("BETTER_MISSCOUNT")
-				,arg1.getString("BETTER_OR_SAME_MISSCOUNT"),arg1.getString("BETTER_COMBO"),arg1.getString("BETTER_OR_SAME_COMBO"),
-				arg1.getString("BETTER_LAMP"),arg1.getString("BETTER_OR_SAME_LAMP"),arg1.getString("BETTER_ALL"),arg1.getString("ALWAYS")};
+		initComboBox(judgealgorithm, new String[] { arg1.getString("JUDGEALG_LR2"), arg1.getString("JUDGEALG_AC"),
+				arg1.getString("JUDGEALG_BOTTOM_PRIORITY") });
+		String[] autosaves = new String[] { arg1.getString("NONE"), arg1.getString("BETTER_SCORE"),
+				arg1.getString("BETTER_OR_SAME_SCORE"), arg1.getString("BETTER_MISSCOUNT"),
+				arg1.getString("BETTER_OR_SAME_MISSCOUNT"), arg1.getString("BETTER_COMBO"),
+				arg1.getString("BETTER_OR_SAME_COMBO"),
+				arg1.getString("BETTER_LAMP"), arg1.getString("BETTER_OR_SAME_LAMP"), arg1.getString("BETTER_ALL"),
+				arg1.getString("ALWAYS") };
 		initComboBox(autosavereplay1, autosaves);
 		initComboBox(autosavereplay2, autosaves);
 		initComboBox(autosavereplay3, autosaves);
@@ -319,7 +375,7 @@ public class PlayConfigurationView implements Initializable {
 			final String downloadURL = MainLoader.getVersionChecker().getDownloadURL();
 			Platform.runLater(() -> {
 				newversion.setText(message);
-				if(downloadURL != null) {
+				if (downloadURL != null) {
 					newversion.setOnAction(new EventHandler<ActionEvent>() {
 
 						@Override
@@ -362,15 +418,15 @@ public class PlayConfigurationView implements Initializable {
 		resourceController.update(config);
 
 		skinController.update(config);
-        // int b = Boolean.valueOf(config.getJKOC()).compareTo(false);
+		// int b = Boolean.valueOf(config.getJKOC()).compareTo(false);
 
-        usecim.setSelected(config.isCacheSkinImage());
-        discord.setSelected(config.isUseDiscordRPC());
+		usecim.setSelected(config.isCacheSkinImage());
+		discord.setSelected(config.isUseDiscordRPC());
 
 		enableIpfs.setSelected(config.isEnableIpfs());
 		ipfsurl.setText(config.getIpfsUrl());
 
-		if(players.getItems().contains(config.getPlayername())) {
+		if (players.getItems().contains(config.getPlayername())) {
 			players.setValue(config.getPlayername());
 		} else {
 			players.getSelectionModel().select(0);
@@ -393,16 +449,16 @@ public class PlayConfigurationView implements Initializable {
 
 	public void addPlayer() {
 		String[] ids = PlayerConfig.readAllPlayerID(config.getPlayerpath());
-		for(int i = 1;i < 1000;i++) {
+		for (int i = 1; i < 1000; i++) {
 			String playerid = "player" + i;
 			boolean b = true;
-			for(String id : ids) {
-				if(playerid.equals(id)) {
-					b =false;
+			for (String id : ids) {
+				if (playerid.equals(id)) {
+					b = false;
 					break;
 				}
 			}
-			if(b) {
+			if (b) {
 				PlayerConfig.create(config.getPlayerpath(), playerid);
 				players.getItems().add(playerid);
 				break;
@@ -436,12 +492,37 @@ public class PlayConfigurationView implements Initializable {
 		bottomshiftablegauge.setValue(player.getBottomShiftableGauge());
 
 		customjudge.setSelected(player.isCustomJudge());
+		customjudgekind.getSelectionModel().select(player.getCustomJudgeKind());
 		njudgepg.getValueFactory().setValue(player.getKeyJudgeWindowRatePerfectGreat());
 		njudgegr.getValueFactory().setValue(player.getKeyJudgeWindowRateGreat());
 		njudgegd.getValueFactory().setValue(player.getKeyJudgeWindowRateGood());
 		sjudgepg.getValueFactory().setValue(player.getScratchJudgeWindowRatePerfectGreat());
 		sjudgegr.getValueFactory().setValue(player.getScratchJudgeWindowRateGreat());
 		sjudgegd.getValueFactory().setValue(player.getScratchJudgeWindowRateGood());
+		nejudgepg.getValueFactory().setValue(player.getKeyEasyJudgeWindowRatePerfectGreat());
+		nejudgegr.getValueFactory().setValue(player.getKeyEasyJudgeWindowRateGreat());
+		nejudgegd.getValueFactory().setValue(player.getKeyEasyJudgeWindowRateGood());
+		sejudgepg.getValueFactory().setValue(player.getScratchEasyJudgeWindowRatePerfectGreat());
+		sejudgegr.getValueFactory().setValue(player.getScratchEasyJudgeWindowRateGreat());
+		sejudgegd.getValueFactory().setValue(player.getScratchEasyJudgeWindowRateGood());
+		nnjudgepg.getValueFactory().setValue(player.getKeyNormalJudgeWindowRatePerfectGreat());
+		nnjudgegr.getValueFactory().setValue(player.getKeyNormalJudgeWindowRateGreat());
+		nnjudgegd.getValueFactory().setValue(player.getKeyNormalJudgeWindowRateGood());
+		snjudgepg.getValueFactory().setValue(player.getScratchNormalJudgeWindowRatePerfectGreat());
+		snjudgegr.getValueFactory().setValue(player.getScratchNormalJudgeWindowRateGreat());
+		snjudgegd.getValueFactory().setValue(player.getScratchNormalJudgeWindowRateGood());
+		nhjudgepg.getValueFactory().setValue(player.getKeyHardJudgeWindowRatePerfectGreat());
+		nhjudgegr.getValueFactory().setValue(player.getKeyHardJudgeWindowRateGreat());
+		nhjudgegd.getValueFactory().setValue(player.getKeyHardJudgeWindowRateGood());
+		shjudgepg.getValueFactory().setValue(player.getScratchHardJudgeWindowRatePerfectGreat());
+		shjudgegr.getValueFactory().setValue(player.getScratchHardJudgeWindowRateGreat());
+		shjudgegd.getValueFactory().setValue(player.getScratchHardJudgeWindowRateGood());
+		nvjudgepg.getValueFactory().setValue(player.getKeyVeryHardJudgeWindowRatePerfectGreat());
+		nvjudgegr.getValueFactory().setValue(player.getKeyVeryHardJudgeWindowRateGreat());
+		nvjudgegd.getValueFactory().setValue(player.getKeyVeryHardJudgeWindowRateGood());
+		svjudgepg.getValueFactory().setValue(player.getScratchVeryHardJudgeWindowRatePerfectGreat());
+		svjudgegr.getValueFactory().setValue(player.getScratchVeryHardJudgeWindowRateGreat());
+		svjudgegd.getValueFactory().setValue(player.getScratchVeryHardJudgeWindowRateGood());
 		minemode.getSelectionModel().select(player.getMineMode());
 		scrollmode.getSelectionModel().select(player.getScrollMode());
 		longnotemode.getSelectionModel().select(player.getLongnoteMode());
@@ -466,7 +547,7 @@ public class PlayConfigurationView implements Initializable {
 
 		txtTwitterPIN.setDisable(true);
 		twitterPINButton.setDisable(true);
-		if(player.getTwitterAccessToken() != null && !player.getTwitterAccessToken().isEmpty()) {
+		if (player.getTwitterAccessToken() != null && !player.getTwitterAccessToken().isEmpty()) {
 			txtTwitterAuthenticated.setVisible(true);
 		} else {
 			txtTwitterAuthenticated.setVisible(false);
@@ -484,7 +565,7 @@ public class PlayConfigurationView implements Initializable {
 	 * ダイアログの項目をconfig.xmlに反映する
 	 */
 	public void commit() {
-	    videoController.commit(config);
+		videoController.commit(config);
 		audioController.commit();
 		musicselectController.commit();
 
@@ -495,9 +576,9 @@ public class PlayConfigurationView implements Initializable {
 
 		resourceController.commit();
 
-        // jkoc_hack is integer but *.setJKOC needs boolean type
+		// jkoc_hack is integer but *.setJKOC needs boolean type
 
-        config.setCacheSkinImage(usecim.isSelected());
+		config.setCacheSkinImage(usecim.isSelected());
 
 		config.setEnableIpfs(enableIpfs.isSelected());
 		config.setIpfsUrl(ipfsurl.getText());
@@ -512,10 +593,10 @@ public class PlayConfigurationView implements Initializable {
 	}
 
 	public void commitPlayer() {
-		if(player == null) {
+		if (player == null) {
 			return;
 		}
-		if(playername.getText().length() > 0) {
+		if (playername.getText().length() > 0) {
 			player.setName(playername.getText());
 		}
 
@@ -539,12 +620,37 @@ public class PlayConfigurationView implements Initializable {
 		player.setGaugeAutoShift(gaugeautoshift.getValue());
 		player.setBottomShiftableGauge(bottomshiftablegauge.getValue());
 		player.setCustomJudge(customjudge.isSelected());
+		player.setCustomJudgeKind(customjudgekind.getValue());
 		player.setKeyJudgeWindowRatePerfectGreat(getValue(njudgepg));
 		player.setKeyJudgeWindowRateGreat(getValue(njudgegr));
 		player.setKeyJudgeWindowRateGood(getValue(njudgegd));
 		player.setScratchJudgeWindowRatePerfectGreat(getValue(sjudgepg));
 		player.setScratchJudgeWindowRateGreat(getValue(sjudgegr));
 		player.setScratchJudgeWindowRateGood(getValue(sjudgegd));
+		player.setKeyEasyJudgeWindowRatePerfectGreat(getValue(nejudgepg));
+		player.setKeyEasyJudgeWindowRateGreat(getValue(nejudgegr));
+		player.setKeyEasyJudgeWindowRateGood(getValue(nejudgegd));
+		player.setScratchEasyJudgeWindowRatePerfectGreat(getValue(sejudgepg));
+		player.setScratchEasyJudgeWindowRateGreat(getValue(sejudgegr));
+		player.setScratchEasyJudgeWindowRateGood(getValue(sejudgegd));
+		player.setKeyNormalJudgeWindowRatePerfectGreat(getValue(nnjudgepg));
+		player.setKeyNormalJudgeWindowRateGreat(getValue(nnjudgegr));
+		player.setKeyNormalJudgeWindowRateGood(getValue(nnjudgegd));
+		player.setScratchNormalJudgeWindowRatePerfectGreat(getValue(snjudgepg));
+		player.setScratchNormalJudgeWindowRateGreat(getValue(snjudgegr));
+		player.setScratchNormalJudgeWindowRateGood(getValue(snjudgegd));
+		player.setKeyHardJudgeWindowRatePerfectGreat(getValue(nhjudgepg));
+		player.setKeyHardJudgeWindowRateGreat(getValue(nhjudgegr));
+		player.setKeyHardJudgeWindowRateGood(getValue(nhjudgegd));
+		player.setScratchHardJudgeWindowRatePerfectGreat(getValue(shjudgepg));
+		player.setScratchHardJudgeWindowRateGreat(getValue(shjudgegr));
+		player.setScratchHardJudgeWindowRateGood(getValue(shjudgegd));
+		player.setKeyVeryHardJudgeWindowRatePerfectGreat(getValue(nvjudgepg));
+		player.setKeyVeryHardJudgeWindowRateGreat(getValue(nvjudgegr));
+		player.setKeyVeryHardJudgeWindowRateGood(getValue(nvjudgegd));
+		player.setScratchVeryHardJudgeWindowRatePerfectGreat(getValue(svjudgepg));
+		player.setScratchVeryHardJudgeWindowRateGreat(getValue(svjudgegr));
+		player.setScratchVeryHardJudgeWindowRateGood(getValue(svjudgegd));
 		player.setMineMode(minemode.getValue());
 		player.setScrollMode(scrollmode.getValue());
 		player.setLongnoteMode(longnotemode.getValue());
@@ -553,8 +659,8 @@ public class PlayConfigurationView implements Initializable {
 		player.setMarkprocessednote(markprocessednote.isSelected());
 		player.setExtranoteDepth(extranotedepth.getValue());
 
-		player.setAutoSaveReplay( new int[]{autosavereplay1.getValue(),autosavereplay2.getValue(),
-				autosavereplay3.getValue(),autosavereplay4.getValue()});
+		player.setAutoSaveReplay(new int[] { autosavereplay1.getValue(), autosavereplay2.getValue(),
+				autosavereplay3.getValue(), autosavereplay4.getValue() });
 
 		player.setShowjudgearea(judgeregion.isSelected());
 		player.setTargetid(target.getValue());
@@ -571,39 +677,39 @@ public class PlayConfigurationView implements Initializable {
 		PlayerConfig.write(config.getPlayerpath(), player);
 	}
 
-    @FXML
+	@FXML
 	public void addBGMPath() {
-    	String s = showDirectoryChooser("BGMのルートフォルダを選択してください");
-    	if(s != null) {
-        	bgmpath.setText(s);
-    	}
+		String s = showDirectoryChooser("BGMのルートフォルダを選択してください");
+		if (s != null) {
+			bgmpath.setText(s);
+		}
 	}
 
-    @FXML
+	@FXML
 	public void addSoundPath() {
-    	String s = showDirectoryChooser("効果音のルートフォルダを選択してください");
-    	if(s != null) {
-    		soundpath.setText(s);
-    	}
+		String s = showDirectoryChooser("効果音のルートフォルダを選択してください");
+		if (s != null) {
+			soundpath.setText(s);
+		}
 	}
 
-    private String showFileChooser(String title) {
-    	FileChooser chooser = new FileChooser();
+	private String showFileChooser(String title) {
+		FileChooser chooser = new FileChooser();
 		chooser.setTitle(title);
 		File f = chooser.showOpenDialog(null);
 		return f != null ? f.getPath() : null;
-    }
+	}
 
-    private String showDirectoryChooser(String title) {
+	private String showDirectoryChooser(String title) {
 		DirectoryChooser chooser = new DirectoryChooser();
 		chooser.setTitle(title);
 		File f = chooser.showDialog(null);
 		return f != null ? f.getPath() : null;
-    }
+	}
 
 	private PlayMode pc = null;
 
-    @FXML
+	@FXML
 	public void updatePlayConfig() {
 		if (pc != null) {
 			PlayConfig conf = player.getPlayConfig(Mode.valueOf(pc.name())).getPlayconfig();
@@ -648,7 +754,7 @@ public class PlayConfigurationView implements Initializable {
 		return spinner.getValue();
 	}
 
-    @FXML
+	@FXML
 	public void start() {
 		commit();
 		playerPanel.setDisable(true);
@@ -665,35 +771,36 @@ public class PlayConfigurationView implements Initializable {
 		MainLoader.play(null, bms.player.beatoraja.BMSPlayerMode.PLAY, true, config, player, songUpdated);
 	}
 
-    @FXML
+	@FXML
 	public void loadAllBMS() {
 		commit();
 		loadBMS(null, true);
 	}
 
-    @FXML
+	@FXML
 	public void loadDiffBMS() {
 		commit();
 		loadBMS(null, false);
 	}
 
-	public void loadBMSPath(String updatepath){
+	public void loadBMSPath(String updatepath) {
 		commit();
-    	loadBMS(updatepath, false);
+		loadBMS(updatepath, false);
 	}
 
 	/**
 	 * BMSを読み込み、楽曲データベースを更新する
 	 *
 	 * @param updateAll
-	 *            falseの場合は追加削除分のみを更新する
+	 *                  falseの場合は追加削除分のみを更新する
 	 */
 	public void loadBMS(String updatepath, boolean updateAll) {
 		commit();
 		try {
 			SongDatabaseAccessor songdb = MainLoader.getScoreDatabaseAccessor();
-			SongInformationAccessor infodb = config.isUseSongInfo() ?
-					new SongInformationAccessor(Paths.get("songinfo.db").toString()) : null;
+			SongInformationAccessor infodb = config.isUseSongInfo()
+					? new SongInformationAccessor(Paths.get("songinfo.db").toString())
+					: null;
 			Logger.getGlobal().info("song.db更新開始");
 			songdb.updateSongDatas(updatepath, config.getBmsroot(), updateAll, infodb);
 			Logger.getGlobal().info("song.db更新完了");
@@ -703,7 +810,7 @@ public class PlayConfigurationView implements Initializable {
 		}
 	}
 
-    @FXML
+	@FXML
 	public void importScoreDataFromLR2() {
 		FileChooser chooser = new FileChooser();
 		chooser.getExtensionFilters().setAll(new ExtensionFilter("Lunatic Rave 2 Score Database File", "*.db"));
@@ -717,7 +824,8 @@ public class PlayConfigurationView implements Initializable {
 			Class.forName("org.sqlite.JDBC");
 			SongDatabaseAccessor songdb = MainLoader.getScoreDatabaseAccessor();
 			String player = players.getValue();
-			ScoreDatabaseAccessor scoredb = new ScoreDatabaseAccessor(config.getPlayerpath() + File.separatorChar + player + File.separatorChar + "score.db");
+			ScoreDatabaseAccessor scoredb = new ScoreDatabaseAccessor(
+					config.getPlayerpath() + File.separatorChar + player + File.separatorChar + "score.db");
 			scoredb.createTable();
 
 			ScoreDataImporter scoreimporter = new ScoreDataImporter(scoredb);
@@ -774,7 +882,7 @@ public class PlayConfigurationView implements Initializable {
 		}
 	}
 
-    @FXML
+	@FXML
 	public void exit() {
 		commit();
 		Platform.exit();
@@ -818,4 +926,3 @@ public class PlayConfigurationView implements Initializable {
 		}
 	}
 }
-

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -346,7 +346,7 @@ public class PlayConfigurationView implements Initializable {
 		initComboBox(bottomshiftablegauge, new String[] { "ASSIST EASY", "EASY", "NORMAL" });
 		initComboBox(minemode, new String[] { "OFF", "REMOVE", "ADD RANDOM", "ADD NEAR", "ADD ALL" });
 		initComboBox(scrollmode, new String[] { "OFF", "REMOVE", "ADD" });
-		initComboBox(customjudgekind, new String[] { "%(all)", "%(each)" });
+		initComboBox(customjudgekind, new String[] { "% for all judge", "% for each judge" });
 		initComboBox(longnotemode, new String[] { "OFF", "REMOVE", "ADD LN", "ADD CN", "ADD HCN", "ADD ALL" });
 
 		initComboBox(judgealgorithm, new String[] { arg1.getString("JUDGEALG_LR2"), arg1.getString("JUDGEALG_AC"),

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -241,20 +241,20 @@ public class BMSPlayer extends MainState {
 									|| config.getKeyEasyJudgeWindowRateGood() > 100
 									|| config.getScratchEasyJudgeWindowRatePerfectGreat() > 100
 									|| config.getScratchEasyJudgeWindowRateGreat() > 100
-									|| config.getScratchEasyJudgeWindowRateGood() > 100)
-							&& (config.getKeyNormalJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchEasyJudgeWindowRateGood() > 100
+									|| config.getKeyNormalJudgeWindowRatePerfectGreat() > 100
 									|| config.getKeyNormalJudgeWindowRateGreat() > 100
 									|| config.getKeyNormalJudgeWindowRateGood() > 100
 									|| config.getScratchNormalJudgeWindowRatePerfectGreat() > 100
 									|| config.getScratchNormalJudgeWindowRateGreat() > 100
-									|| config.getScratchNormalJudgeWindowRateGood() > 100)
-							&& (config.getKeyHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchNormalJudgeWindowRateGood() > 100
+									|| config.getKeyHardJudgeWindowRatePerfectGreat() > 100
 									|| config.getKeyHardJudgeWindowRateGreat() > 100
 									|| config.getKeyHardJudgeWindowRateGood() > 100
 									|| config.getScratchHardJudgeWindowRatePerfectGreat() > 100
 									|| config.getScratchHardJudgeWindowRateGreat() > 100
-									|| config.getScratchHardJudgeWindowRateGood() > 100)
-							&& (config.getKeyVeryHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchHardJudgeWindowRateGood() > 100
+									|| config.getKeyVeryHardJudgeWindowRatePerfectGreat() > 100
 									|| config.getKeyVeryHardJudgeWindowRateGreat() > 100
 									|| config.getKeyVeryHardJudgeWindowRateGood() > 100
 									|| config.getScratchVeryHardJudgeWindowRatePerfectGreat() > 100

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -65,9 +65,10 @@ public class BMSPlayer extends MainState {
 	 */
 	private int notes;
 	/**
-	 * PMS キャラ用 ニュートラルモーション開始時の処理済ノート数{1P,2P} (ニュートラルモーション一周時に変化がなければニュートラルモーションを継続するため)
+	 * PMS キャラ用 ニュートラルモーション開始時の処理済ノート数{1P,2P}
+	 * (ニュートラルモーション一周時に変化がなければニュートラルモーションを継続するため)
 	 */
-	private int[] PMcharaLastnotes = {0, 0};
+	private int[] PMcharaLastnotes = { 0, 0 };
 	/**
 	 * リプレイHS保存用 STATE READY時に保存
 	 */
@@ -111,17 +112,20 @@ public class BMSPlayer extends MainState {
 		ReplayData HSReplay = null;
 
 		// TODO ターゲットスコアはPlayerResourceで受け渡す
-		if(resource.getRivalScoreData() == null) {
+		if (resource.getRivalScoreData() == null) {
 		} else {
 			ScoreData rival = resource.getRivalScoreData();
-			if(rival.getSeed() != -1) {
+			if (rival.getSeed() != -1) {
 				playinfo.randomoption = rival.getOption() % 10;
 				playinfo.randomoption2 = (rival.getOption() / 10) % 10;
 				playinfo.doubleoption = rival.getOption() / 100;
 				playinfo.randomoptionseed = rival.getSeed() % (65536 * 256);
 				playinfo.randomoption2seed = rival.getSeed() / (65536 * 256);
-//				main.getMessageRenderer().addMessage("Rival Chart Option Mode - Option : " + playinfo.randomoption + "/" +
-//						playinfo.randomoption2 + "/" + playinfo.doubleoption + " , Seed : " + playinfo.randomoptionseed + "/" + playinfo.randomoption2seed, 3000, Color.GOLD, 0);
+				// main.getMessageRenderer().addMessage("Rival Chart Option Mode - Option : " +
+				// playinfo.randomoption + "/" +
+				// playinfo.randomoption2 + "/" + playinfo.doubleoption + " , Seed : " +
+				// playinfo.randomoptionseed + "/" + playinfo.randomoption2seed, 3000,
+				// Color.GOLD, 0);
 			}
 		}
 
@@ -155,8 +159,8 @@ public class BMSPlayer extends MainState {
 				replay = main.getPlayDataAccessor().readReplayData(model, config.getLnmode(), autoplay.id);
 				if (replay != null) {
 					boolean isReplayPatternPlay = false;
-					if(main.getInputProcessor().getKeyState(1)) {
-						//保存された譜面オプション/Random Seedから譜面再現
+					if (main.getInputProcessor().getKeyState(1)) {
+						// 保存された譜面オプション/Random Seedから譜面再現
 						Logger.getGlobal().info("リプレイ再現モード : 譜面");
 						playinfo.randomoption = replay.randomoption;
 						playinfo.randomoptionseed = replay.randomoptionseed;
@@ -165,21 +169,21 @@ public class BMSPlayer extends MainState {
 						playinfo.doubleoption = replay.doubleoption;
 						playinfo.rand = replay.rand;
 						isReplayPatternPlay = true;
-					} else if(main.getInputProcessor().getKeyState(2)) {
-						//保存された譜面オプションログから譜面オプション再現
+					} else if (main.getInputProcessor().getKeyState(2)) {
+						// 保存された譜面オプションログから譜面オプション再現
 						Logger.getGlobal().info("リプレイ再現モード : オプション");
 						playinfo.randomoption = replay.randomoption;
 						playinfo.randomoption2 = replay.randomoption2;
 						playinfo.doubleoption = replay.doubleoption;
 						isReplayPatternPlay = true;
 					}
-					if(main.getInputProcessor().getKeyState(4)) {
-						//保存されたHSオプションログからHSオプション再現
+					if (main.getInputProcessor().getKeyState(4)) {
+						// 保存されたHSオプションログからHSオプション再現
 						Logger.getGlobal().info("リプレイ再現モード : ハイスピード");
 						HSReplay = replay;
 						isReplayPatternPlay = true;
 					}
-					if(isReplayPatternPlay) {
+					if (isReplayPatternPlay) {
 						replay = null;
 						autoplay = BMSPlayerMode.PLAY;
 						resource.setPlayMode(autoplay);
@@ -203,7 +207,7 @@ public class BMSPlayer extends MainState {
 				playinfo.rand = resource.getReplayData().rand;
 			}
 
-			if(playinfo.rand != null && playinfo.rand.length > 0) {
+			if (playinfo.rand != null && playinfo.rand.length > 0) {
 				model = resource.loadBMSModel(playinfo.rand);
 				// 暫定処置
 				BMSModelUtils.setStartNoteTime(model, 1000);
@@ -213,7 +217,8 @@ public class BMSPlayer extends MainState {
 			Logger.getGlobal().info("譜面分岐 : " + Arrays.toString(playinfo.rand));
 		}
 		// 通常プレイの場合は最後のノーツ、オートプレイの場合はBG/BGAを含めた最後のノーツ
-		playtime = (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY ? model.getLastTime() : model.getLastNoteTime()) + TIME_MARGIN;
+		playtime = (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY ? model.getLastTime() : model.getLastNoteTime())
+				+ TIME_MARGIN;
 
 		if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY) {
 			if (config.isBpmguide() && (model.getMinBPM() < model.getMaxBPM())) {
@@ -223,52 +228,85 @@ public class BMSPlayer extends MainState {
 			}
 
 			if (config.isCustomJudge() &&
-					(config.getKeyJudgeWindowRatePerfectGreat() > 100 || config.getKeyJudgeWindowRateGreat() > 100 || config.getKeyJudgeWindowRateGood() > 100
-					|| config.getScratchJudgeWindowRatePerfectGreat() > 100 || config.getScratchJudgeWindowRateGreat() > 100 || config.getScratchJudgeWindowRateGood() > 100)) {
+					(config.getCustomJudgeKind() == 0 &&
+							(config.getKeyJudgeWindowRatePerfectGreat() > 100
+									|| config.getKeyJudgeWindowRateGreat() > 100
+									|| config.getKeyJudgeWindowRateGood() > 100
+									|| config.getScratchJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchJudgeWindowRateGreat() > 100
+									|| config.getScratchJudgeWindowRateGood() > 100))
+					|| (config.getCustomJudgeKind() == 1 &&
+							(config.getKeyEasyJudgeWindowRatePerfectGreat() > 100
+									|| config.getKeyEasyJudgeWindowRateGreat() > 100
+									|| config.getKeyEasyJudgeWindowRateGood() > 100
+									|| config.getScratchEasyJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchEasyJudgeWindowRateGreat() > 100
+									|| config.getScratchEasyJudgeWindowRateGood() > 100)
+							&& (config.getKeyNormalJudgeWindowRatePerfectGreat() > 100
+									|| config.getKeyNormalJudgeWindowRateGreat() > 100
+									|| config.getKeyNormalJudgeWindowRateGood() > 100
+									|| config.getScratchNormalJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchNormalJudgeWindowRateGreat() > 100
+									|| config.getScratchNormalJudgeWindowRateGood() > 100)
+							&& (config.getKeyHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getKeyHardJudgeWindowRateGreat() > 100
+									|| config.getKeyHardJudgeWindowRateGood() > 100
+									|| config.getScratchHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchHardJudgeWindowRateGreat() > 100
+									|| config.getScratchHardJudgeWindowRateGood() > 100)
+							&& (config.getKeyVeryHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getKeyVeryHardJudgeWindowRateGreat() > 100
+									|| config.getKeyVeryHardJudgeWindowRateGood() > 100
+									|| config.getScratchVeryHardJudgeWindowRatePerfectGreat() > 100
+									|| config.getScratchVeryHardJudgeWindowRateGreat() > 100
+									|| config.getScratchVeryHardJudgeWindowRateGood() > 100))) {
 				assist = Math.max(assist, 2);
 				score = false;
 			}
 
 			Array<PatternModifier> mods = new Array<PatternModifier>();
 
-			if(config.getScrollMode() > 0) {
-				mods.add(new ScrollSpeedModifier(config.getScrollMode() - 1, config.getScrollSection(), config.getScrollRate()));
+			if (config.getScrollMode() > 0) {
+				mods.add(new ScrollSpeedModifier(config.getScrollMode() - 1, config.getScrollSection(),
+						config.getScrollRate()));
 			}
-			if(config.getLongnoteMode() > 0) {
+			if (config.getLongnoteMode() > 0) {
 				mods.add(new LongNoteModifier(config.getLongnoteMode() - 1, config.getLongnoteRate()));
 			}
-			if(config.getMineMode() > 0) {
+			if (config.getMineMode() > 0) {
 				mods.add(new MineNoteModifier(config.getMineMode() - 1));
 			}
-			if(config.getExtranoteDepth() > 0) {
-				mods.add(new ExtraNoteModifier(config.getExtranoteType(), config.getExtranoteDepth(), config.isExtranoteScratch()));
+			if (config.getExtranoteDepth() > 0) {
+				mods.add(new ExtraNoteModifier(config.getExtranoteType(), config.getExtranoteDepth(),
+						config.isExtranoteScratch()));
 			}
 
-			for(PatternModifier mod : mods) {
+			for (PatternModifier mod : mods) {
 				mod.modify(model);
-				if(mod.getAssistLevel() != PatternModifier.AssistLevel.NONE) {
+				if (mod.getAssistLevel() != PatternModifier.AssistLevel.NONE) {
 					assist = Math.max(assist, mod.getAssistLevel() == PatternModifier.AssistLevel.ASSIST ? 2 : 1);
 					score = false;
 				}
 			}
 
 			if (playinfo.doubleoption >= 2) {
-				if(model.getMode() == Mode.BEAT_5K || model.getMode() == Mode.BEAT_7K || model.getMode() == Mode.KEYBOARD_24K) {
+				if (model.getMode() == Mode.BEAT_5K || model.getMode() == Mode.BEAT_7K
+						|| model.getMode() == Mode.KEYBOARD_24K) {
 					switch (model.getMode()) {
-					case BEAT_5K:
-						model.setMode(Mode.BEAT_10K);
-						break;
-					case BEAT_7K:
-						model.setMode(Mode.BEAT_14K);
-						break;
-					case KEYBOARD_24K:
-						model.setMode(Mode.KEYBOARD_24K_DOUBLE);
-						break;
+						case BEAT_5K:
+							model.setMode(Mode.BEAT_10K);
+							break;
+						case BEAT_7K:
+							model.setMode(Mode.BEAT_14K);
+							break;
+						case KEYBOARD_24K:
+							model.setMode(Mode.KEYBOARD_24K_DOUBLE);
+							break;
 					}
 					LaneShuffleModifier mod = new LaneShuffleModifier(Random.BATTLE);
 					mod.setModifyTarget(PatternModifier.SIDE_1P);
 					mod.modify(model);
-					if(playinfo.doubleoption == 3) {
+					if (playinfo.doubleoption == 3) {
 						PatternModifier as = new AutoplayModifier(model.getMode().scratchKey);
 						as.modify(model);
 					}
@@ -285,7 +323,7 @@ public class BMSPlayer extends MainState {
 		Logger.getGlobal().info("譜面オプション設定");
 		if (replay != null && replay.pattern != null) {
 			// リプレイ譜面再現(PatternModifyLog使用。旧verとの互換性維持用)
-			if(replay.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
+			if (replay.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
 				model.setMode(Mode.POPN_9K);
 			}
 			PatternModifier.modify(model, Arrays.asList(replay.pattern));
@@ -294,15 +332,15 @@ public class BMSPlayer extends MainState {
 
 			// リプレイデータからのoption/seed再現
 			ReplayData rd = null;
-			if(replay != null) {
+			if (replay != null) {
 				rd = replay;
 				Logger.getGlobal().info("リプレイデータから譜面再現 : option/seed");
-			} else if(resource.getReplayData().randomoptionseed != -1) {
+			} else if (resource.getReplayData().randomoptionseed != -1) {
 				rd = resource.getReplayData();
 				Logger.getGlobal().info("前回プレイ時の譜面再現");
 			}
 			if (rd != null) {
-				if(rd.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
+				if (rd.sevenToNinePattern > 0 && model.getMode() == Mode.BEAT_7K) {
 					model.setMode(Mode.POPN_9K);
 				}
 				playinfo.randomoption = rd.randomoption;
@@ -314,86 +352,94 @@ public class BMSPlayer extends MainState {
 
 			Array<PatternModifier> mods = new Array<PatternModifier>();
 			// DP譜面オプション
-			if(model.getMode().player == 2) {
+			if (model.getMode().player == 2) {
 				if (playinfo.doubleoption == 1) {
 					mods.add(new LaneShuffleModifier(Random.FLIP));
 				}
 				Logger.getGlobal().info("譜面オプション(DP) :  " + playinfo.doubleoption);
 
-				PatternModifier pm = PatternModifier.create(playinfo.randomoption2, PatternModifier.SIDE_2P, model.getMode(), config);
-				if(playinfo.randomoption2seed != -1) {
+				PatternModifier pm = PatternModifier.create(playinfo.randomoption2, PatternModifier.SIDE_2P,
+						model.getMode(), config);
+				if (playinfo.randomoption2seed != -1) {
 					pm.setSeed(playinfo.randomoption2seed);
 				} else {
 					playinfo.randomoption2seed = pm.getSeed();
 				}
 				mods.add(pm);
-				Logger.getGlobal().info("譜面オプション(2P) :  " + playinfo.randomoption2 + ", Seed : " + playinfo.randomoption2seed);
+				Logger.getGlobal()
+						.info("譜面オプション(2P) :  " + playinfo.randomoption2 + ", Seed : " + playinfo.randomoption2seed);
 			}
 
 			// POPN_9KのSCR系RANDOMにPOPN_5Kは対応していないため、非SCR系RANDOMに変更
-			if(model.getMode() == Mode.POPN_5K) {
-				switch(Random.getRandom(playinfo.randomoption)) {
-				case ALL_SCR: playinfo.randomoption = Random.IDENTITY.id;
-					break;
-				case RANDOM_EX: playinfo.randomoption = Random.RANDOM.id;
-					break;
-				case S_RANDOM_EX: playinfo.randomoption = Random.S_RANDOM.id;
-					break;
-				default:
-					break;
+			if (model.getMode() == Mode.POPN_5K) {
+				switch (Random.getRandom(playinfo.randomoption)) {
+					case ALL_SCR:
+						playinfo.randomoption = Random.IDENTITY.id;
+						break;
+					case RANDOM_EX:
+						playinfo.randomoption = Random.RANDOM.id;
+						break;
+					case S_RANDOM_EX:
+						playinfo.randomoption = Random.S_RANDOM.id;
+						break;
+					default:
+						break;
 				}
 			}
 
 			// SP譜面オプション
-			PatternModifier pm = PatternModifier.create(playinfo.randomoption, PatternModifier.SIDE_1P, model.getMode(), config);
-			if(playinfo.randomoptionseed != -1) {
+			PatternModifier pm = PatternModifier.create(playinfo.randomoption, PatternModifier.SIDE_1P, model.getMode(),
+					config);
+			if (playinfo.randomoptionseed != -1) {
 				pm.setSeed(playinfo.randomoptionseed);
 			} else {
 				playinfo.randomoptionseed = pm.getSeed();
 			}
 			mods.add(pm);
-			Logger.getGlobal().info("譜面オプション(1P) :  " + playinfo.randomoption + ", Seed : " + playinfo.randomoptionseed);
+			Logger.getGlobal()
+					.info("譜面オプション(1P) :  " + playinfo.randomoption + ", Seed : " + playinfo.randomoptionseed);
 
 			if (config.getSevenToNinePattern() >= 1 && model.getMode() == Mode.BEAT_7K) {
-				//7to9
+				// 7to9
 				ModeModifier mod = new ModeModifier(Mode.BEAT_7K, Mode.POPN_9K, config);
 				mod.setModifyTarget(PatternModifier.SIDE_1P);
 				mods.add(mod);
 			}
 
 			List<PatternModifyLog> pattern = new ArrayList<PatternModifyLog>();
-			for(PatternModifier mod : mods) {
-				pattern = PatternModifier.merge(pattern,mod.modify(model));
-				if(mod.getAssistLevel() != PatternModifier.AssistLevel.NONE) {
+			for (PatternModifier mod : mods) {
+				pattern = PatternModifier.merge(pattern, mod.modify(model));
+				if (mod.getAssistLevel() != PatternModifier.AssistLevel.NONE) {
 					Logger.getGlobal().info("アシスト譜面オプションが選択されました");
 					assist = Math.max(assist, mod.getAssistLevel() == PatternModifier.AssistLevel.ASSIST ? 2 : 1);
 					score = false;
 				}
 			}
-//			playinfo.pattern = pattern.toArray(new PatternModifyLog[pattern.size()]);
+			// playinfo.pattern = pattern.toArray(new PatternModifyLog[pattern.size()]);
 
 		}
 
-		if(HSReplay != null && HSReplay.config != null) {
-			//保存されたHSオプションログからHSオプション再現
+		if (HSReplay != null && HSReplay.config != null) {
+			// 保存されたHSオプションログからHSオプション再現
 			config.getPlayConfig(model.getMode()).setPlayconfig(HSReplay.config);
 		}
 
 		Logger.getGlobal().info("ゲージ設定");
-		if(replay != null) {
-			for(int count = (main.getInputProcessor().getKeyState(5) ? 1 : 0) + (main.getInputProcessor().getKeyState(3) ? 2 : 0);count > 0; count--) {
+		if (replay != null) {
+			for (int count = (main.getInputProcessor().getKeyState(5) ? 1 : 0)
+					+ (main.getInputProcessor().getKeyState(3) ? 2 : 0); count > 0; count--) {
 				if (replay.gauge != GrooveGauge.HAZARD || replay.gauge != GrooveGauge.EXHARDCLASS) {
 					replay.gauge++;
 				}
 			}
 		}
-		if(replay != null && main.getInputProcessor().getKeyState(5)) {
+		if (replay != null && main.getInputProcessor().getKeyState(5)) {
 		}
 		// プレイゲージ、初期値設定
 		gauge = GrooveGauge.create(model, replay != null ? replay.gauge : config.getGauge(), resource);
 		// ゲージログ初期化
 		gaugelog = new FloatArray[gauge.getGaugeTypeLength()];
-		for(int i = 0; i < gaugelog.length; i++) {
+		for (int i = 0; i < gaugelog.length; i++) {
 			gaugelog[i] = new FloatArray(playtime / 500 + 2);
 		}
 
@@ -405,13 +451,14 @@ public class BMSPlayer extends MainState {
 		resource.getSongdata().setBMSModel(model);
 		resource.getSongdata().setDifficulty(difficulty);
 
-		discord = Discord.playingSong(resource.getSongdata().getFullTitle(), resource.getSongdata().getArtist(), resource.getSongdata().getMode());
+		discord = Discord.playingSong(resource.getSongdata().getFullTitle(), resource.getSongdata().getArtist(),
+				resource.getSongdata().getMode());
 		discord.update();
 	}
 
 	public SkinType getSkinType() {
-		for(SkinType type : SkinType.values()) {
-			if(type.getMode() == model.getMode()) {
+		for (SkinType type : SkinType.values()) {
+			if (type.getMode() == model.getMode()) {
 				return type;
 			}
 		}
@@ -433,11 +480,12 @@ public class BMSPlayer extends MainState {
 		setSound(SOUND_READY, "playready.wav", SoundType.SOUND, false);
 		setSound(SOUND_PLAYSTOP, "playstop.wav", SoundType.SOUND, false);
 
-		final String[] guideses = {"guide-pg.wav","guide-gr.wav","guide-gd.wav","guide-bd.wav","guide-pr.wav","guide-ms.wav"};
-		for(int i = 0;i < 6;i++) {
-			if(config.isGuideSE()) {
+		final String[] guideses = { "guide-pg.wav", "guide-gr.wav", "guide-gd.wav", "guide-bd.wav", "guide-pr.wav",
+				"guide-ms.wav" };
+		for (int i = 0; i < 6; i++) {
+			if (config.isGuideSE()) {
 				Path[] paths = getSoundPaths(guideses[i], SoundType.SOUND);
-				if(paths.length > 0) {
+				if (paths.length > 0) {
 					main.getAudioProcessor().setAdditionalKeySound(i, true, paths[0].toString());
 					main.getAudioProcessor().setAdditionalKeySound(i, false, paths[0].toString());
 				}
@@ -448,7 +496,7 @@ public class BMSPlayer extends MainState {
 		}
 
 		final BMSPlayerInputProcessor input = main.getInputProcessor();
-		if(autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
+		if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
 			input.setPlayConfig(config.getPlayConfig(model.getMode()));
 		} else if (autoplay.mode == BMSPlayerMode.Mode.AUTOPLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
 			input.setEnable(false);
@@ -464,7 +512,10 @@ public class BMSPlayer extends MainState {
 		judge.init(model, resource);
 
 		rhythm = new RhythmTimerProcessor(model,
-				(getSkin() instanceof PlaySkin) ? ((PlaySkin) getSkin()).getNoteExpansionRate()[0] != 100 || ((PlaySkin) getSkin()).getNoteExpansionRate()[1] != 100 : false);
+				(getSkin() instanceof PlaySkin)
+						? ((PlaySkin) getSkin()).getNoteExpansionRate()[0] != 100
+								|| ((PlaySkin) getSkin()).getNoteExpansionRate()[1] != 100
+						: false);
 
 		bga = resource.getBGAManager();
 
@@ -479,19 +530,21 @@ public class BMSPlayer extends MainState {
 			practice.create(model);
 			state = STATE_PRACTICE;
 		} else {
-			
-			if(resource.getRivalScoreData() == null || resource.getCourseBMSModels() != null) {
+
+			if (resource.getRivalScoreData() == null || resource.getCourseBMSModels() != null) {
 				ScoreData rivalScore = TargetProperty.getTargetProperty(config.getTargetid()).getTarget(main);
 				resource.setRivalScoreData(rivalScore);
 			}
-			getScoreDataProperty().setTargetScore(score.getExscore(), score.decodeGhost(), resource.getRivalScoreData() != null ? resource.getRivalScoreData().getExscore() : 0 , null, model.getTotalNotes());
+			getScoreDataProperty().setTargetScore(score.getExscore(), score.decodeGhost(),
+					resource.getRivalScoreData() != null ? resource.getRivalScoreData().getExscore() : 0, null,
+					model.getTotalNotes());
 		}
 	}
 
 	@Override
 	public void render() {
 		final PlaySkin skin = (PlaySkin) getSkin();
-		if(skin == null) {
+		if (skin == null) {
 			main.changeState(MainStateType.MUSICSELECT);
 			return;
 		}
@@ -502,309 +555,334 @@ public class BMSPlayer extends MainState {
 
 		final long micronow = main.getNowMicroTime();
 
-		if(micronow > skin.getInput() * 1000){
+		if (micronow > skin.getInput() * 1000) {
 			main.switchTimer(TIMER_STARTINPUT, true);
 		}
-		if(input.startPressed() || input.isSelectPressed()){
+		if (input.startPressed() || input.isSelectPressed()) {
 			startpressedtime = micronow;
 		}
 		switch (state) {
-		// 楽曲ロード
-		case STATE_PRELOAD:
-			if (resource.mediaLoadFinished() && micronow > (skin.getLoadstart() + skin.getLoadend()) * 1000
-					&& micronow - startpressedtime > 1000000) {
-				bga.prepare(this);
-				final long mem = Runtime.getRuntime().freeMemory();
-				System.gc();
-				final long cmem = Runtime.getRuntime().freeMemory();
-				Logger.getGlobal().info("current free memory : " + (cmem / (1024 * 1024)) + "MB , disposed : "
-						+ ((cmem - mem) / (1024 * 1024)) + "MB");
-				state = STATE_READY;
-				main.setTimerOn(TIMER_READY);
-				play(SOUND_READY);
-				Logger.getGlobal().info("STATE_READYに移行");
-			}
-			if(!main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) || !main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)){
-				main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
-				main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
-			}
-			break;
-		// practice mode
-		case STATE_PRACTICE:
-			if (main.isTimerOn(TIMER_PLAY)) {
-				resource.reloadBMSFile();
-				model = resource.getBMSModel();
-				main.getPlayerResource().getSongdata().setBMSModel(model);
-				lanerender.init(model);
-				keyinput.setKeyBeamStop(false);
-				main.setTimerOff(TIMER_PLAY);
-				main.setTimerOff(TIMER_RHYTHM);
-				main.setTimerOff(TIMER_FAILED);
-				main.setTimerOff(TIMER_FADEOUT);
-				main.setTimerOff(TIMER_ENDOFNOTE_1P);
-
-				for(int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_PM_CHARA_DANCE; i++) main.setTimerOff(i);
-			}
-			if(!main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) || !main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)){
-				main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
-				main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
-			}
-			control.setEnableControl(false);
-			control.setEnableCursor(false);
-			practice.processInput(input);
-
-			if (input.getKeyState(0) && resource.mediaLoadFinished() &&  micronow > (skin.getLoadstart() + skin.getLoadend()) * 1000
-					&& micronow - startpressedtime > 1000000) {
-				PracticeProperty property = practice.getPracticeProperty();
-				control.setEnableControl(true);
-				control.setEnableCursor(true);
-				if (property.freq != 100) {
-					BMSModelUtils.changeFrequency(model, property.freq / 100f);
-					if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
-						main.getAudioProcessor().setGlobalPitch(property.freq / 100f);
-					}
+			// 楽曲ロード
+			case STATE_PRELOAD:
+				if (resource.mediaLoadFinished() && micronow > (skin.getLoadstart() + skin.getLoadend()) * 1000
+						&& micronow - startpressedtime > 1000000) {
+					bga.prepare(this);
+					final long mem = Runtime.getRuntime().freeMemory();
+					System.gc();
+					final long cmem = Runtime.getRuntime().freeMemory();
+					Logger.getGlobal().info("current free memory : " + (cmem / (1024 * 1024)) + "MB , disposed : "
+							+ ((cmem - mem) / (1024 * 1024)) + "MB");
+					state = STATE_READY;
+					main.setTimerOn(TIMER_READY);
+					play(SOUND_READY);
+					Logger.getGlobal().info("STATE_READYに移行");
 				}
-				model.setTotal(property.total);
-				PracticeModifier pm = new PracticeModifier(property.starttime * 100 / property.freq,
-						property.endtime * 100 / property.freq);
-				pm.modify(model);
-				if (model.getMode().player == 2) {
-					if (property.doubleop == 1) {
-						new LaneShuffleModifier(Random.FLIP).modify(model);
-					}
-					PatternModifier.create(property.random2, PatternModifier.SIDE_2P, model.getMode(), config).modify(model);
+				if (!main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) || !main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)) {
+					main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
+					main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
 				}
-				PatternModifier.create(property.random, PatternModifier.SIDE_1P, model.getMode(), config).modify(model);
-
-				gauge = practice.getGauge(model);
-				model.setJudgerank(property.judgerank);
-				lanerender.init(model);
-				judge.init(model, resource);
-				notes = 0;
-				PMcharaLastnotes[0] = 0;
-				PMcharaLastnotes[1] = 0;
-				starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / property.freq;
-				playtime = (property.endtime + 1000) * 100 / property.freq + TIME_MARGIN;
-				bga.prepare(this);
-				state = STATE_READY;
-				main.setTimerOn(TIMER_READY);
-				play(SOUND_READY);
-				Logger.getGlobal().info("STATE_READYに移行");
-			}
-			break;
-		// practice終了
-		case STATE_PRACTICE_FINISHED:
-			if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
-				input.setEnable(true);
-				input.setStartTime(0);
-				main.changeState(MainStateType.MUSICSELECT);
-			}
-			break;
-			// GET READY
-		case STATE_READY:
-			if (main.getNowTime(TIMER_READY) > skin.getPlaystart()) {
-				replayConfig = lanerender.getPlayConfig().clone();
-				state = STATE_PLAY;
-				main.setMicroTimer(TIMER_PLAY, micronow - starttimeoffset * 1000);
-				main.setMicroTimer(TIMER_RHYTHM, micronow - starttimeoffset * 1000);
-
-				input.setStartTime(micronow + main.getStartMicroTime() - starttimeoffset * 1000);
-				input.setKeyLogMarginTime(resource.getMarginTime());
-				keyinput.startJudge(model, replay != null ? replay.keylog : null, resource.getMarginTime());
-				keysound.startBGPlay(model, starttimeoffset * 1000);
-				Logger.getGlobal().info("STATE_PLAYに移行");
-			}
-			break;
-		// プレイ
-		case STATE_PLAY:
-			final long deltatime = micronow - prevtime;
-			final long deltaplay = deltatime * (100 - playspeed) / 100;
-			PracticeProperty property = practice.getPracticeProperty();
-			main.setMicroTimer(TIMER_PLAY, main.getMicroTimer(TIMER_PLAY) + deltaplay);
-
-			rhythm.update(this, deltatime, lanerender.getNowBPM(), property.freq);
-
-			final long ptime = main.getNowTime(TIMER_PLAY);
-			float g = gauge.getValue();
-			for(int i = 0; i < gaugelog.length; i++) {
-				if (gaugelog[i].size <= ptime / 500) {
-					gaugelog[i].add(gauge.getValue(i));
-				}
-			}
-			main.switchTimer(TIMER_GAUGE_MAX_1P, gauge.getGauge().isMax());
-
-			if(main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) && main.getNowTime(TIMER_PM_CHARA_1P_NEUTRAL) >= skin.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) && main.getNowTime(TIMER_PM_CHARA_1P_NEUTRAL) % skin.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
-				if(PMcharaLastnotes[0] != notes && judge.getPMcharaJudge() > 0) {
-					if(judge.getPMcharaJudge() == 1 || judge.getPMcharaJudge() == 2) {
-						if(gauge.getGauge().isMax()) main.setTimerOn(TIMER_PM_CHARA_1P_FEVER);
-						else main.setTimerOn(TIMER_PM_CHARA_1P_GREAT);
-					} else if(judge.getPMcharaJudge() == 3) main.setTimerOn(TIMER_PM_CHARA_1P_GOOD);
-					else main.setTimerOn(TIMER_PM_CHARA_1P_BAD);
-					main.setTimerOff(TIMER_PM_CHARA_1P_NEUTRAL);
-				}
-			}
-			if(main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL) && main.getNowTime(TIMER_PM_CHARA_2P_NEUTRAL) >= skin.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) && main.getNowTime(TIMER_PM_CHARA_2P_NEUTRAL) % skin.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
-				if(PMcharaLastnotes[1] != notes && judge.getPMcharaJudge() > 0) {
-					if(judge.getPMcharaJudge() >= 1 && judge.getPMcharaJudge() <= 3) main.setTimerOn(TIMER_PM_CHARA_2P_BAD);
-					else main.setTimerOn(TIMER_PM_CHARA_2P_GREAT);
-					main.setTimerOff(TIMER_PM_CHARA_2P_NEUTRAL);
-				}
-			}
-			for(int i = TIMER_PM_CHARA_1P_FEVER; i <= TIMER_PM_CHARA_2P_BAD; i++) {
-				if(i != TIMER_PM_CHARA_2P_NEUTRAL && main.isTimerOn(i) && main.getNowTime(i) >= skin.getPMcharaTime(i - TIMER_PM_CHARA_1P_NEUTRAL)) {
-					if(i <= TIMER_PM_CHARA_1P_BAD) {
-						main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
-						PMcharaLastnotes[0] = notes;
-					} else {
-						main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
-						PMcharaLastnotes[1] = notes;
-					}
-					main.setTimerOff(i);
-				}
-			}
-			main.switchTimer(TIMER_PM_CHARA_DANCE, true);
-
-			// System.out.println("playing time : " + time);
-			if (playtime < ptime) {
-				state = STATE_FINISHED;
-				main.setTimerOn(TIMER_MUSIC_END);
-				for(int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_PM_CHARA_2P_BAD; i++) {
-					main.setTimerOff(i);
-				}
-				main.setTimerOff(TIMER_PM_CHARA_DANCE);
-
-				Logger.getGlobal().info("STATE_FINISHEDに移行");
-			} else if(playtime - TIME_MARGIN < ptime) {
-				main.switchTimer(TIMER_ENDOFNOTE_1P, true);
-			}
-			// stage failed判定
-			if (config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_BESTCLEAR || config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_SELECT_TO_UNDER) {
-				final int len = config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_BESTCLEAR
-						? (gauge.getType() >= GrooveGauge.CLASS ? GrooveGauge.EXHARDCLASS + 1 : GrooveGauge.HAZARD + 1)
-						: (gauge.isCourseGauge() ? Math.min(Math.max(config.getGauge(), GrooveGauge.NORMAL) + GrooveGauge.CLASS - GrooveGauge.NORMAL, GrooveGauge.EXHARDCLASS) + 1 : config.getGauge() + 1);
-				int type = gauge.isCourseGauge() ? GrooveGauge.CLASS
-						: gauge.getType() < config.getBottomShiftableGauge() ? gauge.getType() : config.getBottomShiftableGauge();
-				for (int i = type; i < len; i++) {
-					if (gauge.getGauge(i).getValue() > 0f && gauge.getGauge(i).isQualified()) {
-						type = i;
-					}
-				}
-				gauge.setType(type);
-			} else if (g == 0) {
-				switch(config.getGaugeAutoShift()) {
-				case PlayerConfig.GAUGEAUTOSHIFT_NONE:
-					// FAILED移行
-					state = STATE_FAILED;
-					main.setTimerOn(TIMER_FAILED);
-					if (resource.mediaLoadFinished()) {
-						main.getAudioProcessor().stop((Note) null);
-					}
-					play(SOUND_PLAYSTOP);
-					Logger.getGlobal().info("STATE_FAILEDに移行");
-					break;
-				case PlayerConfig.GAUGEAUTOSHIFT_CONTINUE:
-					break;
-				case PlayerConfig.GAUGEAUTOSHIFT_SURVIVAL_TO_GROOVE:
-					if(!gauge.isCourseGauge()) {
-						// GAS処理
-						gauge.setType(GrooveGauge.NORMAL);
-					}
-					break;
-				}
-			}
-			break;
-		// 閉店処理
-		case STATE_FAILED:
-			keyinput.stopJudge();
-			keysound.stopBGPlay();
-			if ((input.startPressed() ^ input.isSelectPressed()) && resource.getCourseBMSModels() == null
-					&& autoplay.mode == BMSPlayerMode.Mode.PLAY) {
-				if (!resource.isUpdateScore()) {
-					resource.getReplayData().randomoptionseed = -1;
-					Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
-				} else if (input.startPressed()) {
-					resource.getReplayData().randomoptionseed = -1;
-					Logger.getGlobal().info("オプションを変更せずリプレイ");
-				} else {
-					resource.setScoreData(createScoreData());
-					Logger.getGlobal().info("同じ譜面でリプレイ");
-				}
-				saveConfig();
-				resource.reloadBMSFile();
-				main.changeState(MainStateType.PLAY);
-			} else if (main.getNowTime(TIMER_FAILED) > skin.getClose()) {
-				main.getAudioProcessor().setGlobalPitch(1f);
-				if (resource.mediaLoadFinished()) {
-					resource.getBGAManager().stop();
-				}
-				if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
-					resource.setScoreData(createScoreData());
-				}
-				resource.setCombo(judge.getCourseCombo());
-				resource.setMaxcombo(judge.getCourseMaxcombo());
-				saveConfig();
+				break;
+			// practice mode
+			case STATE_PRACTICE:
 				if (main.isTimerOn(TIMER_PLAY)) {
-					for (long l = main.getTimer(TIMER_FAILED) - main.getTimer(TIMER_PLAY); l < playtime + 500; l += 500) {
-						for(int i = 0; i < gaugelog.length; i++) {
-							gaugelog[i].add(0f);
+					resource.reloadBMSFile();
+					model = resource.getBMSModel();
+					main.getPlayerResource().getSongdata().setBMSModel(model);
+					lanerender.init(model);
+					keyinput.setKeyBeamStop(false);
+					main.setTimerOff(TIMER_PLAY);
+					main.setTimerOff(TIMER_RHYTHM);
+					main.setTimerOff(TIMER_FAILED);
+					main.setTimerOff(TIMER_FADEOUT);
+					main.setTimerOff(TIMER_ENDOFNOTE_1P);
+
+					for (int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_PM_CHARA_DANCE; i++)
+						main.setTimerOff(i);
+				}
+				if (!main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL) || !main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)) {
+					main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
+					main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
+				}
+				control.setEnableControl(false);
+				control.setEnableCursor(false);
+				practice.processInput(input);
+
+				if (input.getKeyState(0) && resource.mediaLoadFinished()
+						&& micronow > (skin.getLoadstart() + skin.getLoadend()) * 1000
+						&& micronow - startpressedtime > 1000000) {
+					PracticeProperty property = practice.getPracticeProperty();
+					control.setEnableControl(true);
+					control.setEnableCursor(true);
+					if (property.freq != 100) {
+						BMSModelUtils.changeFrequency(model, property.freq / 100f);
+						if (main.getConfig().getAudioConfig().getFreqOption() == FrequencyType.FREQUENCY) {
+							main.getAudioProcessor().setGlobalPitch(property.freq / 100f);
 						}
 					}
+					model.setTotal(property.total);
+					PracticeModifier pm = new PracticeModifier(property.starttime * 100 / property.freq,
+							property.endtime * 100 / property.freq);
+					pm.modify(model);
+					if (model.getMode().player == 2) {
+						if (property.doubleop == 1) {
+							new LaneShuffleModifier(Random.FLIP).modify(model);
+						}
+						PatternModifier.create(property.random2, PatternModifier.SIDE_2P, model.getMode(), config)
+								.modify(model);
+					}
+					PatternModifier.create(property.random, PatternModifier.SIDE_1P, model.getMode(), config)
+							.modify(model);
+
+					gauge = practice.getGauge(model);
+					model.setJudgerank(property.judgerank);
+					lanerender.init(model);
+					judge.init(model, resource);
+					notes = 0;
+					PMcharaLastnotes[0] = 0;
+					PMcharaLastnotes[1] = 0;
+					starttimeoffset = (property.starttime > 1000 ? property.starttime - 1000 : 0) * 100 / property.freq;
+					playtime = (property.endtime + 1000) * 100 / property.freq + TIME_MARGIN;
+					bga.prepare(this);
+					state = STATE_READY;
+					main.setTimerOn(TIMER_READY);
+					play(SOUND_READY);
+					Logger.getGlobal().info("STATE_READYに移行");
 				}
-				resource.setGauge(gaugelog);
-				resource.setGrooveGauge(gauge);
-				resource.setAssist(assist);
-				input.setEnable(true);
-				input.setStartTime(0);
-				if (autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
-					state = STATE_PRACTICE;
-				} else if (resource.getScoreData() != null) {
-					main.changeState(MainStateType.RESULT);
-				} else {
+				break;
+			// practice終了
+			case STATE_PRACTICE_FINISHED:
+				if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
+					input.setEnable(true);
+					input.setStartTime(0);
 					main.changeState(MainStateType.MUSICSELECT);
 				}
-			}
-			break;
-		// 完奏処理
-		case STATE_FINISHED:
-			keyinput.stopJudge();
-			keysound.stopBGPlay();
-			if (main.getNowTime(TIMER_MUSIC_END) > skin.getFinishMargin()) {
-				main.switchTimer(TIMER_FADEOUT, true);
-			}
-			if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
-				main.getAudioProcessor().setGlobalPitch(1f);
-				resource.getBGAManager().stop();
+				break;
+			// GET READY
+			case STATE_READY:
+				if (main.getNowTime(TIMER_READY) > skin.getPlaystart()) {
+					replayConfig = lanerender.getPlayConfig().clone();
+					state = STATE_PLAY;
+					main.setMicroTimer(TIMER_PLAY, micronow - starttimeoffset * 1000);
+					main.setMicroTimer(TIMER_RHYTHM, micronow - starttimeoffset * 1000);
 
-				if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
-					resource.setScoreData(createScoreData());
+					input.setStartTime(micronow + main.getStartMicroTime() - starttimeoffset * 1000);
+					input.setKeyLogMarginTime(resource.getMarginTime());
+					keyinput.startJudge(model, replay != null ? replay.keylog : null, resource.getMarginTime());
+					keysound.startBGPlay(model, starttimeoffset * 1000);
+					Logger.getGlobal().info("STATE_PLAYに移行");
 				}
-				resource.setCombo(judge.getCourseCombo());
-				resource.setMaxcombo(judge.getCourseMaxcombo());
-				saveConfig();
-				resource.setGauge(gaugelog);
-				resource.setGrooveGauge(gauge);
-				resource.setAssist(assist);
-				input.setEnable(true);
-				input.setStartTime(0);
-				if (autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
-					state = STATE_PRACTICE;
-				} else if (resource.getScoreData() != null) {
-					Logger.getGlobal().info("\"score\": " + resource.getScoreData());
-					main.changeState(MainStateType.RESULT);
-				} else {
-					if (resource.mediaLoadFinished()) {
-						main.getAudioProcessor().stop((Note) null);
+				break;
+			// プレイ
+			case STATE_PLAY:
+				final long deltatime = micronow - prevtime;
+				final long deltaplay = deltatime * (100 - playspeed) / 100;
+				PracticeProperty property = practice.getPracticeProperty();
+				main.setMicroTimer(TIMER_PLAY, main.getMicroTimer(TIMER_PLAY) + deltaplay);
+
+				rhythm.update(this, deltatime, lanerender.getNowBPM(), property.freq);
+
+				final long ptime = main.getNowTime(TIMER_PLAY);
+				float g = gauge.getValue();
+				for (int i = 0; i < gaugelog.length; i++) {
+					if (gaugelog[i].size <= ptime / 500) {
+						gaugelog[i].add(gauge.getValue(i));
 					}
-					if (resource.getCourseBMSModels() != null && resource.nextCourse()) {
-						main.changeState(MainStateType.PLAY);
-					} else if(resource.nextSong()){
-						main.changeState(MainStateType.DECIDE);
+				}
+				main.switchTimer(TIMER_GAUGE_MAX_1P, gauge.getGauge().isMax());
+
+				if (main.isTimerOn(TIMER_PM_CHARA_1P_NEUTRAL)
+						&& main.getNowTime(TIMER_PM_CHARA_1P_NEUTRAL) >= skin
+								.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL)
+						&& main.getNowTime(TIMER_PM_CHARA_1P_NEUTRAL)
+								% skin.getPMcharaTime(TIMER_PM_CHARA_1P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
+					if (PMcharaLastnotes[0] != notes && judge.getPMcharaJudge() > 0) {
+						if (judge.getPMcharaJudge() == 1 || judge.getPMcharaJudge() == 2) {
+							if (gauge.getGauge().isMax())
+								main.setTimerOn(TIMER_PM_CHARA_1P_FEVER);
+							else
+								main.setTimerOn(TIMER_PM_CHARA_1P_GREAT);
+						} else if (judge.getPMcharaJudge() == 3)
+							main.setTimerOn(TIMER_PM_CHARA_1P_GOOD);
+						else
+							main.setTimerOn(TIMER_PM_CHARA_1P_BAD);
+						main.setTimerOff(TIMER_PM_CHARA_1P_NEUTRAL);
+					}
+				}
+				if (main.isTimerOn(TIMER_PM_CHARA_2P_NEUTRAL)
+						&& main.getNowTime(TIMER_PM_CHARA_2P_NEUTRAL) >= skin
+								.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL)
+						&& main.getNowTime(TIMER_PM_CHARA_2P_NEUTRAL)
+								% skin.getPMcharaTime(TIMER_PM_CHARA_2P_NEUTRAL - TIMER_PM_CHARA_1P_NEUTRAL) < 17) {
+					if (PMcharaLastnotes[1] != notes && judge.getPMcharaJudge() > 0) {
+						if (judge.getPMcharaJudge() >= 1 && judge.getPMcharaJudge() <= 3)
+							main.setTimerOn(TIMER_PM_CHARA_2P_BAD);
+						else
+							main.setTimerOn(TIMER_PM_CHARA_2P_GREAT);
+						main.setTimerOff(TIMER_PM_CHARA_2P_NEUTRAL);
+					}
+				}
+				for (int i = TIMER_PM_CHARA_1P_FEVER; i <= TIMER_PM_CHARA_2P_BAD; i++) {
+					if (i != TIMER_PM_CHARA_2P_NEUTRAL && main.isTimerOn(i)
+							&& main.getNowTime(i) >= skin.getPMcharaTime(i - TIMER_PM_CHARA_1P_NEUTRAL)) {
+						if (i <= TIMER_PM_CHARA_1P_BAD) {
+							main.setTimerOn(TIMER_PM_CHARA_1P_NEUTRAL);
+							PMcharaLastnotes[0] = notes;
+						} else {
+							main.setTimerOn(TIMER_PM_CHARA_2P_NEUTRAL);
+							PMcharaLastnotes[1] = notes;
+						}
+						main.setTimerOff(i);
+					}
+				}
+				main.switchTimer(TIMER_PM_CHARA_DANCE, true);
+
+				// System.out.println("playing time : " + time);
+				if (playtime < ptime) {
+					state = STATE_FINISHED;
+					main.setTimerOn(TIMER_MUSIC_END);
+					for (int i = TIMER_PM_CHARA_1P_NEUTRAL; i <= TIMER_PM_CHARA_2P_BAD; i++) {
+						main.setTimerOff(i);
+					}
+					main.setTimerOff(TIMER_PM_CHARA_DANCE);
+
+					Logger.getGlobal().info("STATE_FINISHEDに移行");
+				} else if (playtime - TIME_MARGIN < ptime) {
+					main.switchTimer(TIMER_ENDOFNOTE_1P, true);
+				}
+				// stage failed判定
+				if (config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_BESTCLEAR
+						|| config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_SELECT_TO_UNDER) {
+					final int len = config.getGaugeAutoShift() == PlayerConfig.GAUGEAUTOSHIFT_BESTCLEAR
+							? (gauge.getType() >= GrooveGauge.CLASS ? GrooveGauge.EXHARDCLASS + 1
+									: GrooveGauge.HAZARD + 1)
+							: (gauge.isCourseGauge() ? Math.min(Math.max(config.getGauge(), GrooveGauge.NORMAL)
+									+ GrooveGauge.CLASS - GrooveGauge.NORMAL, GrooveGauge.EXHARDCLASS) + 1
+									: config.getGauge() + 1);
+					int type = gauge.isCourseGauge() ? GrooveGauge.CLASS
+							: gauge.getType() < config.getBottomShiftableGauge() ? gauge.getType()
+									: config.getBottomShiftableGauge();
+					for (int i = type; i < len; i++) {
+						if (gauge.getGauge(i).getValue() > 0f && gauge.getGauge(i).isQualified()) {
+							type = i;
+						}
+					}
+					gauge.setType(type);
+				} else if (g == 0) {
+					switch (config.getGaugeAutoShift()) {
+						case PlayerConfig.GAUGEAUTOSHIFT_NONE:
+							// FAILED移行
+							state = STATE_FAILED;
+							main.setTimerOn(TIMER_FAILED);
+							if (resource.mediaLoadFinished()) {
+								main.getAudioProcessor().stop((Note) null);
+							}
+							play(SOUND_PLAYSTOP);
+							Logger.getGlobal().info("STATE_FAILEDに移行");
+							break;
+						case PlayerConfig.GAUGEAUTOSHIFT_CONTINUE:
+							break;
+						case PlayerConfig.GAUGEAUTOSHIFT_SURVIVAL_TO_GROOVE:
+							if (!gauge.isCourseGauge()) {
+								// GAS処理
+								gauge.setType(GrooveGauge.NORMAL);
+							}
+							break;
+					}
+				}
+				break;
+			// 閉店処理
+			case STATE_FAILED:
+				keyinput.stopJudge();
+				keysound.stopBGPlay();
+				if ((input.startPressed() ^ input.isSelectPressed()) && resource.getCourseBMSModels() == null
+						&& autoplay.mode == BMSPlayerMode.Mode.PLAY) {
+					if (!resource.isUpdateScore()) {
+						resource.getReplayData().randomoptionseed = -1;
+						Logger.getGlobal().info("アシストモード時は同じ譜面でリプレイできません");
+					} else if (input.startPressed()) {
+						resource.getReplayData().randomoptionseed = -1;
+						Logger.getGlobal().info("オプションを変更せずリプレイ");
+					} else {
+						resource.setScoreData(createScoreData());
+						Logger.getGlobal().info("同じ譜面でリプレイ");
+					}
+					saveConfig();
+					resource.reloadBMSFile();
+					main.changeState(MainStateType.PLAY);
+				} else if (main.getNowTime(TIMER_FAILED) > skin.getClose()) {
+					main.getAudioProcessor().setGlobalPitch(1f);
+					if (resource.mediaLoadFinished()) {
+						resource.getBGAManager().stop();
+					}
+					if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
+						resource.setScoreData(createScoreData());
+					}
+					resource.setCombo(judge.getCourseCombo());
+					resource.setMaxcombo(judge.getCourseMaxcombo());
+					saveConfig();
+					if (main.isTimerOn(TIMER_PLAY)) {
+						for (long l = main.getTimer(TIMER_FAILED) - main.getTimer(TIMER_PLAY); l < playtime
+								+ 500; l += 500) {
+							for (int i = 0; i < gaugelog.length; i++) {
+								gaugelog[i].add(0f);
+							}
+						}
+					}
+					resource.setGauge(gaugelog);
+					resource.setGrooveGauge(gauge);
+					resource.setAssist(assist);
+					input.setEnable(true);
+					input.setStartTime(0);
+					if (autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
+						state = STATE_PRACTICE;
+					} else if (resource.getScoreData() != null) {
+						main.changeState(MainStateType.RESULT);
 					} else {
 						main.changeState(MainStateType.MUSICSELECT);
 					}
 				}
-			}
-			break;
+				break;
+			// 完奏処理
+			case STATE_FINISHED:
+				keyinput.stopJudge();
+				keysound.stopBGPlay();
+				if (main.getNowTime(TIMER_MUSIC_END) > skin.getFinishMargin()) {
+					main.switchTimer(TIMER_FADEOUT, true);
+				}
+				if (main.getNowTime(TIMER_FADEOUT) > skin.getFadeout()) {
+					main.getAudioProcessor().setGlobalPitch(1f);
+					resource.getBGAManager().stop();
+
+					if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.REPLAY) {
+						resource.setScoreData(createScoreData());
+					}
+					resource.setCombo(judge.getCourseCombo());
+					resource.setMaxcombo(judge.getCourseMaxcombo());
+					saveConfig();
+					resource.setGauge(gaugelog);
+					resource.setGrooveGauge(gauge);
+					resource.setAssist(assist);
+					input.setEnable(true);
+					input.setStartTime(0);
+					if (autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
+						state = STATE_PRACTICE;
+					} else if (resource.getScoreData() != null) {
+						Logger.getGlobal().info("\"score\": " + resource.getScoreData());
+						main.changeState(MainStateType.RESULT);
+					} else {
+						if (resource.mediaLoadFinished()) {
+							main.getAudioProcessor().stop((Note) null);
+						}
+						if (resource.getCourseBMSModels() != null && resource.nextCourse()) {
+							main.changeState(MainStateType.PLAY);
+						} else if (resource.nextSong()) {
+							main.changeState(MainStateType.DECIDE);
+						} else {
+							main.changeState(MainStateType.MUSICSELECT);
+						}
+					}
+				}
+				break;
 		}
 
 		prevtime = micronow;
@@ -864,14 +942,16 @@ public class BMSPlayer extends MainState {
 		final PlayerResource resource = main.getPlayerResource();
 		final PlayerConfig config = resource.getPlayerConfig();
 		ScoreData score = judge.getScoreData();
-		if (score.getEpg() + score.getLpg() + score.getEgr() + score.getLgr() + score.getEgd() + score.getLgd() + score.getEbd() + score.getLbd() == 0) {
+		if (score.getEpg() + score.getLpg() + score.getEgr() + score.getLgr() + score.getEgd() + score.getLgd()
+				+ score.getEbd() + score.getLbd() == 0) {
 			return null;
 		}
 
 		ClearType clear = ClearType.Failed;
 		if (state != STATE_FAILED && gauge.isQualified()) {
 			if (assist > 0) {
-				if(resource.getCourseBMSModels() == null) clear = assist == 1 ? ClearType.LightAssistEasy : ClearType.AssistEasy;
+				if (resource.getCourseBMSModels() == null)
+					clear = assist == 1 ? ClearType.LightAssistEasy : ClearType.AssistEasy;
 			} else {
 				if (notes == this.judge.getCombo()) {
 					if (judge.getJudgeCount(2) == 0) {
@@ -891,8 +971,10 @@ public class BMSPlayer extends MainState {
 		score.setClear(clear.id);
 		score.setGauge(gauge.isTypeChanged() ? -1 : gauge.getType());
 		score.setOption(playinfo.randomoption + (model.getMode().player == 2
-				? (playinfo.randomoption2 * 10 + playinfo.doubleoption * 100) : 0));
-		score.setSeed((model.getMode().player == 2 ? playinfo.randomoption2seed * 65536 * 256 : 0) + playinfo.randomoptionseed);
+				? (playinfo.randomoption2 * 10 + playinfo.doubleoption * 100)
+				: 0));
+		score.setSeed((model.getMode().player == 2 ? playinfo.randomoption2seed * 65536 * 256 : 0)
+				+ playinfo.randomoptionseed);
 		score.encodeGhost(judge.getGhost());
 		// リプレイデータ保存。スコア保存されない場合はリプレイ保存しない
 		final ReplayData replay = resource.getReplayData();
@@ -901,7 +983,7 @@ public class BMSPlayer extends MainState {
 		replay.mode = config.getLnmode();
 		replay.date = Calendar.getInstance().getTimeInMillis() / 1000;
 		replay.keylog = main.getInputProcessor().getKeyInputLog();
-//		replay.pattern = playinfo.pattern;
+		// replay.pattern = playinfo.pattern;
 		replay.rand = playinfo.rand;
 		replay.gauge = config.getGauge();
 		replay.sevenToNinePattern = config.getSevenToNinePattern();
@@ -913,8 +995,9 @@ public class BMSPlayer extends MainState {
 		replay.config = replayConfig;
 
 		score.setPassnotes(notes);
-		score.setMinbp(score.getEbd() + score.getLbd() + score.getEpr() + score.getLpr() + score.getEms() + score.getLms() + resource.getSongdata().getNotes() - notes);
-		
+		score.setMinbp(score.getEbd() + score.getLbd() + score.getEpr() + score.getLpr() + score.getEms()
+				+ score.getLms() + resource.getSongdata().getNotes() - notes);
+
 		long count = 0;
 		long avgduration = 0;
 		final int lanes = model.getMode().key;
@@ -927,13 +1010,14 @@ public class BMSPlayer extends MainState {
 					long time = n.getMicroPlayTime();
 					avgduration += state >= 1 && state <= 4 ? Math.abs(time) : 1000000;
 					count++;
-//					System.out.println(time);
+					// System.out.println(time);
 				}
 			}
 		}
 		score.setTotalDuration(avgduration);
 		score.setAvgjudge(avgduration / count);
-//		System.out.println(avgduration + " / " + count + " = " + score.getAvgjudge());
+		// System.out.println(avgduration + " / " + count + " = " +
+		// score.getAvgjudge());
 
 		score.setDeviceType(main.getInputProcessor().getDeviceType());
 		return score;
@@ -958,9 +1042,9 @@ public class BMSPlayer extends MainState {
 			state = STATE_FINISHED;
 			main.setTimerOn(TIMER_FADEOUT);
 			Logger.getGlobal().info("STATE_FINISHEDに移行");
-		} else if(state == STATE_FINISHED && !main.isTimerOn(TIMER_FADEOUT)) {
+		} else if (state == STATE_FINISHED && !main.isTimerOn(TIMER_FADEOUT)) {
 			main.setTimerOn(TIMER_FADEOUT);
-		} else if(state != STATE_FINISHED) {
+		} else if (state != STATE_FINISHED) {
 			state = STATE_FAILED;
 			main.setTimerOn(TIMER_FAILED);
 			if (main.getPlayerResource().mediaLoadFinished()) {
@@ -999,7 +1083,7 @@ public class BMSPlayer extends MainState {
 		gauge.update(judge);
 		// System.out.println("Now count : " + notes + " - " + totalnotes);
 
-		//フルコン判定
+		// フルコン判定
 		main.switchTimer(TIMER_FULLCOMBO_1P, notes == main.getPlayerResource().getSongdata().getNotes()
 				&& notes == this.judge.getCombo());
 
@@ -1008,8 +1092,10 @@ public class BMSPlayer extends MainState {
 		main.switchTimer(TIMER_SCORE_A, getScoreDataProperty().qualifyRank(18));
 		main.switchTimer(TIMER_SCORE_AA, getScoreDataProperty().qualifyRank(21));
 		main.switchTimer(TIMER_SCORE_AAA, getScoreDataProperty().qualifyRank(24));
-		main.switchTimer(TIMER_SCORE_BEST, this.judge.getScoreData().getExscore() >= getScoreDataProperty().getBestScore());
-		main.switchTimer(TIMER_SCORE_TARGET, this.judge.getScoreData().getExscore() >= getScoreDataProperty().getRivalScore());
+		main.switchTimer(TIMER_SCORE_BEST,
+				this.judge.getScoreData().getExscore() >= getScoreDataProperty().getBestScore());
+		main.switchTimer(TIMER_SCORE_TARGET,
+				this.judge.getScoreData().getExscore() >= getScoreDataProperty().getRivalScore());
 	}
 
 	public GrooveGauge getGauge() {

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -65,7 +65,7 @@ public class JudgeManager {
 	 * 判定差時間(ms , +は早押しで-は遅押し)
 	 */
 	private long[] judgefast;
-	
+
 	private long[] mjudgefast;
 	/**
 	 * 処理中のLN
@@ -158,7 +158,7 @@ public class JudgeManager {
 	public void init(BMSModel model, PlayerResource resource) {
 		final Mode orgmode = resource.getOriginalMode();
 		prevmtime = 0;
-		final int  judgeregion = main.getSkin() instanceof PlaySkin ? ((PlaySkin) main.getSkin()).getJudgeregion() : 0;
+		final int judgeregion = main.getSkin() instanceof PlaySkin ? ((PlaySkin) main.getSkin()).getJudgeregion() : 0;
 		judgenow = new int[judgeregion];
 		judgecombo = new int[judgeregion];
 		judgefast = new long[judgeregion];
@@ -167,18 +167,19 @@ public class JudgeManager {
 		score.setNotes(model.getTotalNotes());
 		score.setSha256(model.getSHA256());
 		ghost = new int[model.getTotalNotes()];
-		for (int i=0; i<ghost.length; i++) {
+		for (int i = 0; i < ghost.length; i++) {
 			ghost[i] = 4;
 		}
 
 		this.lntype = model.getLntype();
 		lanes = model.getLanes();
 
-		algorithm = JudgeAlgorithm.valueOf(resource.getPlayerConfig().getPlayConfig(orgmode).getPlayconfig().getJudgetype());
+		algorithm = JudgeAlgorithm
+				.valueOf(resource.getPlayerConfig().getPlayConfig(orgmode).getPlayconfig().getJudgetype());
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(orgmode).judge;
 		score.setJudgeAlgorithm(algorithm);
 		score.setRule(BMSPlayerRule.getBMSPlayerRule(orgmode));
-		
+
 		combocond = rule.combo;
 		miss = rule.miss;
 		judgeVanish = rule.judgeVanish;
@@ -206,22 +207,72 @@ public class JudgeManager {
 
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
-		final int[] keyJudgeWindowRate = config.isCustomJudge()
-				? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}
-				: new int[]{100, 100, 100};
-		final int[] scratchJudgeWindowRate = config.isCustomJudge()
-				? new int[]{config.getScratchJudgeWindowRatePerfectGreat(), config.getScratchJudgeWindowRateGreat(), config.getScratchJudgeWindowRateGood()}
-				: new int[]{100, 100, 100};
+
+		int[][] keyJudgeWindowRate = null;
+		int[][] scratchJudgeWindowRate = null;
+		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
+			keyJudgeWindowRate = new int[][] {
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() } };
+			scratchJudgeWindowRate = new int[][] { { config.getScratchJudgeWindowRatePerfectGreat(),
+					config.getScratchJudgeWindowRateGreat(),
+					config.getScratchJudgeWindowRateGood() },
+					{ config.getScratchJudgeWindowRatePerfectGreat(),
+							config.getScratchJudgeWindowRateGreat(),
+							config.getScratchJudgeWindowRateGood() },
+					{ config.getScratchJudgeWindowRatePerfectGreat(),
+							config.getScratchJudgeWindowRateGreat(),
+							config.getScratchJudgeWindowRateGood() },
+					{ config.getScratchJudgeWindowRatePerfectGreat(),
+							config.getScratchJudgeWindowRateGreat(),
+							config.getScratchJudgeWindowRateGood() } };
+		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
+			keyJudgeWindowRate = new int[][] {
+					{ config.getKeyEasyJudgeWindowRatePerfectGreat(), config.getKeyEasyJudgeWindowRateGreat(),
+							config.getKeyEasyJudgeWindowRateGood() },
+					{ config.getKeyNormalJudgeWindowRatePerfectGreat(), config.getKeyNormalJudgeWindowRateGreat(),
+							config.getKeyNormalJudgeWindowRateGood() },
+					{ config.getKeyHardJudgeWindowRatePerfectGreat(), config.getKeyHardJudgeWindowRateGreat(),
+							config.getKeyHardJudgeWindowRateGood() },
+					{ config.getKeyVeryHardJudgeWindowRatePerfectGreat(), config.getKeyVeryHardJudgeWindowRateGreat(),
+							config.getKeyVeryHardJudgeWindowRateGood() } };
+			scratchJudgeWindowRate = new int[][] { { config.getScratchEasyJudgeWindowRatePerfectGreat(),
+					config.getScratchEasyJudgeWindowRateGreat(),
+					config.getScratchEasyJudgeWindowRateGood() },
+					{ config.getScratchNormalJudgeWindowRatePerfectGreat(),
+							config.getScratchNormalJudgeWindowRateGreat(),
+							config.getScratchNormalJudgeWindowRateGood() },
+					{ config.getScratchHardJudgeWindowRatePerfectGreat(),
+							config.getScratchHardJudgeWindowRateGreat(),
+							config.getScratchHardJudgeWindowRateGood() },
+					{ config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
+							config.getScratchVeryHardJudgeWindowRateGreat(),
+							config.getScratchVeryHardJudgeWindowRateGood() } };
+		} else {
+			keyJudgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
+					{ 100, 100, 100 } };
+			scratchJudgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
+					{ 100, 100, 100 } };
+		}
+
 		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
-			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
-				keyJudgeWindowRate[1] = keyJudgeWindowRate[2] = 0;
-				scratchJudgeWindowRate[1] = scratchJudgeWindowRate[2] = 0;
-			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
-				keyJudgeWindowRate[2] = 0;
-				scratchJudgeWindowRate[2] = 0;
+			for (int i = 0; i < keyJudgeWindowRate.length; i++) {
+				if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+					keyJudgeWindowRate[i][1] = keyJudgeWindowRate[i][2] = 0;
+					scratchJudgeWindowRate[i][1] = scratchJudgeWindowRate[i][2] = 0;
+				} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+					keyJudgeWindowRate[i][2] = 0;
+					scratchJudgeWindowRate[i][2] = 0;
+				}
 			}
 		}
-		
+
 		nmjudge = rule.getJudge(NoteType.NOTE, judgerank, keyJudgeWindowRate);
 		cnendmjudge = rule.getJudge(NoteType.LONGNOTE_END, judgerank, keyJudgeWindowRate);
 		smjudge = rule.getJudge(NoteType.SCRATCH, judgerank, scratchJudgeWindowRate);
@@ -266,7 +317,8 @@ public class JudgeManager {
 					break;
 				}
 			}
-			for (Note note = lanemodel.getNote(); note != null && note.getMicroTime() <= mtime; note = lanemodel.getNote()) {
+			for (Note note = lanemodel.getNote(); note != null
+					&& note.getMicroTime() <= mtime; note = lanemodel.getNote()) {
 				if (note.getMicroTime() <= prevmtime) {
 					continue;
 				}
@@ -286,7 +338,7 @@ public class JudgeManager {
 					final MineNote mnote = (MineNote) note;
 					// 地雷ノート判定
 					main.getGauge().addValue((float) -mnote.getDamage());
-//					System.out.println("Mine Damage : " + (float) mnote.getDamage());
+					// System.out.println("Mine Damage : " + (float) mnote.getDamage());
 					keysound.play(note, config.getAudioConfig().getKeyvolume(), 0);
 				}
 
@@ -305,7 +357,7 @@ public class JudgeManager {
 							if ((lntype == BMSModel.LNTYPE_LONGNOTE && ln.getType() == LongNote.TYPE_UNDEFINED)
 									|| ln.getType() == LongNote.TYPE_LONGNOTE) {
 								mpassingcount[lane] = 0;
-								//LN時のレーザー色変更処理
+								// LN時のレーザー色変更処理
 								this.judge[player[lane]][offset[lane]] = 8;
 							} else {
 								this.updateMicro(lane, ln, mtime, 0, 0);
@@ -371,7 +423,7 @@ public class JudgeManager {
 				}
 				mc.switchTimer(timerActive, true);
 				mc.setTimerOff(timerDamage);
-				if(passing[lane].getPair().getState() > 3) {
+				if (passing[lane].getPair().getState() > 3) {
 					keysound.setVolume(passing[lane], config.getAudioConfig().getKeyvolume());
 				}
 			} else {
@@ -416,7 +468,8 @@ public class JudgeManager {
 
 						keysound.play(processing[lane], config.getAudioConfig().getKeyvolume(), 0);
 						this.updateMicro(lane, processing[lane], mtime, j, dmtime);
-//						 System.out.println("BSS終端判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane].hashCode());
+						// System.out.println("BSS終端判定 - Time : " + ptime + " Judge : " + j + " LN : " +
+						// processing[lane].hashCode());
 						processing[lane] = null;
 						sckey[sc] = 0;
 					} else {
@@ -440,7 +493,8 @@ public class JudgeManager {
 								&& ((LongNote) judgenote).isEnd())) {
 							continue;
 						}
-						if (tnote == null || tnote.getState() != 0 || algorithm.compare(tnote, judgenote, pmtime, mjudge)) {
+						if (tnote == null || tnote.getState() != 0
+								|| algorithm.compare(tnote, judgenote, pmtime, mjudge)) {
 							if (!(miss == MissCondition.ONE && (judgenote.getState() != 0
 									|| (judgenote.getState() == 0 && judgenote.getPlayTime() != 0
 											&& (dmtime > mjudge[2][1] || dmtime < mjudge[2][0]))))) {
@@ -452,12 +506,13 @@ public class JudgeManager {
 									}
 									j = (j >= 4 ? j + 1 : j);
 								}
-								
-								if(j < 6) {
+
+								if (j < 6) {
 									if (j < 6 && (j < 4 || tnote == null
-											|| Math.abs(tnote.getMicroTime() - pmtime) > Math.abs(judgenote.getMicroTime() - pmtime))) {
+											|| Math.abs(tnote.getMicroTime() - pmtime) > Math
+													.abs(judgenote.getMicroTime() - pmtime))) {
 										tnote = judgenote;
-									}									
+									}
 								} else {
 									tnote = null;
 								}
@@ -476,7 +531,7 @@ public class JudgeManager {
 									|| ln.getType() == LongNote.TYPE_LONGNOTE)
 									&& j < 4) {
 								mpassingcount[lane] = dmtime;
-								//LN時のレーザー色変更処理
+								// LN時のレーザー色変更処理
 								this.judge[player[lane]][offset[lane]] = 8;
 							} else {
 								this.updateMicro(lane, ln, mtime, j, dmtime);
@@ -485,7 +540,8 @@ public class JudgeManager {
 								processing[lane] = ln.getPair();
 								if (sc >= 0) {
 									// BSS処理開始
-//									 System.out.println("BSS開始判定 - Time : " + ptime + " Judge : " + j + " KEY : " + key + " LN : " + ln.getPair().hashCode());
+									// System.out.println("BSS開始判定 - Time : " + ptime + " Judge : " + j + " KEY : "
+									// + key + " LN : " + ln.getPair().hashCode());
 									sckey[sc] = key;
 								}
 							}
@@ -544,7 +600,8 @@ public class JudgeManager {
 							if (j != 4 || key != sckey[sc]) {
 								release = false;
 							} else {
-//								 System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);
+								// System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : "
+								// + processing[lane]);
 								sckey[sc] = 0;
 							}
 						}
@@ -562,7 +619,8 @@ public class JudgeManager {
 							if (key != sckey[sc]) {
 								release = false;
 							} else {
-//								 System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);
+								// System.out.println("BSS途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : "
+								// + processing[lane]);
 								sckey[sc] = 0;
 							}
 						}
@@ -579,7 +637,8 @@ public class JudgeManager {
 							this.updateMicro(lane, processing[lane].getPair(), mtime, j, dmtime);
 							keysound.play(processing[lane], config.getAudioConfig().getKeyvolume(), 0);
 							processing[lane] = null;
-//							System.out.println("LN途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);	
+							// System.out.println("LN途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : "
+							// + processing[lane]);
 						}
 					}
 				}
@@ -716,23 +775,24 @@ public class JudgeManager {
 		keysound.play(judge, mfast >= 0);
 
 		final PlayerConfig player = main.main.getPlayerConfig();
-		if(player.isNotesDisplayTimingAutoAdjust()) {
+		if (player.isNotesDisplayTimingAutoAdjust()) {
 			final BMSPlayerMode autoplay = main.main.getPlayerResource().getPlayMode();
-			if(autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
+			if (autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
 				if (judge <= 2 && mfast >= -150000 && mfast <= 150000) {
-					player.setJudgetiming(player.getJudgetiming() - (int)((mfast >= 0 ? mfast + 15000 : mfast - 15000) / 30000));
-				}			
-			}			
+					player.setJudgetiming(
+							player.getJudgetiming() - (int) ((mfast >= 0 ? mfast + 15000 : mfast - 15000) / 30000));
+				}
+			}
 		}
 	}
 
 	public long[] getRecentJudges() {
 		return recentJudges;
 	}
-	
+
 	public long[] getMicroRecentJudges() {
 		return microrecentJudges;
-	}	
+	}
 
 	public int getRecentJudgesIndex() {
 		return recentJudgesIndex;
@@ -804,7 +864,7 @@ public class JudgeManager {
 	 * 指定の判定のカウント数を返す
 	 *
 	 * @param judge
-	 *            0:PG, 1:GR, 2:GD, 3:BD, 4:PR, 5:MS
+	 *              0:PG, 1:GR, 2:GD, 3:BD, 4:PR, 5:MS
 	 * @return 判定のカウント数
 	 */
 	public int getJudgeCount(int judge) {
@@ -815,9 +875,9 @@ public class JudgeManager {
 	 * 指定の判定のカウント数を返す
 	 *
 	 * @param judge
-	 *            0:PG, 1:GR, 2:GD, 3:BD, 4:PR, 5:MS
+	 *              0:PG, 1:GR, 2:GD, 3:BD, 4:PR, 5:MS
 	 * @param fast
-	 *            true:FAST, flase:SLOW
+	 *              true:FAST, flase:SLOW
 	 * @return 判定のカウント数
 	 */
 	public int getJudgeCount(int judge, boolean fast) {

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -208,68 +208,86 @@ public class JudgeManager {
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
 
-		int[][] keyJudgeWindowRate = null;
-		int[][] scratchJudgeWindowRate = null;
+		int[] keyJudgeWindowRate = null;
+		int[] scratchJudgeWindowRate = null;
 		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
-			keyJudgeWindowRate = new int[][] {
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() } };
-			scratchJudgeWindowRate = new int[][] { { config.getScratchJudgeWindowRatePerfectGreat(),
-					config.getScratchJudgeWindowRateGreat(),
-					config.getScratchJudgeWindowRateGood() },
-					{ config.getScratchJudgeWindowRatePerfectGreat(),
-							config.getScratchJudgeWindowRateGreat(),
-							config.getScratchJudgeWindowRateGood() },
-					{ config.getScratchJudgeWindowRatePerfectGreat(),
-							config.getScratchJudgeWindowRateGreat(),
-							config.getScratchJudgeWindowRateGood() },
-					{ config.getScratchJudgeWindowRatePerfectGreat(),
-							config.getScratchJudgeWindowRateGreat(),
-							config.getScratchJudgeWindowRateGood() } };
+			keyJudgeWindowRate = new int[] { config.getKeyJudgeWindowRatePerfectGreat(),
+					config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood() };
+			scratchJudgeWindowRate = new int[] { config.getScratchJudgeWindowRatePerfectGreat(),
+					config.getScratchJudgeWindowRateGreat(), config.getScratchJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			keyJudgeWindowRate = new int[][] {
-					{ config.getKeyEasyJudgeWindowRatePerfectGreat(), config.getKeyEasyJudgeWindowRateGreat(),
-							config.getKeyEasyJudgeWindowRateGood() },
-					{ config.getKeyNormalJudgeWindowRatePerfectGreat(), config.getKeyNormalJudgeWindowRateGreat(),
-							config.getKeyNormalJudgeWindowRateGood() },
-					{ config.getKeyHardJudgeWindowRatePerfectGreat(), config.getKeyHardJudgeWindowRateGreat(),
-							config.getKeyHardJudgeWindowRateGood() },
-					{ config.getKeyVeryHardJudgeWindowRatePerfectGreat(), config.getKeyVeryHardJudgeWindowRateGreat(),
-							config.getKeyVeryHardJudgeWindowRateGood() } };
-			scratchJudgeWindowRate = new int[][] { { config.getScratchEasyJudgeWindowRatePerfectGreat(),
-					config.getScratchEasyJudgeWindowRateGreat(),
-					config.getScratchEasyJudgeWindowRateGood() },
-					{ config.getScratchNormalJudgeWindowRatePerfectGreat(),
-							config.getScratchNormalJudgeWindowRateGreat(),
-							config.getScratchNormalJudgeWindowRateGood() },
-					{ config.getScratchHardJudgeWindowRatePerfectGreat(),
-							config.getScratchHardJudgeWindowRateGreat(),
-							config.getScratchHardJudgeWindowRateGood() },
-					{ config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
+			switch (model.getJudgerank()) {
+				case 0:
+					keyJudgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
+							config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
+					scratchJudgeWindowRate = new int[] { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
 							config.getScratchVeryHardJudgeWindowRateGreat(),
-							config.getScratchVeryHardJudgeWindowRateGood() } };
+							config.getScratchVeryHardJudgeWindowRateGood() };
+					break;
+				case 1:
+					keyJudgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
+							config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
+					scratchJudgeWindowRate = new int[] { config.getScratchHardJudgeWindowRatePerfectGreat(),
+							config.getScratchHardJudgeWindowRateGreat(), config.getScratchHardJudgeWindowRateGood() };
+					break;
+				case 2:
+					keyJudgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
+							config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
+					scratchJudgeWindowRate = new int[] { config.getScratchNormalJudgeWindowRatePerfectGreat(),
+							config.getScratchNormalJudgeWindowRateGreat(),
+							config.getScratchNormalJudgeWindowRateGood() };
+					break;
+				case 3:
+					keyJudgeWindowRate = new int[] { config.getKeyEasyJudgeWindowRatePerfectGreat(),
+							config.getKeyEasyJudgeWindowRateGreat(), config.getKeyEasyJudgeWindowRateGood() };
+					scratchJudgeWindowRate = new int[] { config.getScratchEasyJudgeWindowRatePerfectGreat(),
+							config.getScratchEasyJudgeWindowRateGreat(), config.getScratchEasyJudgeWindowRateGood() };
+					break;
+				default:
+					keyJudgeWindowRate = new int[] { 100, 100, 100 };
+					scratchJudgeWindowRate = new int[] { 100, 100, 100 };
+			}
+
+			/*
+			 * keyJudgeWindowRate = new int[][] {
+			 * { config.getKeyEasyJudgeWindowRatePerfectGreat(),
+			 * config.getKeyEasyJudgeWindowRateGreat(),
+			 * config.getKeyEasyJudgeWindowRateGood() },
+			 * { config.getKeyNormalJudgeWindowRatePerfectGreat(),
+			 * config.getKeyNormalJudgeWindowRateGreat(),
+			 * config.getKeyNormalJudgeWindowRateGood() },
+			 * { config.getKeyHardJudgeWindowRatePerfectGreat(),
+			 * config.getKeyHardJudgeWindowRateGreat(),
+			 * config.getKeyHardJudgeWindowRateGood() },
+			 * { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
+			 * config.getKeyVeryHardJudgeWindowRateGreat(),
+			 * config.getKeyVeryHardJudgeWindowRateGood() } };
+			 * scratchJudgeWindowRate = new int[][] { {
+			 * config.getScratchEasyJudgeWindowRatePerfectGreat(),
+			 * config.getScratchEasyJudgeWindowRateGreat(),
+			 * config.getScratchEasyJudgeWindowRateGood() },
+			 * { config.getScratchNormalJudgeWindowRatePerfectGreat(),
+			 * config.getScratchNormalJudgeWindowRateGreat(),
+			 * config.getScratchNormalJudgeWindowRateGood() },
+			 * { config.getScratchHardJudgeWindowRatePerfectGreat(),
+			 * config.getScratchHardJudgeWindowRateGreat(),
+			 * config.getScratchHardJudgeWindowRateGood() },
+			 * { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
+			 * config.getScratchVeryHardJudgeWindowRateGreat(),
+			 * config.getScratchVeryHardJudgeWindowRateGood() } };
+			 */
 		} else {
-			keyJudgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
-					{ 100, 100, 100 } };
-			scratchJudgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
-					{ 100, 100, 100 } };
+			keyJudgeWindowRate = new int[] { 100, 100, 100 };
+			scratchJudgeWindowRate = new int[] { 100, 100, 100 };
 		}
 
 		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
-			for (int i = 0; i < keyJudgeWindowRate.length; i++) {
-				if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
-					keyJudgeWindowRate[i][1] = keyJudgeWindowRate[i][2] = 0;
-					scratchJudgeWindowRate[i][1] = scratchJudgeWindowRate[i][2] = 0;
-				} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
-					keyJudgeWindowRate[i][2] = 0;
-					scratchJudgeWindowRate[i][2] = 0;
-				}
+			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+				keyJudgeWindowRate[1] = keyJudgeWindowRate[2] = 0;
+				scratchJudgeWindowRate[1] = scratchJudgeWindowRate[2] = 0;
+			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+				keyJudgeWindowRate[2] = 0;
+				scratchJudgeWindowRate[2] = 0;
 			}
 		}
 

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -207,7 +207,6 @@ public class JudgeManager {
 
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
-
 		int[] keyJudgeWindowRate = null;
 		int[] scratchJudgeWindowRate = null;
 		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
@@ -216,66 +215,32 @@ public class JudgeManager {
 			scratchJudgeWindowRate = new int[] { config.getScratchJudgeWindowRatePerfectGreat(),
 					config.getScratchJudgeWindowRateGreat(), config.getScratchJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			switch (model.getJudgerank()) {
-				case 0:
-					keyJudgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
-							config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
-					scratchJudgeWindowRate = new int[] { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
-							config.getScratchVeryHardJudgeWindowRateGreat(),
-							config.getScratchVeryHardJudgeWindowRateGood() };
-					break;
-				case 1:
-					keyJudgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
-							config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
-					scratchJudgeWindowRate = new int[] { config.getScratchHardJudgeWindowRatePerfectGreat(),
-							config.getScratchHardJudgeWindowRateGreat(), config.getScratchHardJudgeWindowRateGood() };
-					break;
-				case 2:
-					keyJudgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
-							config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
-					scratchJudgeWindowRate = new int[] { config.getScratchNormalJudgeWindowRatePerfectGreat(),
-							config.getScratchNormalJudgeWindowRateGreat(),
-							config.getScratchNormalJudgeWindowRateGood() };
-					break;
-				case 3:
-					keyJudgeWindowRate = new int[] { config.getKeyEasyJudgeWindowRatePerfectGreat(),
-							config.getKeyEasyJudgeWindowRateGreat(), config.getKeyEasyJudgeWindowRateGood() };
-					scratchJudgeWindowRate = new int[] { config.getScratchEasyJudgeWindowRatePerfectGreat(),
-							config.getScratchEasyJudgeWindowRateGreat(), config.getScratchEasyJudgeWindowRateGood() };
-					break;
-				default:
-					keyJudgeWindowRate = new int[] { 100, 100, 100 };
-					scratchJudgeWindowRate = new int[] { 100, 100, 100 };
+			if (judgerank <= 25) {
+				keyJudgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
+						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
+				scratchJudgeWindowRate = new int[] { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
+						config.getScratchVeryHardJudgeWindowRateGreat(),
+						config.getScratchVeryHardJudgeWindowRateGood() };
+			} else if (judgerank <= 50) {
+				keyJudgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
+						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
+				scratchJudgeWindowRate = new int[] { config.getScratchHardJudgeWindowRatePerfectGreat(),
+						config.getScratchHardJudgeWindowRateGreat(), config.getScratchHardJudgeWindowRateGood() };
+			} else if (judgerank <= 75) {
+				keyJudgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
+						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
+				scratchJudgeWindowRate = new int[] { config.getScratchNormalJudgeWindowRatePerfectGreat(),
+						config.getScratchNormalJudgeWindowRateGreat(),
+						config.getScratchNormalJudgeWindowRateGood() };
+			} else if (judgerank <= 100) {
+				keyJudgeWindowRate = new int[] { config.getKeyEasyJudgeWindowRatePerfectGreat(),
+						config.getKeyEasyJudgeWindowRateGreat(), config.getKeyEasyJudgeWindowRateGood() };
+				scratchJudgeWindowRate = new int[] { config.getScratchEasyJudgeWindowRatePerfectGreat(),
+						config.getScratchEasyJudgeWindowRateGreat(), config.getScratchEasyJudgeWindowRateGood() };
+			} else {
+				keyJudgeWindowRate = new int[] { 100, 100, 100 };
+				scratchJudgeWindowRate = new int[] { 100, 100, 100 };
 			}
-
-			/*
-			 * keyJudgeWindowRate = new int[][] {
-			 * { config.getKeyEasyJudgeWindowRatePerfectGreat(),
-			 * config.getKeyEasyJudgeWindowRateGreat(),
-			 * config.getKeyEasyJudgeWindowRateGood() },
-			 * { config.getKeyNormalJudgeWindowRatePerfectGreat(),
-			 * config.getKeyNormalJudgeWindowRateGreat(),
-			 * config.getKeyNormalJudgeWindowRateGood() },
-			 * { config.getKeyHardJudgeWindowRatePerfectGreat(),
-			 * config.getKeyHardJudgeWindowRateGreat(),
-			 * config.getKeyHardJudgeWindowRateGood() },
-			 * { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
-			 * config.getKeyVeryHardJudgeWindowRateGreat(),
-			 * config.getKeyVeryHardJudgeWindowRateGood() } };
-			 * scratchJudgeWindowRate = new int[][] { {
-			 * config.getScratchEasyJudgeWindowRatePerfectGreat(),
-			 * config.getScratchEasyJudgeWindowRateGreat(),
-			 * config.getScratchEasyJudgeWindowRateGood() },
-			 * { config.getScratchNormalJudgeWindowRatePerfectGreat(),
-			 * config.getScratchNormalJudgeWindowRateGreat(),
-			 * config.getScratchNormalJudgeWindowRateGood() },
-			 * { config.getScratchHardJudgeWindowRatePerfectGreat(),
-			 * config.getScratchHardJudgeWindowRateGreat(),
-			 * config.getScratchHardJudgeWindowRateGood() },
-			 * { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
-			 * config.getScratchVeryHardJudgeWindowRateGreat(),
-			 * config.getScratchVeryHardJudgeWindowRateGood() } };
-			 */
 		} else {
 			keyJudgeWindowRate = new int[] { 100, 100, 100 };
 			scratchJudgeWindowRate = new int[] { 100, 100, 100 };

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -215,7 +215,7 @@ public class JudgeManager {
 			scratchJudgeWindowRate = new int[] { config.getScratchJudgeWindowRatePerfectGreat(),
 					config.getScratchJudgeWindowRateGreat(), config.getScratchJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			if (judgerank <= 25) {
+			if (model.getMode().key != 9 && judgerank <= 25 || model.getMode().key == 9 && judgerank <= 33) {
 				keyJudgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
 						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
 				scratchJudgeWindowRate = new int[] { config.getScratchVeryHardJudgeWindowRatePerfectGreat(),
@@ -226,7 +226,7 @@ public class JudgeManager {
 						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
 				scratchJudgeWindowRate = new int[] { config.getScratchHardJudgeWindowRatePerfectGreat(),
 						config.getScratchHardJudgeWindowRateGreat(), config.getScratchHardJudgeWindowRateGood() };
-			} else if (judgerank <= 75) {
+			} else if (model.getMode().key != 9 && judgerank <= 75 || model.getMode().key == 9 && judgerank <= 70) {
 				keyJudgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
 						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
 				scratchJudgeWindowRate = new int[] { config.getScratchNormalJudgeWindowRatePerfectGreat(),

--- a/src/bms/player/beatoraja/play/JudgeProperty.java
+++ b/src/bms/player/beatoraja/play/JudgeProperty.java
@@ -7,43 +7,48 @@ package bms.player.beatoraja.play;
  */
 public enum JudgeProperty {
 
-    FIVEKEYS(new long[][]{ {-20000, 20000}, {-50000, 50000}, {-100000, 100000}, {-150000, 150000}, {-150000, 500000} },
-            new long[][]{ {-30000, 30000}, {-60000, 60000}, {-110000, 110000}, {-160000, 160000}, {-160000, 500000}},
-            new long[][]{ {-120000, 120000}, {-150000, 150000}, {-200000, 200000}, {-250000, 250000}},
-            new long[][]{ {-130000, 130000}, {-160000, 160000}, {-110000, 110000}, {-260000, 260000}},
-            new boolean[]{true, true, true, false, false, false },
+    FIVEKEYS(
+            new long[][] { { -20000, 20000 }, { -50000, 50000 }, { -100000, 100000 }, { -150000, 150000 },
+                    { -150000, 500000 } },
+            new long[][] { { -30000, 30000 }, { -60000, 60000 }, { -110000, 110000 }, { -160000, 160000 },
+                    { -160000, 500000 } },
+            new long[][] { { -120000, 120000 }, { -150000, 150000 }, { -200000, 200000 }, { -250000, 250000 } },
+            new long[][] { { -130000, 130000 }, { -160000, 160000 }, { -110000, 110000 }, { -260000, 260000 } },
+            new boolean[] { true, true, true, false, false, false },
             MissCondition.ALWAYS,
-            new boolean[]{true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL
-            ),
-    SEVENKEYS(new long[][]{ {-20000, 20000}, {-60000, 60000}, {-150000, 150000}, {-280000, 220000}, {-150000, 500000} },
-            new long[][]{ {-30000, 30000}, {-70000, 70000}, {-160000, 160000}, {-290000, 230000}, {-160000, 500000}},
-            new long[][]{ {-120000, 120000}, {-160000, 160000}, {-200000, 200000}, {-280000, 220000}},
-            new long[][]{ {-130000, 130000}, {-170000, 170000}, {-210000, 210000}, {-290000, 230000}},
-            new boolean[]{true, true, true, false, false, true },
+            new boolean[] { true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL),
+    SEVENKEYS(
+            new long[][] { { -20000, 20000 }, { -60000, 60000 }, { -150000, 150000 }, { -280000, 220000 },
+                    { -150000, 500000 } },
+            new long[][] { { -30000, 30000 }, { -70000, 70000 }, { -160000, 160000 }, { -290000, 230000 },
+                    { -160000, 500000 } },
+            new long[][] { { -120000, 120000 }, { -160000, 160000 }, { -200000, 200000 }, { -280000, 220000 } },
+            new long[][] { { -130000, 130000 }, { -170000, 170000 }, { -210000, 210000 }, { -290000, 230000 } },
+            new boolean[] { true, true, true, false, false, true },
             MissCondition.ALWAYS,
-            new boolean[]{true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL
-            ),
-    PMS(new long[][]{ {-20000, 20000}, {-50000, 50000}, {-117000, 117000}, {-183000, 183000}, {-175000, 500000} },
-            new long[][]{},
-            new long[][]{ {-120000, 120000}, {-150000, 150000}, {-217000, 217000}, {-283000, 283000}},
-            new long[][]{},
-            new boolean[]{true, true, true, false, false, false },
+            new boolean[] { true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL),
+    PMS(new long[][] { { -20000, 20000 }, { -50000, 50000 }, { -117000, 117000 }, { -183000, 183000 },
+            { -175000, 500000 } },
+            new long[][] {},
+            new long[][] { { -120000, 120000 }, { -150000, 150000 }, { -217000, 217000 }, { -283000, 283000 } },
+            new long[][] {},
+            new boolean[] { true, true, true, false, false, false },
             MissCondition.ONE,
-            new boolean[]{true, true, true, false, true, false },
-            JudgeWindowRule.PMS
-            ),
-	KEYBOARD(new long[][]{ {-30000, 30000}, {-90000, 90000}, {-200000, 200000}, {-320000, 240000}, {-200000, 650000} },
-			new long[][]{},
-			new long[][]{ {-160000, 25000}, {-200000, 75000}, {-260000, 140000}, {-320000, 240000}},
-			new long[][]{},
-            new boolean[]{true, true, true, false, false, true },
+            new boolean[] { true, true, true, false, true, false },
+            JudgeWindowRule.PMS),
+    KEYBOARD(
+            new long[][] { { -30000, 30000 }, { -90000, 90000 }, { -200000, 200000 }, { -320000, 240000 },
+                    { -200000, 650000 } },
+            new long[][] {},
+            new long[][] { { -160000, 25000 }, { -200000, 75000 }, { -260000, 140000 }, { -320000, 240000 } },
+            new long[][] {},
+            new boolean[] { true, true, true, false, false, true },
             MissCondition.ALWAYS,
-            new boolean[]{true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL
-			),
-	;
+            new boolean[] { true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL),
+            ;
 
     /**
      * 通常ノートの格判定幅。PG, GR, GD, BD, MSの順で{LATE下限, EARLY上限}のセットで表現する。
@@ -73,10 +78,11 @@ public enum JudgeProperty {
      * 各判定毎のノートの判定を消失するかどうか。PG, GR, GD, BD, PR, MSの順
      */
     public final boolean[] judgeVanish;
-    
+
     public final JudgeWindowRule windowrule;
 
-    private JudgeProperty(long[][] note, long[][] scratch, long[][] longnote, long[][] longscratch, boolean[] combo, MissCondition miss, boolean[] judgeVanish, JudgeWindowRule windowrule) {
+    private JudgeProperty(long[][] note, long[][] scratch, long[][] longnote, long[][] longscratch, boolean[] combo,
+            MissCondition miss, boolean[] judgeVanish, JudgeWindowRule windowrule) {
         this.note = note;
         this.scratch = scratch;
         this.longnote = longnote;
@@ -87,132 +93,133 @@ public enum JudgeProperty {
         this.windowrule = windowrule;
     }
 
-    public int[][] getNoteJudge(int judgerank, int[] judgeWindowRate) {
-    	return convertMilli(windowrule.create(note, judgerank, judgeWindowRate));
+    public int[][] getNoteJudge(int judgerank, int[][] judgeWindowRate) {
+        return convertMilli(windowrule.create(note, judgerank, judgeWindowRate));
     }
 
-    public int[][] getLongNoteEndJudge(int judgerank, int[] judgeWindowRate) {
-    	return convertMilli(windowrule.create(longnote, judgerank, judgeWindowRate));
+    public int[][] getLongNoteEndJudge(int judgerank, int[][] judgeWindowRate) {
+        return convertMilli(windowrule.create(longnote, judgerank, judgeWindowRate));
     }
 
-    public int[][] getScratchJudge(int judgerank, int[] judgeWindowRate) {
-    	return convertMilli(windowrule.create(scratch, judgerank, judgeWindowRate));
+    public int[][] getScratchJudge(int judgerank, int[][] judgeWindowRate) {
+        return convertMilli(windowrule.create(scratch, judgerank, judgeWindowRate));
     }
 
-    public int[][] getLongScratchEndJudge(int judgerank, int[] judgeWindowRate) {
-    	return convertMilli(windowrule.create(longscratch, judgerank, judgeWindowRate));
+    public int[][] getLongScratchEndJudge(int judgerank, int[][] judgeWindowRate) {
+        return convertMilli(windowrule.create(longscratch, judgerank, judgeWindowRate));
     }
-    
+
     private int[][] convertMilli(long[][] judge) {
-    	int[][] mjudge = new int[judge.length][];
-    	for(int i = 0;i < mjudge.length;i++) {
-    		mjudge[i] = new int[judge[i].length];
-    		for(int j = 0;j < mjudge[i].length;j++) {
-        		mjudge[i][j] = (int) (judge[i][j] / 1000);    			
-    		}
-    	}
-    	return mjudge;
+        int[][] mjudge = new int[judge.length][];
+        for (int i = 0; i < mjudge.length; i++) {
+            mjudge[i] = new int[judge[i].length];
+            for (int j = 0; j < mjudge[i].length; j++) {
+                mjudge[i][j] = (int) (judge[i][j] / 1000);
+            }
+        }
+        return mjudge;
     }
-    
-    public long[][] getJudge(NoteType notetype, int judgerank, int[] judgeWindowRate) {
-    	switch(notetype) {
-    	case NOTE:
-        	return windowrule.create(note, judgerank, judgeWindowRate);
-    	case LONGNOTE_END:
-        	return windowrule.create(longnote, judgerank, judgeWindowRate);
-    	case SCRATCH:
-        	return windowrule.create(scratch, judgerank, judgeWindowRate);
-    	case LONGSCRATCH_END:
-        	return windowrule.create(longscratch, judgerank, judgeWindowRate);
-    	default:
-        	return windowrule.create(note, judgerank, judgeWindowRate);
-    	}
+
+    public long[][] getJudge(NoteType notetype, int judgerank, int[][] judgeWindowRate) {
+        switch (notetype) {
+            case NOTE:
+                return windowrule.create(note, judgerank, judgeWindowRate);
+            case LONGNOTE_END:
+                return windowrule.create(longnote, judgerank, judgeWindowRate);
+            case SCRATCH:
+                return windowrule.create(scratch, judgerank, judgeWindowRate);
+            case LONGSCRATCH_END:
+                return windowrule.create(longscratch, judgerank, judgeWindowRate);
+            default:
+                return windowrule.create(note, judgerank, judgeWindowRate);
+        }
     }
-    
+
     public enum MissCondition {
-    	ONE, ALWAYS
+        ONE, ALWAYS
     }
-    
+
     public enum NoteType {
-    	NOTE, LONGNOTE_END, SCRATCH, LONGSCRATCH_END
+        NOTE, LONGNOTE_END, SCRATCH, LONGSCRATCH_END
     }
-    
+
     public enum JudgeWindowRule {
-    	NORMAL (new int[]{25, 50, 75, 100, 125}){
+        NORMAL(new int[] { 25, 50, 75, 100, 125 }) {
 
-			@Override
-			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
-				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, false);
-			}
-    		
-    	},
-    	PMS (new int[]{33, 50, 70, 100, 133}) {
+            @Override
+            public long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate) {
+                return JudgeWindowRule.create(org, judgerank, judgeWindowRate, false);
+            }
 
-			@Override
-			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
-				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, true);
-			}
-    		
-    	};
-    	
-    	/**
-    	 * JUDGERANKの倍率(VERYHARD, HARD, NORMAL, EASY, VERYEASY)
-    	 */
-    	public final int[] judgerank;
-    	
-        private static long[][] create(long[][] org, int judgerank, int[] judgeWindowRate, boolean pms) {
-    		final long[][] judge = new long[org.length][2];
-    		final boolean[] fix = pms ? new boolean[]{true, false, false, true, true} : new boolean[]{false, false, false, false, true};
-    		for (int i = 0; i < judge.length; i++) {
-    			for(int j = 0;j < 2;j++) {
-					judge[i][j] = fix[i] ? org[i][j] : org[i][j] * judgerank / 100;
-    			}
-    		}
+        },
+        PMS(new int[] { 33, 50, 70, 100, 133 }) {
 
-    		int fixmin = -1;
-    		for (int i = 0; i < Math.min(org.length, 4); i++) {
-    			if(fix[i]) {
-    				fixmin = i;
-    				continue;
-    			}
-        		int fixmax = -1;
-    			for(int j = i + 1;j < 4;j++) {
-        			if(fix[j]) {
-        				fixmax = j;
-        				break;
-        			}
-    			}
-        		
-    			for(int j = 0;j < 2;j++) {
-					if(fixmin != -1 && Math.abs(judge[i][j]) < Math.abs(judge[fixmin][j])) {
-						judge[i][j] = judge[fixmin][j];
-					}
-					if(fixmax != -1 && Math.abs(judge[i][j]) > Math.abs(judge[fixmax][j])) {
-						judge[i][j] = judge[fixmax][j];
-					}
-    			}
-    		}
+            @Override
+            public long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate) {
+                return JudgeWindowRule.create(org, judgerank, judgeWindowRate, true);
+            }
 
-    		// judgeWindowRateによる補正
-    		for (int i = 0; i < Math.min(org.length, 3); i++) {
-    			for(int j = 0;j < 2;j++) {
-					judge[i][j] = judge[i][j]*judgeWindowRate[i] / 100;
-					if(Math.abs(judge[i][j]) > Math.abs(judge[3][j])) {
-						judge[i][j] = judge[3][j];
-					}
-					if(i > 0 && Math.abs(judge[i][j]) < Math.abs(judge[i - 1][j])) {
-						judge[i][j] = judge[i - 1][j];
-					}
-    			}
-    		}
-    		
-    		return judge;
+        };
+
+        /**
+         * JUDGERANKの倍率(VERYHARD, HARD, NORMAL, EASY, VERYEASY)
+         */
+        public final int[] judgerank;
+
+        private static long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate, boolean pms) {
+            final long[][] judge = new long[org.length][2];
+            final boolean[] fix = pms ? new boolean[] { true, false, false, true, true }
+                    : new boolean[] { false, false, false, false, true };
+            for (int i = 0; i < judge.length; i++) {
+                for (int j = 0; j < 2; j++) {
+                    judge[i][j] = fix[i] ? org[i][j] : org[i][j] * judgerank / 100;
+                }
+            }
+
+            int fixmin = -1;
+            for (int i = 0; i < Math.min(org.length, 4); i++) {
+                if (fix[i]) {
+                    fixmin = i;
+                    continue;
+                }
+                int fixmax = -1;
+                for (int j = i + 1; j < 4; j++) {
+                    if (fix[j]) {
+                        fixmax = j;
+                        break;
+                    }
+                }
+
+                for (int j = 0; j < 2; j++) {
+                    if (fixmin != -1 && Math.abs(judge[i][j]) < Math.abs(judge[fixmin][j])) {
+                        judge[i][j] = judge[fixmin][j];
+                    }
+                    if (fixmax != -1 && Math.abs(judge[i][j]) > Math.abs(judge[fixmax][j])) {
+                        judge[i][j] = judge[fixmax][j];
+                    }
+                }
+            }
+
+            // judgeWindowRateによる補正
+            for (int i = 0; i < Math.min(org.length, 3); i++) {
+                for (int j = 0; j < 2; j++) {
+                    judge[i][j] = judge[i][j] * judgeWindowRate[judgerank][i] / 100;
+                    if (Math.abs(judge[i][j]) > Math.abs(judge[3][j])) {
+                        judge[i][j] = judge[3][j];
+                    }
+                    if (i > 0 && Math.abs(judge[i][j]) < Math.abs(judge[i - 1][j])) {
+                        judge[i][j] = judge[i - 1][j];
+                    }
+                }
+            }
+
+            return judge;
         }
-        
+
         private JudgeWindowRule(int[] judgerank) {
-        	this.judgerank = judgerank;
+            this.judgerank = judgerank;
         }
-        
-    	public abstract long[][] create(long[][] org, int judgerank, int[] judgeWindowRate);
+
+        public abstract long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate);
     }
 }

--- a/src/bms/player/beatoraja/play/JudgeProperty.java
+++ b/src/bms/player/beatoraja/play/JudgeProperty.java
@@ -7,48 +7,43 @@ package bms.player.beatoraja.play;
  */
 public enum JudgeProperty {
 
-    FIVEKEYS(
-            new long[][] { { -20000, 20000 }, { -50000, 50000 }, { -100000, 100000 }, { -150000, 150000 },
-                    { -150000, 500000 } },
-            new long[][] { { -30000, 30000 }, { -60000, 60000 }, { -110000, 110000 }, { -160000, 160000 },
-                    { -160000, 500000 } },
-            new long[][] { { -120000, 120000 }, { -150000, 150000 }, { -200000, 200000 }, { -250000, 250000 } },
-            new long[][] { { -130000, 130000 }, { -160000, 160000 }, { -110000, 110000 }, { -260000, 260000 } },
-            new boolean[] { true, true, true, false, false, false },
+    FIVEKEYS(new long[][]{ {-20000, 20000}, {-50000, 50000}, {-100000, 100000}, {-150000, 150000}, {-150000, 500000} },
+            new long[][]{ {-30000, 30000}, {-60000, 60000}, {-110000, 110000}, {-160000, 160000}, {-160000, 500000}},
+            new long[][]{ {-120000, 120000}, {-150000, 150000}, {-200000, 200000}, {-250000, 250000}},
+            new long[][]{ {-130000, 130000}, {-160000, 160000}, {-110000, 110000}, {-260000, 260000}},
+            new boolean[]{true, true, true, false, false, false },
             MissCondition.ALWAYS,
-            new boolean[] { true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL),
-    SEVENKEYS(
-            new long[][] { { -20000, 20000 }, { -60000, 60000 }, { -150000, 150000 }, { -280000, 220000 },
-                    { -150000, 500000 } },
-            new long[][] { { -30000, 30000 }, { -70000, 70000 }, { -160000, 160000 }, { -290000, 230000 },
-                    { -160000, 500000 } },
-            new long[][] { { -120000, 120000 }, { -160000, 160000 }, { -200000, 200000 }, { -280000, 220000 } },
-            new long[][] { { -130000, 130000 }, { -170000, 170000 }, { -210000, 210000 }, { -290000, 230000 } },
-            new boolean[] { true, true, true, false, false, true },
+            new boolean[]{true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL
+            ),
+    SEVENKEYS(new long[][]{ {-20000, 20000}, {-60000, 60000}, {-150000, 150000}, {-280000, 220000}, {-150000, 500000} },
+            new long[][]{ {-30000, 30000}, {-70000, 70000}, {-160000, 160000}, {-290000, 230000}, {-160000, 500000}},
+            new long[][]{ {-120000, 120000}, {-160000, 160000}, {-200000, 200000}, {-280000, 220000}},
+            new long[][]{ {-130000, 130000}, {-170000, 170000}, {-210000, 210000}, {-290000, 230000}},
+            new boolean[]{true, true, true, false, false, true },
             MissCondition.ALWAYS,
-            new boolean[] { true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL),
-    PMS(new long[][] { { -20000, 20000 }, { -50000, 50000 }, { -117000, 117000 }, { -183000, 183000 },
-            { -175000, 500000 } },
-            new long[][] {},
-            new long[][] { { -120000, 120000 }, { -150000, 150000 }, { -217000, 217000 }, { -283000, 283000 } },
-            new long[][] {},
-            new boolean[] { true, true, true, false, false, false },
+            new boolean[]{true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL
+            ),
+    PMS(new long[][]{ {-20000, 20000}, {-50000, 50000}, {-117000, 117000}, {-183000, 183000}, {-175000, 500000} },
+            new long[][]{},
+            new long[][]{ {-120000, 120000}, {-150000, 150000}, {-217000, 217000}, {-283000, 283000}},
+            new long[][]{},
+            new boolean[]{true, true, true, false, false, false },
             MissCondition.ONE,
-            new boolean[] { true, true, true, false, true, false },
-            JudgeWindowRule.PMS),
-    KEYBOARD(
-            new long[][] { { -30000, 30000 }, { -90000, 90000 }, { -200000, 200000 }, { -320000, 240000 },
-                    { -200000, 650000 } },
-            new long[][] {},
-            new long[][] { { -160000, 25000 }, { -200000, 75000 }, { -260000, 140000 }, { -320000, 240000 } },
-            new long[][] {},
-            new boolean[] { true, true, true, false, false, true },
+            new boolean[]{true, true, true, false, true, false },
+            JudgeWindowRule.PMS
+            ),
+	KEYBOARD(new long[][]{ {-30000, 30000}, {-90000, 90000}, {-200000, 200000}, {-320000, 240000}, {-200000, 650000} },
+			new long[][]{},
+			new long[][]{ {-160000, 25000}, {-200000, 75000}, {-260000, 140000}, {-320000, 240000}},
+			new long[][]{},
+            new boolean[]{true, true, true, false, false, true },
             MissCondition.ALWAYS,
-            new boolean[] { true, true, true, true, true, false },
-            JudgeWindowRule.NORMAL),
-            ;
+            new boolean[]{true, true, true, true, true, false },
+            JudgeWindowRule.NORMAL
+			),
+	;
 
     /**
      * 通常ノートの格判定幅。PG, GR, GD, BD, MSの順で{LATE下限, EARLY上限}のセットで表現する。
@@ -78,11 +73,10 @@ public enum JudgeProperty {
      * 各判定毎のノートの判定を消失するかどうか。PG, GR, GD, BD, PR, MSの順
      */
     public final boolean[] judgeVanish;
-
+    
     public final JudgeWindowRule windowrule;
 
-    private JudgeProperty(long[][] note, long[][] scratch, long[][] longnote, long[][] longscratch, boolean[] combo,
-            MissCondition miss, boolean[] judgeVanish, JudgeWindowRule windowrule) {
+    private JudgeProperty(long[][] note, long[][] scratch, long[][] longnote, long[][] longscratch, boolean[] combo, MissCondition miss, boolean[] judgeVanish, JudgeWindowRule windowrule) {
         this.note = note;
         this.scratch = scratch;
         this.longnote = longnote;
@@ -93,133 +87,132 @@ public enum JudgeProperty {
         this.windowrule = windowrule;
     }
 
-    public int[][] getNoteJudge(int judgerank, int[][] judgeWindowRate) {
-        return convertMilli(windowrule.create(note, judgerank, judgeWindowRate));
+    public int[][] getNoteJudge(int judgerank, int[] judgeWindowRate) {
+    	return convertMilli(windowrule.create(note, judgerank, judgeWindowRate));
     }
 
-    public int[][] getLongNoteEndJudge(int judgerank, int[][] judgeWindowRate) {
-        return convertMilli(windowrule.create(longnote, judgerank, judgeWindowRate));
+    public int[][] getLongNoteEndJudge(int judgerank, int[] judgeWindowRate) {
+    	return convertMilli(windowrule.create(longnote, judgerank, judgeWindowRate));
     }
 
-    public int[][] getScratchJudge(int judgerank, int[][] judgeWindowRate) {
-        return convertMilli(windowrule.create(scratch, judgerank, judgeWindowRate));
+    public int[][] getScratchJudge(int judgerank, int[] judgeWindowRate) {
+    	return convertMilli(windowrule.create(scratch, judgerank, judgeWindowRate));
     }
 
-    public int[][] getLongScratchEndJudge(int judgerank, int[][] judgeWindowRate) {
-        return convertMilli(windowrule.create(longscratch, judgerank, judgeWindowRate));
+    public int[][] getLongScratchEndJudge(int judgerank, int[] judgeWindowRate) {
+    	return convertMilli(windowrule.create(longscratch, judgerank, judgeWindowRate));
     }
-
+    
     private int[][] convertMilli(long[][] judge) {
-        int[][] mjudge = new int[judge.length][];
-        for (int i = 0; i < mjudge.length; i++) {
-            mjudge[i] = new int[judge[i].length];
-            for (int j = 0; j < mjudge[i].length; j++) {
-                mjudge[i][j] = (int) (judge[i][j] / 1000);
-            }
-        }
-        return mjudge;
+    	int[][] mjudge = new int[judge.length][];
+    	for(int i = 0;i < mjudge.length;i++) {
+    		mjudge[i] = new int[judge[i].length];
+    		for(int j = 0;j < mjudge[i].length;j++) {
+        		mjudge[i][j] = (int) (judge[i][j] / 1000);    			
+    		}
+    	}
+    	return mjudge;
     }
-
-    public long[][] getJudge(NoteType notetype, int judgerank, int[][] judgeWindowRate) {
-        switch (notetype) {
-            case NOTE:
-                return windowrule.create(note, judgerank, judgeWindowRate);
-            case LONGNOTE_END:
-                return windowrule.create(longnote, judgerank, judgeWindowRate);
-            case SCRATCH:
-                return windowrule.create(scratch, judgerank, judgeWindowRate);
-            case LONGSCRATCH_END:
-                return windowrule.create(longscratch, judgerank, judgeWindowRate);
-            default:
-                return windowrule.create(note, judgerank, judgeWindowRate);
-        }
+    
+    public long[][] getJudge(NoteType notetype, int judgerank, int[] judgeWindowRate) {
+    	switch(notetype) {
+    	case NOTE:
+        	return windowrule.create(note, judgerank, judgeWindowRate);
+    	case LONGNOTE_END:
+        	return windowrule.create(longnote, judgerank, judgeWindowRate);
+    	case SCRATCH:
+        	return windowrule.create(scratch, judgerank, judgeWindowRate);
+    	case LONGSCRATCH_END:
+        	return windowrule.create(longscratch, judgerank, judgeWindowRate);
+    	default:
+        	return windowrule.create(note, judgerank, judgeWindowRate);
+    	}
     }
-
+    
     public enum MissCondition {
-        ONE, ALWAYS
+    	ONE, ALWAYS
     }
-
+    
     public enum NoteType {
-        NOTE, LONGNOTE_END, SCRATCH, LONGSCRATCH_END
+    	NOTE, LONGNOTE_END, SCRATCH, LONGSCRATCH_END
     }
-
+    
     public enum JudgeWindowRule {
-        NORMAL(new int[] { 25, 50, 75, 100, 125 }) {
+    	NORMAL (new int[]{25, 50, 75, 100, 125}){
 
-            @Override
-            public long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate) {
-                return JudgeWindowRule.create(org, judgerank, judgeWindowRate, false);
-            }
+			@Override
+			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
+				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, false);
+			}
+    		
+    	},
+    	PMS (new int[]{33, 50, 70, 100, 133}) {
 
-        },
-        PMS(new int[] { 33, 50, 70, 100, 133 }) {
+			@Override
+			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
+				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, true);
+			}
+    		
+    	};
+    	
+    	/**
+    	 * JUDGERANKの倍率(VERYHARD, HARD, NORMAL, EASY, VERYEASY)
+    	 */
+    	public final int[] judgerank;
+    	
+        private static long[][] create(long[][] org, int judgerank, int[] judgeWindowRate, boolean pms) {
+    		final long[][] judge = new long[org.length][2];
+    		final boolean[] fix = pms ? new boolean[]{true, false, false, true, true} : new boolean[]{false, false, false, false, true};
+    		for (int i = 0; i < judge.length; i++) {
+    			for(int j = 0;j < 2;j++) {
+					judge[i][j] = fix[i] ? org[i][j] : org[i][j] * judgerank / 100;
+    			}
+    		}
 
-            @Override
-            public long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate) {
-                return JudgeWindowRule.create(org, judgerank, judgeWindowRate, true);
-            }
+    		int fixmin = -1;
+    		for (int i = 0; i < Math.min(org.length, 4); i++) {
+    			if(fix[i]) {
+    				fixmin = i;
+    				continue;
+    			}
+        		int fixmax = -1;
+    			for(int j = i + 1;j < 4;j++) {
+        			if(fix[j]) {
+        				fixmax = j;
+        				break;
+        			}
+    			}
+        		
+    			for(int j = 0;j < 2;j++) {
+					if(fixmin != -1 && Math.abs(judge[i][j]) < Math.abs(judge[fixmin][j])) {
+						judge[i][j] = judge[fixmin][j];
+					}
+					if(fixmax != -1 && Math.abs(judge[i][j]) > Math.abs(judge[fixmax][j])) {
+						judge[i][j] = judge[fixmax][j];
+					}
+    			}
+    		}
 
-        };
-
-        /**
-         * JUDGERANKの倍率(VERYHARD, HARD, NORMAL, EASY, VERYEASY)
-         */
-        public final int[] judgerank;
-
-        private static long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate, boolean pms) {
-            final long[][] judge = new long[org.length][2];
-            final boolean[] fix = pms ? new boolean[] { true, false, false, true, true }
-                    : new boolean[] { false, false, false, false, true };
-            for (int i = 0; i < judge.length; i++) {
-                for (int j = 0; j < 2; j++) {
-                    judge[i][j] = fix[i] ? org[i][j] : org[i][j] * judgerank / 100;
-                }
-            }
-
-            int fixmin = -1;
-            for (int i = 0; i < Math.min(org.length, 4); i++) {
-                if (fix[i]) {
-                    fixmin = i;
-                    continue;
-                }
-                int fixmax = -1;
-                for (int j = i + 1; j < 4; j++) {
-                    if (fix[j]) {
-                        fixmax = j;
-                        break;
-                    }
-                }
-
-                for (int j = 0; j < 2; j++) {
-                    if (fixmin != -1 && Math.abs(judge[i][j]) < Math.abs(judge[fixmin][j])) {
-                        judge[i][j] = judge[fixmin][j];
-                    }
-                    if (fixmax != -1 && Math.abs(judge[i][j]) > Math.abs(judge[fixmax][j])) {
-                        judge[i][j] = judge[fixmax][j];
-                    }
-                }
-            }
-
-            // judgeWindowRateによる補正
-            for (int i = 0; i < Math.min(org.length, 3); i++) {
-                for (int j = 0; j < 2; j++) {
-                    judge[i][j] = judge[i][j] * judgeWindowRate[judgerank][i] / 100;
-                    if (Math.abs(judge[i][j]) > Math.abs(judge[3][j])) {
-                        judge[i][j] = judge[3][j];
-                    }
-                    if (i > 0 && Math.abs(judge[i][j]) < Math.abs(judge[i - 1][j])) {
-                        judge[i][j] = judge[i - 1][j];
-                    }
-                }
-            }
-
-            return judge;
+    		// judgeWindowRateによる補正
+    		for (int i = 0; i < Math.min(org.length, 3); i++) {
+    			for(int j = 0;j < 2;j++) {
+					judge[i][j] = judge[i][j]*judgeWindowRate[i] / 100;
+					if(Math.abs(judge[i][j]) > Math.abs(judge[3][j])) {
+						judge[i][j] = judge[3][j];
+					}
+					if(i > 0 && Math.abs(judge[i][j]) < Math.abs(judge[i - 1][j])) {
+						judge[i][j] = judge[i - 1][j];
+					}
+    			}
+    		}
+    		
+    		return judge;
         }
-
+        
         private JudgeWindowRule(int[] judgerank) {
-            this.judgerank = judgerank;
+        	this.judgerank = judgerank;
         }
-
-        public abstract long[][] create(long[][] org, int judgerank, int[][] judgeWindowRate);
+        
+    	public abstract long[][] create(long[][] org, int judgerank, int[] judgeWindowRate);
     }
 }

--- a/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
@@ -54,9 +54,9 @@ public class SkinHitErrorVisualizer extends SkinObject {
 	private float alpha;
 
 	public SkinHitErrorVisualizer(int width, int judgeWidthMillis, int lineWidth, int colorMode,
-								  int hiterrorMode, int emaMode, String lineColor, String centerColor,
-								  String PGColor, String GRColor, String GDColor, String BDColor, String PRColor,
-								  String emaColor, float alpha, int windowLength, int transparent, int drawDecay) {
+			int hiterrorMode, int emaMode, String lineColor, String centerColor,
+			String PGColor, String GRColor, String GDColor, String BDColor, String PRColor,
+			String emaColor, float alpha, int windowLength, int transparent, int drawDecay) {
 
 		this.lineWidth = MathUtils.clamp(lineWidth, 1, 4);
 		this.width = width;
@@ -77,30 +77,30 @@ public class SkinHitErrorVisualizer extends SkinObject {
 				transparent == 1 ? Color.CLEAR : Color.valueOf(PRColor)
 		};
 		this.hiterrorMode = hiterrorMode == 1 ? true : false;
-		this.colorMode    = colorMode == 1 ? true : false;
-		this.drawDecay    = drawDecay == 1 ? true : false;
+		this.colorMode = colorMode == 1 ? true : false;
+		this.drawDecay = drawDecay == 1 ? true : false;
 	}
 
 	public void prepare(long time, MainState state) {
-		if(!(state instanceof BMSPlayer)) {
+		if (!(state instanceof BMSPlayer)) {
 			draw = false;
 			return;
 		}
 		super.prepare(time, state);
 		final PlayerResource resource = state.main.getPlayerResource();
-		if(resource.getBMSModel() != model) {
+		if (resource.getBMSModel() != model) {
 			model = resource.getBMSModel();
-			judgeArea = getJudgeArea(resource);			
+			judgeArea = getJudgeArea(resource);
 		}
-		
-		index = ((BMSPlayer)state).getJudgeManager().getRecentJudgesIndex();
-		recent = ((BMSPlayer)state).getJudgeManager().getRecentJudges();
+
+		index = ((BMSPlayer) state).getJudgeManager().getRecentJudgesIndex();
+		recent = ((BMSPlayer) state).getJudgeManager().getRecentJudges();
 	}
 
-	private void updateEMA (long value) {
+	private void updateEMA(long value) {
 		ema = ema + (long) (alpha * (value - ema));
 	}
-	
+
 	public void draw(SkinObjectRenderer sprite) {
 		if (shape == null) {
 			shape = new Pixmap(width, windowLength * 2, Pixmap.Format.RGBA8888);
@@ -130,12 +130,13 @@ public class SkinHitErrorVisualizer extends SkinObject {
 						shape.setColor(JColor[2]);
 					} else if (judge > judgeArea[3][0] && judge < judgeArea[3][1]) {
 						shape.setColor(JColor[3]);
-					} else {//(judge > judgeArea[4][0] && judge < judgeArea[4][1]) {
+					} else {// (judge > judgeArea[4][0] && judge < judgeArea[4][1]) {
 						shape.setColor(JColor[4]);
 					}
 				} else {
 					shape.setColor(
-							Color.rgba8888(lineColor.r, lineColor.g, lineColor.b, (lineColor.a * i / (1.0f * windowLength / 2))));
+							Color.rgba8888(lineColor.r, lineColor.g, lineColor.b,
+									(lineColor.a * i / (1.0f * windowLength / 2))));
 				}
 				int x = (width - lineWidth) / 2
 						+ (int) (MathUtils.clamp(recent[cycle], -center, center) * -judgeWidthRate);
@@ -168,8 +169,8 @@ public class SkinHitErrorVisualizer extends SkinObject {
 				shape.fillRectangle(x, 0, lineWidth, windowLength * 2);
 			}
 			if (emaMode == 2 || emaMode == 3) {
-				x = x+(lineWidth/2);
-				if(w%2!=0) {
+				x = x + (lineWidth / 2);
+				if (w % 2 != 0) {
 					w++;
 				}
 				shape.fillTriangle(x, (windowLength * 2) / 3, x + w, 0, x - w, 0);
@@ -191,15 +192,39 @@ public class SkinHitErrorVisualizer extends SkinObject {
 
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
-		final int[] judgeWindowRate = config.isCustomJudge()
-				? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}
-				: new int[]{100, 100, 100};
-				
+		int[][] judgeWindowRate = null;
+		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
+			judgeWindowRate = new int[][] {
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() },
+					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
+							config.getKeyJudgeWindowRateGood() } };
+		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
+			judgeWindowRate = new int[][] {
+					{ config.getKeyEasyJudgeWindowRatePerfectGreat(), config.getKeyEasyJudgeWindowRateGreat(),
+							config.getKeyEasyJudgeWindowRateGood() },
+					{ config.getKeyNormalJudgeWindowRatePerfectGreat(), config.getKeyNormalJudgeWindowRateGreat(),
+							config.getKeyNormalJudgeWindowRateGood() },
+					{ config.getKeyHardJudgeWindowRatePerfectGreat(), config.getKeyHardJudgeWindowRateGreat(),
+							config.getKeyHardJudgeWindowRateGood() },
+					{ config.getKeyVeryHardJudgeWindowRatePerfectGreat(), config.getKeyVeryHardJudgeWindowRateGreat(),
+							config.getKeyVeryHardJudgeWindowRateGood() } };
+		} else {
+			judgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
+					{ 100, 100, 100 } };
+		}
+
 		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
-			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
-				judgeWindowRate[1] = judgeWindowRate[2] = 0;
-			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
-				judgeWindowRate[2] = 0;
+			for (int i = 0; i < judgeWindowRate.length; i++) {
+				if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+					judgeWindowRate[i][1] = judgeWindowRate[i][2] = 0;
+				} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+					judgeWindowRate[i][2] = 0;
+				}
 			}
 		}
 

--- a/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
@@ -197,13 +197,13 @@ public class SkinHitErrorVisualizer extends SkinObject {
 			judgeWindowRate = new int[] { config.getKeyJudgeWindowRatePerfectGreat(),
 					config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			if (judgerank <= 25) {
+			if (model.getMode().key != 9 && judgerank <= 25 || model.getMode().key == 9 && judgerank <= 33) {
 				judgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
 						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
 			} else if (judgerank <= 50) {
 				judgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
 						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
-			} else if (judgerank <= 75) {
+			} else if (model.getMode().key != 9 && judgerank <= 75 || model.getMode().key == 9 && judgerank <= 70) {
 				judgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
 						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
 			} else if (judgerank <= 100) {

--- a/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinHitErrorVisualizer.java
@@ -192,39 +192,35 @@ public class SkinHitErrorVisualizer extends SkinObject {
 
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
-		int[][] judgeWindowRate = null;
+		int[] judgeWindowRate = null;
 		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
-			judgeWindowRate = new int[][] {
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() } };
+			judgeWindowRate = new int[] { config.getKeyJudgeWindowRatePerfectGreat(),
+					config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			judgeWindowRate = new int[][] {
-					{ config.getKeyEasyJudgeWindowRatePerfectGreat(), config.getKeyEasyJudgeWindowRateGreat(),
-							config.getKeyEasyJudgeWindowRateGood() },
-					{ config.getKeyNormalJudgeWindowRatePerfectGreat(), config.getKeyNormalJudgeWindowRateGreat(),
-							config.getKeyNormalJudgeWindowRateGood() },
-					{ config.getKeyHardJudgeWindowRatePerfectGreat(), config.getKeyHardJudgeWindowRateGreat(),
-							config.getKeyHardJudgeWindowRateGood() },
-					{ config.getKeyVeryHardJudgeWindowRatePerfectGreat(), config.getKeyVeryHardJudgeWindowRateGreat(),
-							config.getKeyVeryHardJudgeWindowRateGood() } };
+			if (judgerank <= 25) {
+				judgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
+						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
+			} else if (judgerank <= 50) {
+				judgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
+						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
+			} else if (judgerank <= 75) {
+				judgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
+						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
+			} else if (judgerank <= 100) {
+				judgeWindowRate = new int[] { config.getKeyEasyJudgeWindowRatePerfectGreat(),
+						config.getKeyEasyJudgeWindowRateGreat(), config.getKeyEasyJudgeWindowRateGood() };
+			} else {
+				judgeWindowRate = new int[] { 100, 100, 100 };
+			}
 		} else {
-			judgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
-					{ 100, 100, 100 } };
+			judgeWindowRate = new int[] { 100, 100, 100 };
 		}
 
 		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
-			for (int i = 0; i < judgeWindowRate.length; i++) {
-				if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
-					judgeWindowRate[i][1] = judgeWindowRate[i][2] = 0;
-				} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
-					judgeWindowRate[i][2] = 0;
-				}
+			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+				judgeWindowRate[1] = judgeWindowRate[2] = 0;
+			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+				judgeWindowRate[2] = 0;
 			}
 		}
 

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -176,39 +176,35 @@ public class SkinTimingVisualizer extends SkinObject {
 
 		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
-		int[][] judgeWindowRate = null;
+		int[] judgeWindowRate = null;
 		if (config.isCustomJudge() && config.getCustomJudgeKind() == 0) {
-			judgeWindowRate = new int[][] {
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() },
-					{ config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(),
-							config.getKeyJudgeWindowRateGood() } };
+			judgeWindowRate = new int[] { config.getKeyJudgeWindowRatePerfectGreat(),
+					config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			judgeWindowRate = new int[][] {
-					{ config.getKeyEasyJudgeWindowRatePerfectGreat(), config.getKeyEasyJudgeWindowRateGreat(),
-							config.getKeyEasyJudgeWindowRateGood() },
-					{ config.getKeyNormalJudgeWindowRatePerfectGreat(), config.getKeyNormalJudgeWindowRateGreat(),
-							config.getKeyNormalJudgeWindowRateGood() },
-					{ config.getKeyHardJudgeWindowRatePerfectGreat(), config.getKeyHardJudgeWindowRateGreat(),
-							config.getKeyHardJudgeWindowRateGood() },
-					{ config.getKeyVeryHardJudgeWindowRatePerfectGreat(), config.getKeyVeryHardJudgeWindowRateGreat(),
-							config.getKeyVeryHardJudgeWindowRateGood() } };
+			if (judgerank <= 25) {
+				judgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
+						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
+			} else if (judgerank <= 50) {
+				judgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
+						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
+			} else if (judgerank <= 75) {
+				judgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
+						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
+			} else if (judgerank <= 100) {
+				judgeWindowRate = new int[] { config.getKeyEasyJudgeWindowRatePerfectGreat(),
+						config.getKeyEasyJudgeWindowRateGreat(), config.getKeyEasyJudgeWindowRateGood() };
+			} else {
+				judgeWindowRate = new int[] { 100, 100, 100 };
+			}
 		} else {
-			judgeWindowRate = new int[][] { { 100, 100, 100 }, { 100, 100, 100 }, { 100, 100, 100 },
-					{ 100, 100, 100 } };
+			judgeWindowRate = new int[] { 100, 100, 100 };
 		}
 
 		for (CourseData.CourseDataConstraint mode : resource.getConstraint()) {
-			for (int i = 0; i < judgeWindowRate.length; i++) {
-				if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
-					judgeWindowRate[i][1] = judgeWindowRate[i][2] = 0;
-				} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
-					judgeWindowRate[i][2] = 0;
-				}
+			if (mode == CourseData.CourseDataConstraint.NO_GREAT) {
+				judgeWindowRate[1] = judgeWindowRate[2] = 0;
+			} else if (mode == CourseData.CourseDataConstraint.NO_GOOD) {
+				judgeWindowRate[2] = 0;
 			}
 		}
 

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -181,13 +181,13 @@ public class SkinTimingVisualizer extends SkinObject {
 			judgeWindowRate = new int[] { config.getKeyJudgeWindowRatePerfectGreat(),
 					config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood() };
 		} else if (config.isCustomJudge() && config.getCustomJudgeKind() == 1) {
-			if (judgerank <= 25) {
+			if (model.getMode().key != 9 && judgerank <= 25 || model.getMode().key == 9 && judgerank <= 33) {
 				judgeWindowRate = new int[] { config.getKeyVeryHardJudgeWindowRatePerfectGreat(),
 						config.getKeyVeryHardJudgeWindowRateGreat(), config.getKeyVeryHardJudgeWindowRateGood() };
 			} else if (judgerank <= 50) {
 				judgeWindowRate = new int[] { config.getKeyHardJudgeWindowRatePerfectGreat(),
 						config.getKeyHardJudgeWindowRateGreat(), config.getKeyHardJudgeWindowRateGood() };
-			} else if (judgerank <= 75) {
+			} else if (model.getMode().key != 9 && judgerank <= 75 || model.getMode().key == 9 && judgerank <= 70) {
 				judgeWindowRate = new int[] { config.getKeyNormalJudgeWindowRatePerfectGreat(),
 						config.getKeyNormalJudgeWindowRateGreat(), config.getKeyNormalJudgeWindowRateGood() };
 			} else if (judgerank <= 100) {


### PR DESCRIPTION
目的:
筆者は普段、Expand Judgeの各項目を100以下に設定し、判定を厳しくした状態でbmsを遊んでいます。
しかし、現状ではVeryEasy・Easy・Normal・Hard・VeryHard判定で共通のExpand Judgeしか設定できないため、
Easyを厳しくするように設定するとNormal判定以上が厳しすぎてしまい、
逆にNormal判定以上を緩く設定しようとするとEasy判定が緩すぎてしまうため、
丁度いい設定ができず、もどかしさを感じていました。
そこで、VeryEasy・Easy・Normal・Hard・VeryHard判定で個別にExpand Judgeを設定できるようにすることで、上記の解消を図りました。

実装方針:
- どの判定でも共通の設定を適用する従来の仕様は残しつつ、個別の設定ができるように仕様を追加しました。
    - プルダウンリストで選択するようになっており、<br>従来の仕様を使いたい場合は "% for all judge"、新仕様は"% for each judge"を選択して各項目を入力します 
- beatoraja内部ではJudgerankの値を使用してどの判定かを判別しているようなので、その値に準じて分岐をかけるようにしています。
- 個別の設定をした場合、各項目が全て100以下でないとスコアが保存されない仕様にしています

補足:
- 下記理由により、現在はWIP扱いです
    - 自分の開発環境で自動インデントがかかっている事に気づかずコミットしてしまったため、差分が見づらいです
    - ~~BMSとPMSでJudgerankに対応する判定の境界値が異なることを忘れており、そのままバグとして残っています~~
    - VeryEasy判定の存在を忘れており、現在設定ができない状態です
