### PR TITLE
Support 0.8.6 IR jars without breaking backwards compatibility

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -167,11 +167,21 @@ public class MainController {
 			if(ir != null) {
 				if(irconfig.getUserid().length() == 0 || irconfig.getPassword().length() == 0) {
 				} else {
-					IRResponse<IRPlayerData> response = ir.login(new IRAccount(irconfig.getUserid(), irconfig.getPassword(), ""));
-					if(response.isSucceeded()) {
-						irarray.add(new IRStatus(irconfig, ir, response.getData()));
-					} else {
-						Logger.getGlobal().warning("IRへのログイン失敗 : " + response.getMessage());
+					try {
+						IRResponse<IRPlayerData> response = ir.login(new IRAccount(irconfig.getUserid(), irconfig.getPassword(), ""));
+						if(response.isSucceeded()) {
+							irarray.add(new IRStatus(irconfig, ir, response.getData()));
+						} else {
+							Logger.getGlobal().warning("IRへのログイン失敗 : " + response.getMessage());
+						}
+					} catch (IllegalArgumentException e) {
+						Logger.getGlobal().info("trying pre-0.8.6 IR login method");
+						IRResponse<IRPlayerData> response = ir.login(irconfig.getUserid(), irconfig.getPassword());
+						if(response.isSucceeded()) {
+							irarray.add(new IRStatus(irconfig, ir, response.getData()));
+						} else {
+							Logger.getGlobal().warning("IRへのログイン失敗 : " + response.getMessage());
+						}
 					}
 				}
 			}

--- a/src/bms/player/beatoraja/ir/IRConnection.java
+++ b/src/bms/player/beatoraja/ir/IRConnection.java
@@ -14,7 +14,13 @@ public interface IRConnection {
 	 *            アカウント情報
 	 * @return
 	 */
-	public IRResponse<IRPlayerData> register(IRAccount account);
+	default public IRResponse<IRPlayerData> register(IRAccount account)  {
+		throw new IllegalArgumentException("Use of this function with this signature without providing an implementation is not permitted");
+	};
+
+	default public IRResponse<IRPlayerData> register(String id, String pass, String name)  {
+		throw new IllegalArgumentException("Use of this function with this signature without providing an implementation is not permitted");
+	};
 
 	/**
 	 * IRにログインする。起動時に呼び出される
@@ -23,7 +29,12 @@ public interface IRConnection {
 	 *            アカウント情報
 	 * @return
 	 */
-	public IRResponse<IRPlayerData> login(IRAccount account);
+	default public IRResponse<IRPlayerData> login(IRAccount account)  {
+		throw new IllegalArgumentException("Use of this function with this signature without providing an implementation is not permitted");
+	};
+	default public IRResponse<IRPlayerData> login(String id, String pass)  {
+		throw new IllegalArgumentException("Use of this function with this signature without providing an implementation is not permitted");
+	};
 
 	/**
 	 * ライバルデータを収録する


### PR DESCRIPTION
When version 0.8.6 was released it was not mentioned anywhere that this would break compatibility with IR jars from previous versions, resulting in a crash with no feedback as to what went wrong. This adds backwards compatibility for pre-0.8.6 IR jars as nothing has actually changed between the two versions except the method signatures and the inclusion of a wrapper object IR login can try the 0.8.6 login method before softly falling back to the pre-0.8.6 case in MainController without needing to break any existing behaviour.