### PR TITLE
Fixed compatibility issues with loop processing

### DIFF
--- a/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/FFmpegProcessor.java
@@ -239,7 +239,7 @@ public class FFmpegProcessor implements MovieProcessor {
 		
 		private void restart() throws Exception {
 			pixmap = null;
-			grabber.setVideoFrameNumber(0);
+			grabber.setFrameNumber(0);
 			eof = false;
 			offset = grabber.getTimestamp() - time * 1000;
 			framecount = 1;


### PR DESCRIPTION
PR #801 (Improved video loop performance) にて、現在プロジェクトで依存関係にあるJavaCV v1.3.3で利用できないメソッド `grabber.setVideoFrameNumber(int)` (v1.4.1から利用可能) を用いていたため、互換性のあるメソッド `setFrameNumber(int)` を用いるように修正しました。

v1.3.3と最新版v1.5.10では `setFrameNumber(int)` の実装が少し異なりますが、どちらでも動作することを確認しています。