### PR TITLE
Fix for the corrupted preview music playback

### DIFF
--- a/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
+++ b/src/bms/player/beatoraja/select/PreviewMusicProcessor.java
@@ -77,6 +77,7 @@ public class PreviewMusicProcessor {
 
         public void run() {
             audio.play(defaultMusic, config.getAudioConfig().getSystemvolume(), true);
+            playing = defaultMusic;
             currentVolume = config.getAudioConfig().getSystemvolume();
             while(!stop) {
                 if(!commands.isEmpty()) {


### PR DESCRIPTION
-The PreviewMusicProcessor class manages the playback of the song select menu music and the preview music.
-The very first instance of the defaultMusic playback that is scheduled at the start of the thread is not tracked.
-When using random menu bgm selection, skins without much animations and fast PCs, this can result in the PreviewThread not processing any requests and going straight to exit.
-At exit, the thread tries to stop the playback of a currently tracked music, but since the first playback is untracked, it fails to be stopped, resulting in overlaying BGM playback if you have random BGM selection.
-Fixed by making this first playback schedule trackable.