### PR TITLE
Add SONG_HASH_MD5 and SONG_HASH_SHA256 property

### DIFF
--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -245,6 +245,8 @@ public class SkinProperty {
 	public static final int STRING_TABLE_FULL = 1003;
 	public static final int STRING_VERSION = 1010;
 	public static final int STRING_IR_NAME = 1020;
+	public static final int STRING_SONG_HASH_MD5 = 1030;
+	public static final int STRING_SONG_HASH_SHA256 = 1031;
 
 	public static final int NUMBER_HISPEED_LR2 = 10;
 	public static final int NUMBER_HISPEED = 310;

--- a/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/StringPropertyFactory.java
@@ -263,6 +263,14 @@ public class StringPropertyFactory {
 			}
 			return "";
 		}),
+		songhashmd5(1030, (state) -> {
+			final SongData song = state.resource.getSongdata();
+			return song != null ? song.getMd5() : "";
+		}),
+		songhashsha256(1031, (state) -> {
+			final SongData song = state.resource.getSongdata();
+			return song != null ? song.getSha256() : "";
+		}),
 		;
 		
 		/**


### PR DESCRIPTION
スキンで選択中の楽曲のMD5ハッシュとSHA-256ハッシュを得る文字列プロパティを追加しました。楽曲の情報がない場合は空文字列になります。

コースのハッシュについては、コースデータ自体はハッシュを持たず、各IRなど用途ごとにハッシュの計算方法を定める形式のため対応していません（プレイ中に現在のステージの楽曲ハッシュを得ることは可能です）。