### PR TITLE
Add noGapX to remove width gaps in note graphs

### DIFF
--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -45,9 +45,9 @@ public class PracticeConfiguration {
 	private PracticeProperty property = new PracticeProperty();
 
 	private SkinNoteDistributionGraph[] graph = { 
-			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_NORMAL, 500, 0, 0, 0),
-			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_JUDGE, 500, 0, 0, 0),
-			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_EARLYLATE, 500, 0, 0, 0),
+			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_NORMAL, 500, 0, 0, 0, 0),
+			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_JUDGE, 500, 0, 0, 0, 0),
+			new SkinNoteDistributionGraph(SkinNoteDistributionGraph.TYPE_EARLYLATE, 500, 0, 0, 0, 0),
 	};
 	
 	private static final String[] GRAPHTYPE = {"NOTETYPE", "JUDGE", "EARLYLATE"};

--- a/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -391,7 +391,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 				for (int j = 0, k = n[0], index = 0; j < max && index < n.length;) {
 					if (k > 0) {
 						k--;
-						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4, 4 + (isNoGap ? 1 : 0));
+						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGap ? 1 : 0), 4 + (isNoGap ? 1 : 0));
 						j++;
 					} else {
 						index++;
@@ -405,7 +405,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 				for (int j = 0, k = n[n.length - 1], index = n.length - 1; j < max && index < n.length;) {
 					if (k > 0) {
 						k--;
-						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4, 4 + (isNoGap ? 1 : 0));
+						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGap ? 1 : 0), 4 + (isNoGap ? 1 : 0));
 						j++;
 					} else {
 						index--;

--- a/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -67,6 +67,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 	private int delay = 500;
 	private boolean isOrderReverse = false;
 	private boolean isNoGap = false;
+	private boolean isNoGapX = false;
 
 	/*
 	 * 処理済みノート数 プレイ時は処理済みノート数に変化があった時だけ更新する
@@ -82,20 +83,21 @@ public class SkinNoteDistributionGraph extends SkinObject {
 	private static final Color TRANSPARENT_COLOR = Color.valueOf("00000000");
 
 	public SkinNoteDistributionGraph() {
-		this(TYPE_NORMAL, 500, 0, 0, 0);
+		this(TYPE_NORMAL, 500, 0, 0, 0, 0);
 	}
 
-	public SkinNoteDistributionGraph(int type, int delay, int backTexOff, int orderReverse, int noGap) {
-		this(null, type, delay, backTexOff, orderReverse, noGap);
+	public SkinNoteDistributionGraph(int type, int delay, int backTexOff, int orderReverse, int noGap, int noGapX) {
+		this(null, type, delay, backTexOff, orderReverse, noGap, noGapX);
 	}
 	
-	public SkinNoteDistributionGraph(Pixmap[] chips, int type, int delay, int backTexOff, int orderReverse, int noGap) {
+	public SkinNoteDistributionGraph(Pixmap[] chips, int type, int delay, int backTexOff, int orderReverse, int noGap, int noGapX) {
 		this.chips = chips;
 		this.type = type;
 		this.isBackTexOff = backTexOff == 1;
 		this.delay = delay;
 		this.isOrderReverse = orderReverse == 1;
 		this.isNoGap = noGap == 1;
+		this.isNoGapX = noGapX == 1;
 		pastNotes = 0;
 	}
 	
@@ -391,7 +393,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 				for (int j = 0, k = n[0], index = 0; j < max && index < n.length;) {
 					if (k > 0) {
 						k--;
-						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGap ? 1 : 0), 4 + (isNoGap ? 1 : 0));
+						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGapX ? 1 : 0), 4 + (isNoGap ? 1 : 0));
 						j++;
 					} else {
 						index++;
@@ -405,7 +407,7 @@ public class SkinNoteDistributionGraph extends SkinObject {
 				for (int j = 0, k = n[n.length - 1], index = n.length - 1; j < max && index < n.length;) {
 					if (k > 0) {
 						k--;
-						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGap ? 1 : 0), 4 + (isNoGap ? 1 : 0));
+						shape.drawPixmap(chips[index], 0, 0, 1, 1, i * 5, j * 5, 4 + (isNoGapX ? 1 : 0), 4 + (isNoGap ? 1 : 0));
 						j++;
 					} else {
 						index--;

--- a/src/bms/player/beatoraja/skin/json/JsonSkin.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkin.java
@@ -232,6 +232,7 @@ public class JsonSkin {
 		public int delay = 500;
 		public int orderReverse = 0;
 		public int noGap = 0;
+		public int noGapX = 0;
 	}
 
 	public static class BPMGraph {

--- a/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
@@ -282,7 +282,7 @@ public abstract class JsonSkinObjectLoader<S extends Skin> {
 		}
 		for (JsonSkin.JudgeGraph ggraph : sk.judgegraph) {
 			if (dst.id.equals(ggraph.id)) {
-				SkinNoteDistributionGraph st = new SkinNoteDistributionGraph(ggraph.type, ggraph.delay, ggraph.backTexOff, ggraph.orderReverse, ggraph.noGap);
+				SkinNoteDistributionGraph st = new SkinNoteDistributionGraph(ggraph.type, ggraph.delay, ggraph.backTexOff, ggraph.orderReverse, ggraph.noGap, ggraph.noGapX);
 				obj = st;
 				break;
 			}

--- a/src/bms/player/beatoraja/skin/lr2/LR2CourseResultSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2CourseResultSkinLoader.java
@@ -68,7 +68,7 @@ enum CourseCommand implements LR2SkinLoader.Command<LR2CourseResultSkinLoader> {
 
         public void execute(LR2CourseResultSkinLoader loader, String[] str) {
             int[] values = loader.parseInt(str);
-            loader.noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18]);
+            loader.noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18], values[19]);
             loader.gauge = new Rectangle(0, 0, values[11], values[12]);
             loader.skin.add(loader.noteobj);
 

--- a/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2PlaySkinLoader.java
@@ -551,7 +551,7 @@ public class LR2PlaySkinLoader extends LR2SkinCSVLoader<PlaySkin> {
 			@Override
 			public void execute(String[] str) {
 				int[] values = parseInt(str);
-				noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18]);
+				noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18], values[19]);
 				gauge = new Rectangle(0, 0, values[11], values[12]);
 				skin.add(noteobj);
 			}

--- a/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2ResultSkinLoader.java
@@ -68,7 +68,7 @@ enum ResultCommand implements LR2SkinLoader.Command<LR2ResultSkinLoader> {
 
 		public void execute(LR2ResultSkinLoader loader, String[] str) {
 			int[] values = loader.parseInt(str);
-			loader.noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18]);
+			loader.noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18], values[19]);
 			loader.gauge = new Rectangle(0, 0, values[11], values[12]);
 			loader.skin.add(loader.noteobj);
 

--- a/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
+++ b/src/bms/player/beatoraja/skin/lr2/LR2SelectSkinLoader.java
@@ -461,7 +461,7 @@ public class LR2SelectSkinLoader extends LR2SkinCSVLoader<MusicSelectSkin> {
 			@Override
 			public void execute(String[] str) {
 				int[] values = parseInt(str);
-				noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18]);
+				noteobj = new SkinNoteDistributionGraph(values[1], values[15], values[16], values[17], values[18], values[19]);
 				gauge = new Rectangle(0, 0, values[11], values[12]);
 				skin.add(noteobj);
 			}


### PR DESCRIPTION
Remove measure gaps for cleaner notegraphs. These typically appear heavily aliased in skins.

Before:
![image](https://github.com/seraxis/lr2oraja-endlessdream/assets/87740032/f4699fcd-ced2-438f-8e4c-728a0bdf1783)
After:
![image](https://github.com/seraxis/lr2oraja-endlessdream/assets/87740032/94718620-f044-433d-a439-7b2acd763fb6)

Measures can still be distinguished by heights of different bars and colour within.