### PR TITLE
Fixed a sorting problem in SCORE_SORTER for score rates with very small differences

### DIFF
--- a/src/bms/player/beatoraja/select/BarSorter.java
+++ b/src/bms/player/beatoraja/select/BarSorter.java
@@ -170,8 +170,10 @@ public enum BarSorter implements Comparator<Bar> {
 			if (n2 == 0) {
 				return -1;
 			}
-			final float diff = (float) o1.getScore().getExscore() / n1 - (float) o2.getScore().getExscore() / n2;
-			return diff > 0 ? 1 : diff < 0 ? -1 : 0;
+			return Float.compare(
+					(float) o1.getScore().getExscore() / n1,
+					(float) o2.getScore().getExscore() / n2
+			);
 		}
 	},
 	/**

--- a/src/bms/player/beatoraja/select/BarSorter.java
+++ b/src/bms/player/beatoraja/select/BarSorter.java
@@ -5,6 +5,7 @@ import bms.player.beatoraja.select.bar.FolderBar;
 import bms.player.beatoraja.select.bar.SongBar;
 
 import java.util.Comparator;
+import java.util.logging.Logger;
 
 /**
  * バーのソートアルゴリズム
@@ -170,7 +171,8 @@ public enum BarSorter implements Comparator<Bar> {
 			if (n2 == 0) {
 				return -1;
 			}
-			return o1.getScore().getExscore() * 1000 / n1 - o2.getScore().getExscore() * 1000 / n2;
+			final float diff = (float) o1.getScore().getExscore() / n1 - (float) o2.getScore().getExscore() / n2;
+			return diff > 0 ? 1 : diff < 0 ? -1 : 0;
 		}
 	},
 	/**

--- a/src/bms/player/beatoraja/select/BarSorter.java
+++ b/src/bms/player/beatoraja/select/BarSorter.java
@@ -5,7 +5,6 @@ import bms.player.beatoraja.select.bar.FolderBar;
 import bms.player.beatoraja.select.bar.SongBar;
 
 import java.util.Comparator;
-import java.util.logging.Logger;
 
 /**
  * バーのソートアルゴリズム


### PR DESCRIPTION
選曲画面におけるソートでスコアレートの差が非常に小さい場合に正しい並び順にならないことがある問題を修正しました。

この原因は、比較用の値が整数同士で計算され小数部が切り捨てられること、ならびに差を比較結果として返した時に自動的にintにキャストされ小数部が切り捨てられることで比較関数の返値が0になるという問題でした。そこで、floatで計算した上で明示的に整数で返すように変更しました。

もしかするとパフォーマンス上の理由により意図的に精度を落としていたのかもしれませんが、スキンでスコアレートを小数点以下2桁まで%表示できる場合にそのレートと並びが食い違うケースを通常のゲームプレイの中で確認したため、精度を上げた方が良いと判断しました。変更後の処理の負荷に関しては問題ない範疇だと考えています。

### 問題が発生するケースの例

a. (score: 1992 * 1000 / notes: 1428) = 1394.9579831932774 (69.74%)
b. (score: 2091 * 1000 / notes: 1500) = 1394 (69.70%)