### PR TITLE
Fix to also update rivalrateInt when updating rivalscore in ScoreDataProperty

### DIFF
--- a/src/bms/player/beatoraja/ScoreDataProperty.java
+++ b/src/bms/player/beatoraja/ScoreDataProperty.java
@@ -57,7 +57,8 @@ public class ScoreDataProperty {
 
         rivalscore = exscore;
         rivalscorerate = totalnotes == 0 ? 1.0f : ((float)exscore) / (totalnotes * 2);
-
+        rivalrateInt = (int)(rivalscorerate * 100);
+        rivalrateAfterDot = ((int)(rivalscorerate * 10000)) % 100;
     }
 
     public void update(ScoreData score, int notes) {
@@ -142,7 +143,9 @@ public class ScoreDataProperty {
     
     public void updateTargetScore(int rivalscore) {
     	this.rivalscore = rivalscore;
-        rivalscorerate= ((float)rivalscore)  / (totalnotes * 2);
+        rivalscorerate = ((float)rivalscore)  / (totalnotes * 2);
+        rivalrateInt = (int)(rivalscorerate * 100);
+        rivalrateAfterDot = ((int)(rivalscorerate * 10000)) % 100;
     }
 
     public void setTargetScore(int bestscore, int rivalscore, int totalnotes) {


### PR DESCRIPTION
`ScoreDataProperty` 内の `rivalscore` と `rivalscorerate` の更新時に `rivalrateInt` と `rivalrateAfterDot` も更新するようにしました。今までは `ScoreDataProperty::setTargetScore` の呼び出し時のみ更新されていました。この変更により、選曲バーの幾つかの操作とライバルスコアの取得後に上記の値が更新されずスキンで正常に参照できなかった問題が解決します。

### 問題の再現手順

1. IRに接続した状態で、ターゲットスコアをIR関連にする
2. PLAYスキンを `rivalrateInt` と `rivalrateAfterDot` を参照する整数プロパティ(122と123など)が用いられたものに設定する
3. 選曲画面でランキングの取得前にIRのプレイ人数が1人以上の譜面を選曲し、プレイ画面に移行する
4. ターゲットスコアが1以上であるにもかかわらずレート表示が0.00%のようになっている