### PR TITLE
Judgerankの下限を固定するオプションの追加

### DIFF
--- a/src/bms/player/beatoraja/PlayerConfig.java
+++ b/src/bms/player/beatoraja/PlayerConfig.java
@@ -28,7 +28,7 @@ import com.badlogic.gdx.utils.SerializationException;
 public class PlayerConfig {
 
 	static final Path configpath_old = Paths.get("config.json");
-	static final Path configpath = Paths.get("config_player.json");	
+	static final Path configpath = Paths.get("config_player.json");
 
 	private String id;
     /**
@@ -57,7 +57,7 @@ public class PlayerConfig {
 	 * スコアターゲット
 	 */
 	private String targetid = "MAX";
-	
+
 	private String[] targetlist = new String[] {"RATE_A-","RATE_A", "RATE_A+","RATE_AA-","RATE_AA", "RATE_AA+", "RATE_AAA-", "RATE_AAA", "RATE_AAA+", "MAX"
 			,"RANK_NEXT", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3", "IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10"
 			, "IR_RANK_1", "IR_RANK_5", "IR_RANK_10", "IR_RANK_20", "IR_RANK_30", "IR_RANK_40", "IR_RANK_50"
@@ -66,10 +66,10 @@ public class PlayerConfig {
 	 * 判定タイミング
 	 */
 	private int judgetiming = 0;
-	
+
 	public static final int JUDGETIMING_MAX = 500;
 	public static final int JUDGETIMING_MIN = -500;
-	
+
 	private boolean notesDisplayTimingAutoAdjust = false;
 
     /**
@@ -95,7 +95,14 @@ public class PlayerConfig {
 	 * ロングノート追加/削除モード
 	 */
     private int longnoteMode = 0;
-    private double longnoteRate = 1.0;
+	private double longnoteRate = 1.0;
+	/**
+	 * 最低のJudgerankType
+	 * JudgerankTypeと数値の対応関係は以下
+	 * 0: VeryHard, 1: Hard, 2: Normal, 3: Easy, 4: VeryEasy
+	 */
+	private boolean enableLeastJudgerankType = false;
+	private int leastJudgerankType = 0;
 	/**
 	 * アシストオプション:判定拡大
 	 */
@@ -172,7 +179,7 @@ public class PlayerConfig {
 	 * Window Hold
 	 */
 	private boolean isWindowHold = false;
-	
+
 	/**
 	 * Enable folder random select bar
 	 */
@@ -202,7 +209,7 @@ public class PlayerConfig {
 	 * 通過ノートを表示するかどうか
 	 */
 	private boolean showpastnote = false;
-	
+
 	/**
 	 * 選択中の選曲時ソート
 	 */
@@ -214,7 +221,7 @@ public class PlayerConfig {
 	private int musicselectinput = 0;
 
 	private IRConfig[] irconfig;
-	
+
 	private String twitterConsumerKey;
 
 	private String twitterConsumerSecret;
@@ -477,7 +484,7 @@ public class PlayerConfig {
 	public Mode getMode()  {
 		return mode;
 	}
-	
+
 	public int getSort() {
 		return this.sort ;
 	}
@@ -547,6 +554,22 @@ public class PlayerConfig {
 
 	public void setMisslayerDuration(int misslayerTime) {
 		this.misslayerDuration = misslayerTime;
+	}
+
+	public boolean isEnableLeastJudgerankType() {
+		return enableLeastJudgerankType;
+	}
+
+	public void setEnableLeastJudgerankType(boolean enableLeastJudgerankType) {
+		this.enableLeastJudgerankType = enableLeastJudgerankType;
+	}
+
+	public int getLeastJudgerankType() {
+		return leastJudgerankType;
+	}
+
+	public void setLeastJudgerankType(int leastJudgerankType) {
+		this.leastJudgerankType = leastJudgerankType;
 	}
 
 	public boolean isCustomJudge() {
@@ -652,11 +675,11 @@ public class PlayerConfig {
 	public void setWindowHold(boolean isWindowHold) {
 		this.isWindowHold = isWindowHold;
 	}
-	
+
 	public boolean isRandomSelect() {
 		return isRandomSelect;
 	}
-	
+
 	public void setRandomSelect(boolean isRandomSelect) {
 		this.isRandomSelect = isRandomSelect;
 	}
@@ -724,7 +747,7 @@ public class PlayerConfig {
 	public void setTwitterAccessTokenSecret(String twitterAccessTokenSecret) {
 		this.twitterAccessTokenSecret = twitterAccessTokenSecret;
 	}
-	
+
 	// --Stream
 	public boolean getRequestEnable() {
         return enableRequest;
@@ -796,7 +819,7 @@ public class PlayerConfig {
 		mode9.validate(9);
 		mode24.validate(26);
 		mode24double.validate(52);
-		
+
 		sort = MathUtils.clamp(sort, 0 , BarSorter.values().length - 1);
 
 		gauge = MathUtils.clamp(gauge, 0, 5);
@@ -815,7 +838,7 @@ public class PlayerConfig {
 		scratchJudgeWindowRateGreat = MathUtils.clamp(scratchJudgeWindowRateGreat, 0, 400);
 		scratchJudgeWindowRateGood = MathUtils.clamp(scratchJudgeWindowRateGood, 0, 400);
 		hranThresholdBPM = MathUtils.clamp(hranThresholdBPM, 1, 1000);
-		
+
 		if(autosavereplay == null) {
 			autosavereplay = config.autosavereplay != null ? config.autosavereplay.clone() : new int[4];
 		}
@@ -842,7 +865,7 @@ public class PlayerConfig {
 				irconfig[i].setIrname(irnames[i]);
 			}
 		}
-		
+
 		for(int i = 0;i < irconfig.length;i++) {
 			if(irconfig[i] == null || irconfig[i].getIrname() == null) {
 				continue;
@@ -850,7 +873,7 @@ public class PlayerConfig {
 			for(int j = i + 1;j < irconfig.length;j++) {
 				if(irconfig[j] != null && irconfig[i].getIrname().equals(irconfig[j].getIrname())) {
 					irconfig[j].setIrname(null);
-				}				
+				}
 			}
 		}
 		irconfig = Validatable.removeInvalidElements(irconfig);
@@ -940,7 +963,7 @@ public class PlayerConfig {
 				}
 			} catch(Throwable e) {
 				e.printStackTrace();
-			}			
+			}
 		} else if(Files.exists(path_old)) {
 			try (FileReader reader = new FileReader(path_old.toFile())) {
 				Json json = new Json();
@@ -983,7 +1006,7 @@ public class PlayerConfig {
     public void setScrollMode(int scrollMode) {
         this.scrollMode = scrollMode;
     }
-    
+
 	public int getScrollSection() {
 		return scrollSection;
 	}

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.fxml
@@ -187,8 +187,10 @@
                                          <ComboBox fx:id="gaugeop" prefWidth="150.0" GridPane.columnIndex="3" GridPane.rowIndex="7" />
                                          <Label text="%LNTYPE" GridPane.rowIndex="8" />
                                          <ComboBox fx:id="lntype" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="8" />
-                                         <CheckBox fx:id="customjudge" mnemonicParsing="false" text="%EXPAND_JUDGE" GridPane.columnIndex="0" GridPane.rowIndex="10" />
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="10" GridPane.columnSpan="3">
+                                         <CheckBox fx:id="enableLeastJudgerankType" mnemonicParsing="false" text="Least Judgerank Type" GridPane.columnIndex="0" GridPane.rowIndex="10" />
+                                         <ComboBox fx:id="leastJudgerankType" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="10" />
+                                         <CheckBox fx:id="customjudge" mnemonicParsing="false" text="%EXPAND_JUDGE" GridPane.columnIndex="0" GridPane.rowIndex="11" />
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="11" GridPane.columnSpan="3">
                                          <Label text="KEY PG" prefWidth="60.0"/>
                                          <NumericSpinner fx:id="njudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>
@@ -208,7 +210,7 @@
                                              </valueFactory>
                                          </NumericSpinner>
                                          </HBox>
-                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="11" GridPane.columnSpan="3">
+                                         <HBox prefHeight="30.0" prefWidth="723.0" GridPane.columnIndex="1" GridPane.rowIndex="12" GridPane.columnSpan="3">
                                          <Label text="SCR PG" prefWidth="60.0" />
                                          <NumericSpinner fx:id="sjudgepg" editable="true" prefWidth="100.0">
                                              <valueFactory>

--- a/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/PlayConfigurationView.java
@@ -151,6 +151,10 @@ public class PlayConfigurationView implements Initializable {
 	@FXML
 	private ComboBox<Integer> bottomshiftablegauge;
 	@FXML
+	private CheckBox enableLeastJudgerankType;
+	@FXML
+	private ComboBox<Integer> leastJudgerankType;
+	@FXML
 	private CheckBox customjudge;
 	@FXML
 	private Spinner<Integer> njudgepg;
@@ -293,6 +297,7 @@ public class PlayConfigurationView implements Initializable {
 		initComboBox(lntype, new String[] { "LONG NOTE", "CHARGE NOTE", "HELL CHARGE NOTE" });
 		initComboBox(gaugeautoshift, new String[] { "NONE", "CONTINUE", "SURVIVAL TO GROOVE","BEST CLEAR","SELECT TO UNDER" });
 		initComboBox(bottomshiftablegauge, new String[] { "ASSIST EASY", "EASY", "NORMAL" });
+		initComboBox(leastJudgerankType, new String[] { "VeryHard", "Hard", "Normal", "Easy", "VeryEasy" });
 		initComboBox(minemode, new String[] { "OFF", "REMOVE", "ADD RANDOM", "ADD NEAR", "ADD ALL" });
 		initComboBox(scrollmode, new String[] { "OFF", "REMOVE", "ADD" });
 		initComboBox(longnotemode, new String[] { "OFF", "REMOVE", "ADD LN", "ADD CN", "ADD HCN", "ADD ALL" });
@@ -435,6 +440,9 @@ public class PlayConfigurationView implements Initializable {
 		gaugeautoshift.setValue(player.getGaugeAutoShift());
 		bottomshiftablegauge.setValue(player.getBottomShiftableGauge());
 
+		enableLeastJudgerankType.setSelected(player.isEnableLeastJudgerankType());
+		leastJudgerankType.getSelectionModel().select(player.getLeastJudgerankType());
+
 		customjudge.setSelected(player.isCustomJudge());
 		njudgepg.getValueFactory().setValue(player.getKeyJudgeWindowRatePerfectGreat());
 		njudgegr.getValueFactory().setValue(player.getKeyJudgeWindowRateGreat());
@@ -538,6 +546,8 @@ public class PlayConfigurationView implements Initializable {
 		player.setBpmguide(bpmguide.isSelected());
 		player.setGaugeAutoShift(gaugeautoshift.getValue());
 		player.setBottomShiftableGauge(bottomshiftablegauge.getValue());
+		player.setEnableLeastJudgerankType(enableLeastJudgerankType.isSelected());
+		player.setLeastJudgerankType(leastJudgerankType.getValue());
 		player.setCustomJudge(customjudge.isSelected());
 		player.setKeyJudgeWindowRatePerfectGreat(getValue(njudgepg));
 		player.setKeyJudgeWindowRateGreat(getValue(njudgegr));
@@ -818,4 +828,3 @@ public class PlayConfigurationView implements Initializable {
 		}
 	}
 }
-

--- a/src/bms/player/beatoraja/play/JudgeManager.java
+++ b/src/bms/player/beatoraja/play/JudgeManager.java
@@ -65,7 +65,7 @@ public class JudgeManager {
 	 * 判定差時間(ms , +は早押しで-は遅押し)
 	 */
 	private long[] judgefast;
-	
+
 	private long[] mjudgefast;
 	/**
 	 * 処理中のLN
@@ -178,7 +178,7 @@ public class JudgeManager {
 		JudgeProperty rule = BMSPlayerRule.getBMSPlayerRule(orgmode).judge;
 		score.setJudgeAlgorithm(algorithm);
 		score.setRule(BMSPlayerRule.getBMSPlayerRule(orgmode));
-		
+
 		combocond = rule.combo;
 		miss = rule.miss;
 		judgeVanish = rule.judgeVanish;
@@ -203,9 +203,10 @@ public class JudgeManager {
 		for (int key = 0; key < keyassign.length; key++) {
 			auto_presstime[key] = Long.MIN_VALUE;
 		}
-
-		final int judgerank = model.getJudgerank();
 		final PlayerConfig config = resource.getPlayerConfig();
+		final int judgerank = config.isEnableLeastJudgerankType()
+				? rule.getLeastJudgerank(model.getJudgerank(), config.getLeastJudgerankType())
+				: model.getJudgerank();
 		final int[] keyJudgeWindowRate = config.isCustomJudge()
 				? new int[]{config.getKeyJudgeWindowRatePerfectGreat(), config.getKeyJudgeWindowRateGreat(), config.getKeyJudgeWindowRateGood()}
 				: new int[]{100, 100, 100};
@@ -220,8 +221,10 @@ public class JudgeManager {
 				keyJudgeWindowRate[2] = 0;
 				scratchJudgeWindowRate[2] = 0;
 			}
+
 		}
-		
+
+
 		nmjudge = rule.getJudge(NoteType.NOTE, judgerank, keyJudgeWindowRate);
 		cnendmjudge = rule.getJudge(NoteType.LONGNOTE_END, judgerank, keyJudgeWindowRate);
 		smjudge = rule.getJudge(NoteType.SCRATCH, judgerank, scratchJudgeWindowRate);
@@ -452,12 +455,12 @@ public class JudgeManager {
 									}
 									j = (j >= 4 ? j + 1 : j);
 								}
-								
+
 								if(j < 6) {
 									if (j < 6 && (j < 4 || tnote == null
 											|| Math.abs(tnote.getMicroTime() - pmtime) > Math.abs(judgenote.getMicroTime() - pmtime))) {
 										tnote = judgenote;
-									}									
+									}
 								} else {
 									tnote = null;
 								}
@@ -579,7 +582,8 @@ public class JudgeManager {
 							this.updateMicro(lane, processing[lane].getPair(), mtime, j, dmtime);
 							keysound.play(processing[lane], config.getAudioConfig().getKeyvolume(), 0);
 							processing[lane] = null;
-//							System.out.println("LN途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : " + processing[lane]);	
+							// System.out.println("LN途中離し判定 - Time : " + ptime + " Judge : " + j + " LN : "
+							// + processing[lane]);
 						}
 					}
 				}
@@ -721,18 +725,18 @@ public class JudgeManager {
 			if(autoplay.mode == BMSPlayerMode.Mode.PLAY || autoplay.mode == BMSPlayerMode.Mode.PRACTICE) {
 				if (judge <= 2 && mfast >= -150000 && mfast <= 150000) {
 					player.setJudgetiming(player.getJudgetiming() - (int)((mfast >= 0 ? mfast + 15000 : mfast - 15000) / 30000));
-				}			
-			}			
+				}
+			}
 		}
 	}
 
 	public long[] getRecentJudges() {
 		return recentJudges;
 	}
-	
+
 	public long[] getMicroRecentJudges() {
 		return microrecentJudges;
-	}	
+	}
 
 	public int getRecentJudgesIndex() {
 		return recentJudgesIndex;

--- a/src/bms/player/beatoraja/play/JudgeProperty.java
+++ b/src/bms/player/beatoraja/play/JudgeProperty.java
@@ -73,7 +73,7 @@ public enum JudgeProperty {
      * 各判定毎のノートの判定を消失するかどうか。PG, GR, GD, BD, PR, MSの順
      */
     public final boolean[] judgeVanish;
-    
+
     public final JudgeWindowRule windowrule;
 
     private JudgeProperty(long[][] note, long[][] scratch, long[][] longnote, long[][] longscratch, boolean[] combo, MissCondition miss, boolean[] judgeVanish, JudgeWindowRule windowrule) {
@@ -102,18 +102,23 @@ public enum JudgeProperty {
     public int[][] getLongScratchEndJudge(int judgerank, int[] judgeWindowRate) {
     	return convertMilli(windowrule.create(longscratch, judgerank, judgeWindowRate));
     }
-    
+
     private int[][] convertMilli(long[][] judge) {
     	int[][] mjudge = new int[judge.length][];
     	for(int i = 0;i < mjudge.length;i++) {
     		mjudge[i] = new int[judge[i].length];
     		for(int j = 0;j < mjudge[i].length;j++) {
-        		mjudge[i][j] = (int) (judge[i][j] / 1000);    			
+                mjudge[i][j] = (int) (judge[i][j] / 1000);
     		}
     	}
     	return mjudge;
     }
-    
+
+    public int getLeastJudgerank(int judgerank, int leastJudgerankType) {
+        int leastJudgerank = windowrule.judgerank[leastJudgerankType];
+        return leastJudgerank < judgerank ? leastJudgerank : judgerank;
+    }
+
     public long[][] getJudge(NoteType notetype, int judgerank, int[] judgeWindowRate) {
     	switch(notetype) {
     	case NOTE:
@@ -128,15 +133,15 @@ public enum JudgeProperty {
         	return windowrule.create(note, judgerank, judgeWindowRate);
     	}
     }
-    
+
     public enum MissCondition {
     	ONE, ALWAYS
     }
-    
+
     public enum NoteType {
     	NOTE, LONGNOTE_END, SCRATCH, LONGSCRATCH_END
     }
-    
+
     public enum JudgeWindowRule {
     	NORMAL (new int[]{25, 50, 75, 100, 125}){
 
@@ -144,7 +149,7 @@ public enum JudgeProperty {
 			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
 				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, false);
 			}
-    		
+
     	},
     	PMS (new int[]{33, 50, 70, 100, 133}) {
 
@@ -152,14 +157,14 @@ public enum JudgeProperty {
 			public long[][] create(long[][] org, int judgerank, int[] judgeWindowRate) {
 				return JudgeWindowRule.create(org, judgerank,judgeWindowRate, true);
 			}
-    		
+
     	};
-    	
+
     	/**
     	 * JUDGERANKの倍率(VERYHARD, HARD, NORMAL, EASY, VERYEASY)
     	 */
-    	public final int[] judgerank;
-    	
+        public final int[] judgerank;
+
         private static long[][] create(long[][] org, int judgerank, int[] judgeWindowRate, boolean pms) {
     		final long[][] judge = new long[org.length][2];
     		final boolean[] fix = pms ? new boolean[]{true, false, false, true, true} : new boolean[]{false, false, false, false, true};
@@ -182,7 +187,7 @@ public enum JudgeProperty {
         				break;
         			}
     			}
-        		
+
     			for(int j = 0;j < 2;j++) {
 					if(fixmin != -1 && Math.abs(judge[i][j]) < Math.abs(judge[fixmin][j])) {
 						judge[i][j] = judge[fixmin][j];
@@ -205,14 +210,21 @@ public enum JudgeProperty {
 					}
     			}
     		}
-    		
+
     		return judge;
         }
-        
+
         private JudgeWindowRule(int[] judgerank) {
-        	this.judgerank = judgerank;
+            this.judgerank = judgerank;
         }
-        
+
+        public void setLeastJudgerank(int leastJudgerankType) {
+            int leastJudgerank = judgerank[leastJudgerankType];
+            for (int i = leastJudgerankType; i < judgerank.length; i++) {
+                judgerank[i] = leastJudgerank;
+            }
+        }
+
     	public abstract long[][] create(long[][] org, int judgerank, int[] judgeWindowRate);
     }
 }


### PR DESCRIPTION
目的:
筆者は普段、Expand Judgeの各項目を100以下に設定し、判定を厳しくした状態でbmsを遊んでいます。
しかし、現状ではVeryEasy・Easy・Normal・Hard・VeryHard判定で共通のExpand Judgeしか設定できないため、
Easyを厳しくするように設定するとNormal判定以上が厳しすぎてしまい、
逆にNormal判定以上を緩く設定しようとするとEasy判定が緩すぎてしまうため、
丁度いい設定ができず、もどかしさを感じていました。
そこで、Easy以下の判定は強制的にNormal判定にすることができるようなオプションを実装し、上記問題の解決を図りました。

実装方針:
Judgerankの下限を固定するオプション(Least Judgerank Type)を設けました。
例えば、"Hard"と設定すれば、Normal以下の判定は全てHard判定になります。

補足:
直感的には、難易度が上がれば難易度を示す指標(レベルとか)が上がるため、
Judgerankの下限の固定という表現をしていますが、
プログラム内部的にはむしろ逆で、上限を固定する処理になっています。
