### PR TITLE
Fixed to draw the gauge graph to the right end

### DIFF
--- a/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
+++ b/src/bms/player/beatoraja/result/SkinGaugeGraphObject.java
@@ -168,6 +168,9 @@ public class SkinGaugeGraphObject extends SkinObject {
 
 			shape = new Pixmap((int) region.width, (int) region.height, Pixmap.Format.RGBA8888);
 			Float f1 = null;
+			float lastGauge = -1;
+			int lastX = -1;
+			int lastY = -1;
 
 			for (int i = 0; i < gaugehistory.size; i++) {
 				if (section.contains(i)) {
@@ -182,6 +185,9 @@ public class SkinGaugeGraphObject extends SkinObject {
 					final int x2 = (int) (region.width * i / gaugehistory.size);
 					final int y2 = (int) ((f2 / max) * (region.height - lineWidth));
 					final int yb = (int) ((border / max) * (region.height - lineWidth));
+					lastGauge = f2;
+					lastX = x2;
+					lastY = y2;
 					if (f1 < border) {
 						if (f2 < border) {
 							shape.setColor(graphline[color]);
@@ -210,6 +216,12 @@ public class SkinGaugeGraphObject extends SkinObject {
 				}
 				f1 = f2;
 			}
+
+			if (lastGauge != -1) {
+				shape.setColor(lastGauge < border ? graphline[color] : borderline[color]);
+				shape.fillRectangle(lastX, lastY, (int) (region.width - lastX), lineWidth);
+			}
+
 			shapetex = new TextureRegion(new Texture(shape));
 			shape.dispose();
 		}


### PR DESCRIPTION
リザルト画面のゲージグラフの折れ線をグラフ領域の右端まで描画するように修正しました。

![image](https://github.com/exch-bms2/beatoraja/assets/2842142/5d2cb764-d434-466f-90e4-b3230d48bcad)
