### PR TITLE
Improved StringProperty search performance

### DIFF
--- a/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -15,6 +15,9 @@ import bms.player.beatoraja.select.bar.DirectoryBar;
 import bms.player.beatoraja.select.bar.GradeBar;
 import bms.player.beatoraja.select.bar.RandomCourseBar;
 import bms.player.beatoraja.song.SongData;
+import com.badlogic.gdx.utils.IntMap;
+
+import java.util.*;
 
 /**
  * StringPropertyのFactoryクラス
@@ -30,12 +33,8 @@ public class StringPropertyFactory {
 	 * @return 対応するStringProperty
 	 */
 	public static StringProperty getStringProperty(final int id) {
-		for(StringType t : StringType.values()) {
-			if(t.id == id) {
-				return t.property;
-			}
-		}
-		return null;
+		StringType type = StringType.get(id);
+		return type != null ? type.property : null;
 	}
 	
 	/**
@@ -45,7 +44,7 @@ public class StringPropertyFactory {
 	 * @return 対応するStringProperty
 	 */
 	public static StringProperty getStringProperty(final String name) {
-		for(StringType t : StringType.values()) {
+		for(StringType t : StringType.VALUES) {
 			if(t.name().equals(name)) {
 				return t.property;
 			}
@@ -274,6 +273,21 @@ public class StringPropertyFactory {
 		 * StringProperty
 		 */
 		private final StringProperty property;
+
+		public static final List<StringType> VALUES = Collections.unmodifiableList(Arrays.asList(StringType.values()));
+
+		private static final IntMap<StringType> ID_MAP;
+
+		static {
+			ID_MAP = new IntMap<>(VALUES.size());
+			for (StringType type : VALUES) {
+				ID_MAP.put(type.id, type);
+			}
+		}
+
+		public static StringType get(int id) {
+			return ID_MAP.get(id);
+		}
 		
 		private StringType(int id, StringProperty property) {
 			this.id = id;


### PR DESCRIPTION
`StringPropertyFactory.getStringProperty(...)` メソッドのパフォーマンス（実行速度とメモリ消費）を改善しました。

このメソッド内では、プロパティを検索するために `StringType.values()` を呼び出しています。しかし、列挙型の `values()` メソッドは、列挙型の不変性を保つために毎回新しい配列が生成（コピー）されています。`getStringProperty(...)` は毎フレーム複数回呼び出されるため、かなりのメモリを消費していました。そこで `values()` をキャッシュして変更不可能化することでこの問題の改善を試みました。

併せて、予めIDをキーとした `IntMap` に格納することで Boxing/Unboxing を回避し、パフォーマンスの向上を図りました。プロパティ名で検索する `getStringProperty(name)` 関数は未使用なので最適化していませんが、今後使用する場合は `HashMap` を使うと高速化できるでしょう。