### PR TITLE
Make the game window not resizable

### DIFF
--- a/src/bms/player/beatoraja/MainLoader.java
+++ b/src/bms/player/beatoraja/MainLoader.java
@@ -136,6 +136,7 @@ public class MainLoader extends Application {
 			LwjglApplicationConfiguration cfg = new LwjglApplicationConfiguration();
 			cfg.width = config.getResolution().width;
 			cfg.height = config.getResolution().height;
+			cfg.resizable = false;
 
 			// fullscreen
 			switch (config.getDisplaymode()) {


### PR DESCRIPTION
Tiling window manager tries to move all the windows in the tile, the game shows skewed screen regardless of configured value.

Making the window not resizable will fix that issue, allowing the window to be positioned and sized as configured.