### PR TITLE
Use parallelStream() to process directories when updating song data

### DIFF
--- a/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
+++ b/src/bms/player/beatoraja/song/SQLiteSongDatabaseAccessor.java
@@ -371,7 +371,7 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 					qr.update(conn, "DELETE FROM song WHERE " + dsql.toString(), param);					
 				}
 				
-				Arrays.stream(paths).parallel().forEach((p) -> {
+				Arrays.asList(paths).parallelStream().forEach((p) -> {
 					try {
 						BMSFolder folder = new BMSFolder(p, bmsroot);
 						folder.processDirectory(property);
@@ -465,7 +465,7 @@ public class SQLiteSongDatabaseAccessor extends SQLiteDatabaseAccessor implement
 			}
 			
 			if(!containsBMS) {
-				dirs.forEach((bf) -> {
+				dirs.parallelStream().forEach((bf) -> {
 					try {
 						bf.processDirectory(property);
 					} catch (IOException | SQLException | IllegalArgumentException | ReflectiveOperationException | IntrospectionException e) {


### PR DESCRIPTION
When a single new BMS path is added in the launcher the directories under that path are not currently processed in parallel, resulting in slow (sometimes multiple hour long) process times. This uses a parallel stream instead of a regular stream to iterate over recursive directories and files under the added path instead of processing them sequentially.

This reopens #569, critically using the slightly faster parallelStream() interface of List over the slower stream.parallel().

I am aware that there had appeared to have been an issue resulting in the closure of #569:
> I've tried to implement same code, but it sometimes causes OutOfMemoryError. (Maybe too much threads)

_Originally posted by @exch-bms2 in https://github.com/exch-bms2/beatoraja/issues/569#issuecomment-724024485_

However after having multiple people test this change I cannot seem to get anyone to replicate the OutOfMemoryError exception. If @exch-bms2 encounters this again I would love to know if this wasn't a product of low available system memory, low JVM heap memory (under 4G) or a peculiar directory setup (symlinks, massive flat directory structure etc)

With this change users have reported massively reduced processing times (over 50x on some configurations)