### PR TITLE
Fixed bad string comparisons

### DIFF
--- a/src/bms/player/beatoraja/launcher/InputConfigurationView.java
+++ b/src/bms/player/beatoraja/launcher/InputConfigurationView.java
@@ -21,6 +21,7 @@ import javafx.util.converter.IntegerStringConverter;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.ResourceBundle;
 import java.util.stream.Collectors;
 
@@ -122,7 +123,7 @@ public class InputConfigurationView implements Initializable {
 	    
 	    @Override
 	    public Integer fromString(String arg0) {
-		if (arg0 == v2String) {
+		if (Objects.equals(arg0, v2String)) {
 		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_2;
 		} else {
 		    return PlayModeConfig.ControllerConfig.ANALOG_SCRATCH_VER_1;

--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -1022,7 +1022,7 @@ public class BarRenderer {
 									try {
 										Object value = randomFolder.getFilter().get(key);
 										if (scoreData == null) {
-											if (value instanceof String && "" != (String) value) {
+											if (value instanceof String && !"".equals((String) value)) {
 												return false;
 											}
 											if (value instanceof Integer && 0 != (Integer) value) {

--- a/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
+++ b/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
@@ -3,6 +3,7 @@ package bms.player.beatoraja.select;
 import java.nio.file.InvalidPathException;
 import java.nio.file.Paths;
 import java.util.Deque;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.logging.Logger;
 
@@ -85,14 +86,14 @@ public class PreviewMusicProcessor {
                     }
                     if(!path.equals(playing)) {
                         stopPreview(true);
-                        if(path != defaultMusic) {
+                        if(!path.equals(defaultMusic)) {
                             audio.play(path, config.getAudioConfig().getSystemvolume(), config.getSongPreview() == SongPreview.LOOP);
                         } else {
                             audio.setVolume(defaultMusic, config.getAudioConfig().getSystemvolume());
                         }
                         playing = path;
                     }
-                } else if(playing != defaultMusic && !audio.isPlaying(playing)){
+                } else if(!Objects.equals(playing, defaultMusic) && !audio.isPlaying(playing)){
                 	// プレビュー演奏終了後に選曲BGMに戻す
                     stopPreview(true);
                     audio.setVolume(defaultMusic, config.getAudioConfig().getSystemvolume());

--- a/src/bms/player/beatoraja/skin/SkinText.java
+++ b/src/bms/player/beatoraja/skin/SkinText.java
@@ -90,7 +90,7 @@ public abstract class SkinText extends SkinObject {
     }
 
     public void draw(SkinObjectRenderer sprite) {
-        if(currentText != text) {
+        if(!currentText.equals(text)) {
             setText(currentText);
         }
         draw(sprite, 0,0);

--- a/src/bms/player/beatoraja/stream/command/StreamRequestCommand.java
+++ b/src/bms/player/beatoraja/stream/command/StreamRequestCommand.java
@@ -75,8 +75,8 @@ public class StreamRequestCommand extends StreamCommand {
                 SongData[] _songDatas = selector.getSongDatabase().getSongDatas(new String[] { escape(sha256) });
                 if (_songDatas.length > 0) {
                     SongData data = _songDatas[0];
-                    if (songDatas.stream().filter(song -> song.getSha256() == sha256).count() > 0 ||
-                        stack.stream().filter(hash -> hash == sha256).count() > 1) { // stackの中身には自身を含めるため、1個の場合は通す
+                    if (songDatas.stream().filter(song -> song.getSha256().equals(sha256)).count() > 0 ||
+                        stack.stream().filter(hash -> hash.equals(sha256)).count() > 1) { // stackの中身には自身を含めるため、1個の場合は通す
                         // すでに追加済みならスキップ
                         notifier.addMessage(data.getFullTitle() + " はリクエスト済です" , MESSAGE_TIME, Color.ORANGE, 0);
                     }
@@ -94,7 +94,7 @@ public class StreamRequestCommand extends StreamCommand {
                     // 溜まってるぶんを順に取得
                     while (stack.size() != 0) {
                         String sha256 = stack.pop();
-                        if (songDatas.stream().filter(song -> song.getSha256() == sha256).count() > 0) {
+                        if (songDatas.stream().filter(song -> song.getSha256().equals(sha256)).count() > 0) {
                             // すでに追加済みならスキップ
                             continue;
                         }


### PR DESCRIPTION
Javaでは文字列の比較に比較演算子ではなく `String::equals` メソッドを用いることが強く推奨されているため、そのように修正しました。これは広く知られたbad practiceであるため理由の詳しい説明は省略します。なお、左辺にnullの可能性がある箇所は `Object.equals` を使用しています。

特に `SkinText::draw` メソッドのそれは、前回の描画と異なる文字列だった場合に実行される `prepareText` メソッドによって不要なはずの負荷を招くケースが非常に多いことが確認されました (ただし `SkinText` の実装のうち  `.fnt` ファイルを扱う `SkinTextBitmap` は `prepareText` メソッドの実装が空なので負荷はほぼない) 。

修正された中にはそのままでも問題ないと思われる箇所があったかもしれませんが、個々に区別するのは脆弱な方針であり、また今後の仕様変更や実行環境の違いによって不具合として顕在化する可能性があるため、一括で修正すべきと判断しました。

----

余談: 頻繁に実行されるなら比較演算子を使った方がいいというのも全くの間違いではないですが、それでも `String::equals` メソッドの実装を見ると大抵の場合（Liberica 17など）高速化のため最初に `==` で比較しているようなので、やはり `equals` メソッドを使うのが良いでしょう。