### PR TITLE
FEATURE:  Visualize random lane pattern in result screen

### DIFF
--- a/src/bms/player/beatoraja/ReplayData.java
+++ b/src/bms/player/beatoraja/ReplayData.java
@@ -34,6 +34,7 @@ public class ReplayData implements Validatable {
 	 * 譜面オプションによる変更ログ
 	 */
 	public PatternModifyLog[] pattern;
+	public int[][] laneShufflePattern;
 	/**
 	 * ランダムシーケンスを含むbmsの場合、選択されたRANDOM番号
 	 */

--- a/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
+++ b/src/bms/player/beatoraja/pattern/LaneShuffleModifier.java
@@ -288,4 +288,37 @@ public class LaneShuffleModifier extends PatternModifier {
 		return log;
 	}
 
+	public boolean isToDisplay() {
+		switch (type) {
+			case RANDOM:
+			case R_RANDOM:
+			case CROSS:
+			case RANDOM_EX:
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	public int[] getRandomPattern(Mode mode) {
+		int targetSide = getModifyTarget();
+		int keys = mode.key / mode.player;
+		int[] repr = new int[keys];
+		switch (type) {
+			case RANDOM:
+			case R_RANDOM:
+			case CROSS:
+			case RANDOM_EX:
+				if (mode.scratchKey.length > 0 && type != Random.RANDOM_EX) { // BEAT-*K
+					System.arraycopy(random, keys * targetSide, repr, 0, keys - 1);
+					repr[keys - 1] = mode.scratchKey[targetSide];
+				} else {
+					System.arraycopy(random, keys * targetSide, repr, 0, keys);
+				}
+				break;
+			default:
+				break;
+		}
+		return repr;
+	}
 }

--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -358,6 +358,8 @@ public class BMSPlayer extends MainState {
 				mods.add(mod);
 			}
 
+			int[][] patternArray = new int[model.getMode().player][];
+
 			List<PatternModifyLog> pattern = new ArrayList<PatternModifyLog>();
 			for(PatternModifier mod : mods) {
 				pattern = PatternModifier.merge(pattern,mod.modify(model));
@@ -366,8 +368,16 @@ public class BMSPlayer extends MainState {
 					assist = Math.max(assist, mod.getAssistLevel() == PatternModifier.AssistLevel.ASSIST ? 2 : 1);
 					score = false;
 				}
+
+				if (mod instanceof LaneShuffleModifier){
+					LaneShuffleModifier lmod = (LaneShuffleModifier)mod;
+					if(lmod.isToDisplay()){
+						patternArray[lmod.getModifyTarget()] = lmod.getRandomPattern(model.getMode());
+					}
+				}
 			}
 //			playinfo.pattern = pattern.toArray(new PatternModifyLog[pattern.size()]);
+			playinfo.laneShufflePattern = patternArray;
 
 		}
 
@@ -909,6 +919,7 @@ public class BMSPlayer extends MainState {
 		replay.date = Calendar.getInstance().getTimeInMillis() / 1000;
 		replay.keylog = main.getInputProcessor().getKeyInputLog();
 //		replay.pattern = playinfo.pattern;
+		replay.laneShufflePattern = playinfo.laneShufflePattern;
 		replay.rand = playinfo.rand;
 		replay.gauge = config.getGauge();
 		replay.sevenToNinePattern = config.getSevenToNinePattern();

--- a/src/bms/player/beatoraja/skin/SkinProperty.java
+++ b/src/bms/player/beatoraja/skin/SkinProperty.java
@@ -507,6 +507,25 @@ public class SkinProperty {
 	public static final int NUMBER_RANKING1_CLEAR = 390;
 	public static final int NUMBER_RANKING10_CLEAR = 399;
 
+	public static final int NUMBER_RANDOM_1P_1KEY = 450;
+	public static final int NUMBER_RANDOM_1P_2KEY = 451;
+	public static final int NUMBER_RANDOM_1P_3KEY = 452;
+	public static final int NUMBER_RANDOM_1P_4KEY = 453;
+	public static final int NUMBER_RANDOM_1P_5KEY = 454;
+	public static final int NUMBER_RANDOM_1P_6KEY = 455;
+	public static final int NUMBER_RANDOM_1P_7KEY = 456;
+	public static final int NUMBER_RANDOM_1P_8KEY = 457;
+	public static final int NUMBER_RANDOM_1P_9KEY = 458;
+	public static final int NUMBER_RANDOM_1P_SCR = 459;
+	public static final int NUMBER_RANDOM_2P_1KEY = 460;
+	public static final int NUMBER_RANDOM_2P_2KEY = 461;
+	public static final int NUMBER_RANDOM_2P_3KEY = 462;
+	public static final int NUMBER_RANDOM_2P_4KEY = 463;
+	public static final int NUMBER_RANDOM_2P_5KEY = 464;
+	public static final int NUMBER_RANDOM_2P_6KEY = 465;
+	public static final int NUMBER_RANDOM_2P_7KEY = 466;
+	public static final int NUMBER_RANDOM_2P_SCR = 469;
+
 	
 	public static final int VALUE_JUDGE_1P_DURATION = 525;
 	public static final int VALUE_JUDGE_2P_DURATION = 526;

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -5,6 +5,8 @@ import static bms.player.beatoraja.skin.SkinProperty.*;
 import java.util.Arrays;
 import java.util.Calendar;
 
+import bms.model.Mode;
+import bms.player.beatoraja.pattern.Random;
 import com.badlogic.gdx.Gdx;
 
 import bms.model.BMSModel;
@@ -1200,6 +1202,25 @@ public class IntegerPropertyFactory {
 		cleartype_ranking8(397, createRankinCleartypeProperty(7)),
 		cleartype_ranking9(398, createRankinCleartypeProperty(8)),
 		cleartype_ranking10(399, createRankinCleartypeProperty(9)),
+		pattern_1p_1(450, getAssignedLane(0, false)),
+		pattern_1p_2(451, getAssignedLane(1, false)),
+		pattern_1p_3(452, getAssignedLane(2, false)),
+		pattern_1p_4(453, getAssignedLane(3, false)),
+		pattern_1p_5(454, getAssignedLane(4, false)),
+		pattern_1p_6(455, getAssignedLane(5, false)),
+		pattern_1p_7(456, getAssignedLane(6, false)),
+		pattern_1p_8(457, getAssignedLane(7, false)),
+		pattern_1p_9(458, getAssignedLane(8, false)),
+		pattern_1p_SCR(459, getAssignedLane(-1, false)),
+		pattern_2p_1(460, getAssignedLane(0, true)),
+		pattern_2p_2(461, getAssignedLane(1, true)),
+		pattern_2p_3(462, getAssignedLane(2, true)),
+		pattern_2p_4(463, getAssignedLane(3, true)),
+		pattern_2p_5(464, getAssignedLane(4, true)),
+		pattern_2p_6(465, getAssignedLane(5, true)),
+		pattern_2p_7(466, getAssignedLane(6, true)),
+		pattern_2p_SCR(469, getAssignedLane(-1, true)),
+
 		
 		// 旧仕様
 		assist_constant(BUTTON_ASSIST_CONSTANT, (state) -> (state.resource.getPlayerConfig().getScrollMode() == 1 ? 1 : 0)),
@@ -1235,6 +1256,49 @@ public class IntegerPropertyFactory {
 				}
 				IRScoreData score = irc != null ? irc.getScore(index + rankingOffset) : null;
 				return score != null ? score.clear.id : Integer.MIN_VALUE;
+			};
+		}
+
+		/**
+		 * ランダムオプションで割り当てられたレーンを返す
+		 */
+		private static IntegerProperty getAssignedLane(int key, boolean is2PSide){
+			return (state) -> {
+				PlayerConfig pc = state.resource.getPlayerConfig();
+				Random type = Random.getRandom(is2PSide? pc.getRandom2(): pc.getRandom());
+
+				switch (type){
+					case RANDOM:
+					case R_RANDOM:
+					case CROSS:
+					case RANDOM_EX:
+						break;
+					default:
+						return 0;
+				}
+
+				Mode mode = state.resource.getBMSModel().getMode();
+				if(mode.player == 1 && is2PSide){
+					return 0;
+				}
+				int keyNum = mode.key / mode.player;
+
+				int index;
+				if(key >= keyNum) {
+					return 0;
+				} else if(key == -1){ // scratch
+					if (mode.scratchKey.length == 0){ // no scratch
+						return 0;
+					}
+					index = mode.scratchKey[0];
+				} else {
+					index = key;
+				}
+				int[] pattern = state.resource.getReplayData().laneShufflePattern[is2PSide? 1 : 0];
+				if (pattern == null){
+					return 0;
+				}
+				return pattern[index] + 1 - (is2PSide? keyNum: 0);
 			};
 		}
 	}

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1287,7 +1287,7 @@ public class IntegerPropertyFactory {
 				if(key >= keyNum) {
 					return 0;
 				} else if(key == -1){ // scratch
-					if (mode.scratchKey.length == 0){ // no scratch
+					if (mode.scratchKey.length == 0 || type != Random.RANDOM_EX){ // no scratch
 						return 0;
 					}
 					index = mode.scratchKey[0];


### PR DESCRIPTION
*English version is below*

## 要約
新機能の追加: リザルトでランダムの配置が見られるようにする

## 目的
- issue: #766 

本家IIDXのライトニングモデルのプレミアムエリアでできるように、レーンを入れ替えるタイプのランダムオプションが選択されたとき、リザルト画面にランダムの配置を表示する。

## 変更 
- `LaneShuffleModifier` classにランダムの配置を取得する`int[] getRandomPattern()`メソッドを追加
- `ReplayData` classにメンバ変数`int[] laneShufflePattern`を追加して、リザルト遷移時にランダム配置を保持させる
-  ランダムで何のレーンが割り当てられたかを返すIndexTypeのSkinPropertyを追加 (op番号は適当に450~469を割り当てました)

---
(English version)
## summary
Add feature: Visualize random lane pattern in result screen

## purpose
- issue: #766 

As in premium area of IIDX Lightning model, show the random pattern in result screen when random option (which swaps lanes) is used.

## changes

- Add `int[] getRandomPattern` method to `LaneShuffleModifier` class
- Add variable `int[] laneShufflePattern` to `ReplayData` class to refer random pattern while result screen
- Add SkinProperty of `IndexType` which returns which lane is assigned to each key (I assigned op no. 450~469 to them for a moment)