### PR TITLE
Fixed of score calculation process related to score ranks

### DIFF
--- a/src/bms/player/beatoraja/ScoreDataProperty.java
+++ b/src/bms/player/beatoraja/ScoreDataProperty.java
@@ -101,11 +101,11 @@ public class ScoreDataProperty {
         for(int i = 0;i < rank.length;i++) {
             rank[i] = totalnotes != 0 && rate >= 1f * i / rank.length;
             if(i % 3 == 0 && !rank[i] && nextrank == Integer.MIN_VALUE) {
-                nextrank = Math.round((i * (notes * 2) / rank.length) - rate * (notes * 2));
+                nextrank = (int)Math.ceil((i * (notes * 2) / (double)rank.length) - rate * (notes * 2));
             }
         }
         if(nextrank == Integer.MIN_VALUE) {
-            nextrank = Math.round((notes * 2) - rate * (notes * 2));
+            nextrank = (notes * 2) - exscore;
         }
         for(int i = 0;i < nowrank.length;i++) {
             nowrank[i] = totalnotes != 0 && nowrate >= 1f * i / nowrank.length;

--- a/src/bms/player/beatoraja/play/TargetProperty.java
+++ b/src/bms/player/beatoraja/play/TargetProperty.java
@@ -106,7 +106,7 @@ class StaticTargetProperty extends TargetProperty {
 
     @Override
     public ScoreData getTarget(MainController main) {
-    	int rivalscore = (int) (main.getPlayerResource().getBMSModel().getTotalNotes() * 2 * rate / 100f);
+    	int rivalscore = (int)Math.ceil(main.getPlayerResource().getBMSModel().getTotalNotes() * 2 * rate / 100f);
 		targetScore.setPlayer(getName(main));
 		targetScore.setEpg(rivalscore / 2);
 		targetScore.setEgr(rivalscore % 2);
@@ -315,7 +315,7 @@ class NextRankTargetProperty extends TargetProperty {
         final int max = main.getPlayerResource().getBMSModel().getTotalNotes() * 2;
         int targetscore = max;
         for(int i = 15;i < 27;i++) {
-            int target = max * i / 27;
+            int target = (int)Math.ceil(max * i / 27f);
             if(nowscore < target) {
             	targetscore = target;
             	break;


### PR DESCRIPTION
スコアランク (AAAなど) に関連する一部の計算処理を修正します。

## in `ScoreDataProperty`

nextrankの算出時、次のランクまでの差分の小数点以下の四捨五入を切り上げに修正しました。

例えば、1771ノーツの譜面のAランク下限スコアは `(1771 * 2) * (6 / 9) = 2361.3333333333335` です。そして「Aランクの下限以上 (Greater than or Equal)」の最小の整数は2362なので、スコア2361はA-1となります。従来は四捨五入だったのでA-0になり、それ以上(AAまで)計算されていませんでした。B(A+0)やAA(AAA+0)のような表記になることが稀にあるのはこれが原因です。

## in `StaticTargetProperty`, `NextRankTargetProperty`

スコアランクのレートからターゲットスコアを算出する際に小数点以下の切り捨てを切り上げに修正しました。前項の例だとAランクのスコアが2361から2362になります。もっと確認しやすい例だと2000ノーツのAAAスコアが3555から3556になります。