### PR TITLE
Fix BUTTON_TARGET skin property (pacemaker target setting display during music select)

### DIFF
--- a/src/bms/player/beatoraja/PlayerConfig.java
+++ b/src/bms/player/beatoraja/PlayerConfig.java
@@ -56,7 +56,7 @@ public class PlayerConfig {
 	/**
 	 * スコアターゲット
 	 */
-	private String targetid = "MAX";
+	private int targetIndex = 9;
 	
 	private String[] targetlist = new String[] {"RATE_A-","RATE_A", "RATE_A+","RATE_AA-","RATE_AA", "RATE_AA+", "RATE_AAA-", "RATE_AAA", "RATE_AAA+", "MAX"
 			,"RANK_NEXT", "IR_NEXT_1", "IR_NEXT_2", "IR_NEXT_3", "IR_NEXT_4", "IR_NEXT_5", "IR_NEXT_10"
@@ -523,19 +523,29 @@ public class PlayerConfig {
 	}
 
 	public String getTargetid() {
-		return targetid;
+		if (targetIndex >= targetlist.length) {
+			targetIndex = 0;
+		}
+		return targetlist[targetIndex];
+	}
+
+	public int getTargetIndex() {
+		return targetIndex;
 	}
 
 	public void setTargetid(String targetid) {
-		this.targetid = targetid;
+		for(int index = 0; index < targetlist.length; index++) {
+			if(targetlist[index].equals(targetid)) {
+				this.targetIndex = index;
+				return;
+			}
+		}
+		Logger.getGlobal().warning("無効なtargetid: " + targetid);
+		this.targetIndex = 0;
 	}
 
 	public String[] getTargetlist() {
 		return targetlist;
-	}
-
-	public void setTargetlist(String[] targetlist) {
-		this.targetlist = targetlist;
 	}
 
 	public int getMisslayerDuration() {
@@ -803,8 +813,8 @@ public class PlayerConfig {
 		random = MathUtils.clamp(random, 0, 9);
 		random2 = MathUtils.clamp(random2, 0, 9);
 		doubleoption = MathUtils.clamp(doubleoption, 0, 3);
-		targetid = targetid!= null ? targetid : "MAX";
 		targetlist = targetlist != null ? targetlist : new String[0];
+		targetIndex = MathUtils.clamp(targetIndex, 0, targetlist.length);
 		judgetiming = MathUtils.clamp(judgetiming, JUDGETIMING_MIN, JUDGETIMING_MAX);
 		misslayerDuration = MathUtils.clamp(misslayerDuration, 0, 5000);
 		lnmode = MathUtils.clamp(lnmode, 0, 2);

--- a/src/bms/player/beatoraja/skin/property/EventFactory.java
+++ b/src/bms/player/beatoraja/skin/property/EventFactory.java
@@ -318,15 +318,9 @@ public class EventFactory {
 		}),
 		target(77, (state, arg1) -> {
 			if(state instanceof MusicSelector) {
-		        final PlayerConfig config = state.main.getPlayerResource().getPlayerConfig();
-	            final String[] targets = TargetProperty.getTargets();
-	            int index = 0;
-	            for(;index < targets.length;index++) {
-	            	if(targets[index].equals(config.getTargetid())) {
-	            		break;
-	            	}
-	            }
-	            config.setTargetid(targets[(index + (arg1 >= 0 ? 1 : targets.length - 1)) % targets.length]);
+				final PlayerConfig config = state.main.getPlayerResource().getPlayerConfig();
+				final String[] targets = TargetProperty.getTargets();
+				config.setTargetid(targets[((config.getTargetIndex() + arg1) % targets.length + targets.length) % targets.length]);
 			}
 		}),
 		gaugeautoshift(78, (state, arg1) -> {

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -990,6 +990,7 @@ public class IntegerPropertyFactory {
 		customjudge(BUTTON_ASSIST_EXJUDGE, (state) -> (state.main.getPlayerResource().getPlayerConfig().isCustomJudge() ? 1 : 0)),
 		lnmode(BUTTON_LNMODE, (state) -> (state.main.getPlayerResource().getPlayerConfig().getLnmode())),
 		notesdisplaytimingautoadjust(75, (state) -> (state.main.getPlayerResource().getPlayerConfig().isNotesDisplayTimingAutoAdjust() ? 1 : 0)),
+		target(77, (state) -> (state.main.getPlayerResource().getPlayerConfig().getTargetIndex())),
 		gaugeautoshift(78, (state) -> (state.main.getPlayerResource().getPlayerConfig().getGaugeAutoShift())),
 		bottomshiftablegauge(BUTTON_BOTTOMSIFTABLEFGAUGE, (state) -> (state.main.getPlayerResource().getPlayerConfig().getBottomShiftableGauge())),
 		bga(72, (state) -> (state.main.getPlayerResource().getConfig().getBga())),


### PR DESCRIPTION
# Issue
Currently, the `BUTTON_TARGET = 77` skin property is not working, because it has been removed from IntegerPropertyFactory.

This means that for many skins, we cannot see the pacemaker (target) option during music select.

Deprecating `BUTTON_TARGET` may have been intentional as [targetlist](https://github.com/exch-bms2/beatoraja/blob/f6e9ac83d2f388b69062bdcec1e40cca9596bab7/src/bms/player/beatoraja/PlayerConfig.java#L61) can now be modified (04d412a), so the string value of the target is preferred over the index. However this breaks the functionality of many old skins.

# Changes
I have changed PlayerConfig.java to internally store the index of the pacemaker (target) option instead of the string. However, the get and set methods use the string value, so string functionality is maintained.

We store the index internally so that it can be retrieved from IntegerPropertyFactory.java without having to do a loop each time the value is retrieved.

Also, the loop in EventFactory.java has been removed because now the index can be retrieved directly.

# Note 1
Old skins will still be unable to display all pacemaker options (e.g. IR options), but they at least they can still show the old options.

https://github.com/exch-bms2/beatoraja/assets/27341392/8592c9f4-9c1e-4a0b-bead-448b1d832c08

Maybe it will be good to rename the option to `BUTTON_TARGET_DEPRECATED = 77`, to maintain compatibility with old skins while encouraging skin makers to use the StringProperty instead.

# Note 2
I removed the `setTargetlist()` function for targetlist in PlayerConfig.java because it is not used. If this is not preferable, please add it back.