### PR TITLE
Fixed NUMBER_DURATION_LANECOVER_* duration and duration_green being reversed

### DIFF
--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -59,7 +59,7 @@ public class IntegerPropertyFactory {
 						break;
 					}
 					return (int) Math.round((240000 / bpm / lanerender.getHispeed())
-							* (cover ? 1 - lanerender.getLanecover() : 1) * (green ? 1 : 0.6));
+							* (cover ? 1 - lanerender.getLanecover() : 1) * (green ? 0.6 : 1));
 				}
 				return 0;
 			};


### PR DESCRIPTION
スキンの整数プロパティにはレーンカバーON/OFF時 × MIN/MAX/MAIN BPM時のDurationと緑数字を個別で得られるプロパティが1312~1327の範囲で用意されていますが、このDurationと緑数字が逆になっていた問題を修正しました。