### PR TITLE
Improved video loop performance

### DIFF
--- a/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -239,8 +239,7 @@ public class FFmpegProcessor implements MovieProcessor {
 		
 		private void restart() throws Exception {
 			pixmap = null;
-			grabber.restart();
-			grabber.grabImage();
+			grabber.setVideoFrameNumber(0);
 			eof = false;
 			offset = grabber.getTimestamp() - time * 1000;
 			framecount = 1;


### PR DESCRIPTION
動画のループ処理がリソースの開放と再取得を行っていたため、単純に先頭へシークするように変更し、パフォーマンスを改善しました。