### PR TITLE
Fixed a problem where target options could not be referenced from rivals and IR

### DIFF
--- a/src/bms/player/beatoraja/play/TargetProperty.java
+++ b/src/bms/player/beatoraja/play/TargetProperty.java
@@ -2,6 +2,7 @@ package bms.player.beatoraja.play;
 
 import java.util.Arrays;
 
+import bms.player.beatoraja.ir.IRScoreData;
 import com.badlogic.gdx.utils.Array;
 
 import bms.player.beatoraja.MainController;
@@ -229,11 +230,14 @@ class RivalTargetProperty extends TargetProperty {
     		targetScore.setEpg(score.getEpg());
     		targetScore.setLpg(score.getLpg());
     		targetScore.setEgr(score.getEgr());
-    		targetScore.setLgr(score.getLgr());    		
+    		targetScore.setLgr(score.getLgr());
+			targetScore.setOption(score.getOption());
     	} else if(name != null) {
-    		targetScore.setPlayer("NO DATA");    		
+    		targetScore.setPlayer("NO DATA");
+			targetScore.setOption(0);
     	} else {
-    		targetScore.setPlayer("NO RIVAL");    		
+    		targetScore.setPlayer("NO RIVAL");
+			targetScore.setOption(0);
     	}
     	
         return targetScore;
@@ -364,18 +368,22 @@ class InternetRankingTargetProperty extends TargetProperty {
     	final RankingData ranking = main.getPlayerResource().getRankingData();
     	if(ranking == null) {
 			targetScore.setPlayer("NO DATA");
+			targetScore.setOption(0);
 			return targetScore;    		
     	}
     	
     	if(ranking.getState() == RankingData.FINISH) {
     		if(ranking.getTotalPlayer() > 0) {
-    			int index = getTargetRank(main, ranking);
-    			int targetscore = ranking.getScore(index).getExscore();
-    			targetScore.setPlayer(ranking.getScore(index).player.length() > 0 ? ranking.getScore(index).player : "YOU");
+    			final int index = getTargetRank(main, ranking);
+				final IRScoreData irScore = ranking.getScore(index);
+				final int targetscore = irScore.getExscore();
+    			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
         		targetScore.setEpg(targetscore / 2);
         		targetScore.setEgr(targetscore % 2);
+				targetScore.setOption(irScore.option);
     		} else {
-    			targetScore.setPlayer("NO DATA");    			
+    			targetScore.setPlayer("NO DATA");
+				targetScore.setOption(0);
     		}
     		return targetScore;
     	}
@@ -389,13 +397,16 @@ class InternetRankingTargetProperty extends TargetProperty {
 			}
 	    	if(ranking.getState() == RankingData.FINISH) {
 	    		if(ranking.getTotalPlayer() > 0) {
-	    			int index = getTargetRank(main, ranking);
-	    			int targetscore = ranking.getScore(index).getExscore();
-	    			targetScore.setPlayer(ranking.getScore(index).player.length() > 0 ? ranking.getScore(index).player : "YOU");
+	    			final int index = getTargetRank(main, ranking);
+					final IRScoreData irScore = ranking.getScore(index);
+					final int targetscore = irScore.getExscore();
+	    			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
 	        		targetScore.setEpg(targetscore / 2);
 	        		targetScore.setEgr(targetscore % 2);
+					targetScore.setOption(irScore.option);
 	    		} else {
-	    			targetScore.setPlayer("NO DATA");    			
+	    			targetScore.setPlayer("NO DATA");
+					targetScore.setOption(0);
 	    		}
 	    		
 				main.getCurrentState().getScoreDataProperty().updateTargetScore(targetScore.getExscore());	    		

--- a/src/bms/player/beatoraja/play/TargetProperty.java
+++ b/src/bms/player/beatoraja/play/TargetProperty.java
@@ -231,13 +231,13 @@ class RivalTargetProperty extends TargetProperty {
     		targetScore.setLpg(score.getLpg());
     		targetScore.setEgr(score.getEgr());
     		targetScore.setLgr(score.getLgr());
-			targetScore.setOption(score.getOption());
+    		targetScore.setOption(score.getOption());
     	} else if(name != null) {
     		targetScore.setPlayer("NO DATA");
-			targetScore.setOption(0);
+    		targetScore.setOption(0);
     	} else {
     		targetScore.setPlayer("NO RIVAL");
-			targetScore.setOption(0);
+    		targetScore.setOption(0);
     	}
     	
         return targetScore;
@@ -375,15 +375,15 @@ class InternetRankingTargetProperty extends TargetProperty {
     	if(ranking.getState() == RankingData.FINISH) {
     		if(ranking.getTotalPlayer() > 0) {
     			final int index = getTargetRank(main, ranking);
-				final IRScoreData irScore = ranking.getScore(index);
-				final int targetscore = irScore.getExscore();
+    			final IRScoreData irScore = ranking.getScore(index);
+    			final int targetscore = irScore.getExscore();
     			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
         		targetScore.setEpg(targetscore / 2);
         		targetScore.setEgr(targetscore % 2);
 				targetScore.setOption(irScore.option);
     		} else {
     			targetScore.setPlayer("NO DATA");
-				targetScore.setOption(0);
+    			targetScore.setOption(0);
     		}
     		return targetScore;
     	}
@@ -398,15 +398,15 @@ class InternetRankingTargetProperty extends TargetProperty {
 	    	if(ranking.getState() == RankingData.FINISH) {
 	    		if(ranking.getTotalPlayer() > 0) {
 	    			final int index = getTargetRank(main, ranking);
-					final IRScoreData irScore = ranking.getScore(index);
-					final int targetscore = irScore.getExscore();
+	    			final IRScoreData irScore = ranking.getScore(index);
+	    			final int targetscore = irScore.getExscore();
 	    			targetScore.setPlayer(irScore.player.length() > 0 ? irScore.player : "YOU");
 	        		targetScore.setEpg(targetscore / 2);
 	        		targetScore.setEgr(targetscore % 2);
-					targetScore.setOption(irScore.option);
+	    			targetScore.setOption(irScore.option);
 	    		} else {
 	    			targetScore.setPlayer("NO DATA");
-					targetScore.setOption(0);
+	    			targetScore.setOption(0);
 	    		}
 	    		
 				main.getCurrentState().getScoreDataProperty().updateTargetScore(targetScore.getExscore());	    		


### PR DESCRIPTION
ターゲットスコアがライバルまたはIR順位の場合、そのターゲットのランダム配置 (IndexType 61~63) の値が常に0になり、正常に取得できない問題を修正しました。

スコアが存在しない場合に設定される値0は `IDENTITY` (RANDOM OFF) と区別できませんが、対応するにせよしないにせよ、ここの変更で手を出す問題ではないと考えたため暫定的に0にしています。