### PR TITLE
Moved skin loading timing during initialization of COURSE RESULT to the end

### DIFF
--- a/src/bms/player/beatoraja/result/CourseResult.java
+++ b/src/bms/player/beatoraja/result/CourseResult.java
@@ -46,8 +46,6 @@ public class CourseResult extends AbstractResult {
 		setSound(SOUND_FAIL, "course_fail.wav", SoundType.SOUND, false);
 		setSound(SOUND_CLOSE, "course_close.wav", SoundType.SOUND, false);
 
-		loadSkin(SkinType.COURSE_RESULT);
-
 		for(int i = resource.getCourseGauge().size;i < resource.getCourseBMSModels().length;i++) {
 			FloatArray[] list = new FloatArray[resource.getGrooveGauge().getGaugeTypeLength()];
 			for(int type = 0; type < list.length; type++) {
@@ -76,6 +74,8 @@ public class CourseResult extends AbstractResult {
 		}
 
 		gaugeType = resource.getGrooveGauge().getType();
+
+		loadSkin(SkinType.COURSE_RESULT);
 	}
 	
 	public void prepare() {


### PR DESCRIPTION
`CourseResult` クラスの `create()` メソッド内におけるスキン読み込みタイミングをメソッドの最後へ移動しました。

これにより、 `create()` 内で初期化が終わっていない値をLuaスキンの初期処理時に `main_state` で正常に参照できない問題が解決され、例えばコースリザルトのスコアに基づくスキン表示条件の複雑な制御などが可能になります。

従来のままでもスキンが実際に描画されるタイミングでは初期化が終わっているので、 `ref` の指定や `value` に渡した関数などによる参照は正常に動作していると思われます。