### PR TITLE
fix controller availability in keyconfig and play state

### DIFF
--- a/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -120,6 +120,9 @@ public class KeyConfiguration extends MainState {
 		input = main.getInputProcessor();
 		keyboard = input.getKeyBoardInputProcesseor();
 		controllers = input.getBMInputProcessor();
+		for (BMControllerInputProcessor controller: controllers) {
+			controller.setEnable(true);
+		}
 		midiinput = input.getMidiInputProcessor();
 		setMode(0);
 	}

--- a/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
+++ b/src/bms/player/beatoraja/input/BMSPlayerInputProcessor.java
@@ -272,14 +272,7 @@ public class BMSPlayerInputProcessor {
 		
 		// 各デバイスにキーコンフィグをセット
 		kbinput.setConfig(playconfig.getKeyboardConfig());
-		for(int i = 0;i < bminput.length;i++) {
-			for(ControllerConfig controller : playconfig.getController()) {
-				if(bminput[i].getName().equals(controller.getName())) {
-					bminput[i].setConfig(controller);
-					break;
-				}
-			}
-		}
+		setControllerConfig(playconfig.getController());
 		midiinput.setConfig(playconfig.getMidiConfig());
 		
 		if(kbcount >= cocount && kbcount >= micount) {


### PR DESCRIPTION
## 問題  issue

選曲画面で読み込まれた`ControllerConfig`の状態がそのまま残っているので、キーコンフィグおよびプレイにおいてコントローラがdisabledのままになっている。
`PlayerConfig.musicselectinput`が`0`(iidx sp)か`1`(pop'n)のとき、選曲画面でコントローラが1つしかenabledにならないので、その状態でキーコンフィグ設定やDPをプレイをしようとすると、2つ目以降のコントローラの入力を受け付けなくなる。
`PlayerConfig.musicselectinput`が`2`(iidx dp)でも、選曲画面でコントローラが2つしかenabledにならないので、コントローラが3つ以上接続されている場合、3つ目以降のコントローラにキーを設定できない。

The availabilities of controllers set in music select are not properly cleared and remain in keyconfig and play.
When` PlayerConfig.musicselectinput` is `0` (iidx sp) or `1` (pop'n), only one controller is enabled in music select, thus the other controllers are ignored in keyconfig or DP play.
Even when `PlayerConfig.musicselectinput` is `2` (iidx dp), just two controllers are enabled in music select, so you cannot assign keys to third or later controllers.

## 変更 changes

- キーコンフィグは、`create()`ですべてのコントローラをenabledにする
- プレイは、選曲画面と同じように`setControllerConfig()`を使って有効化状態を設定するように置き換える

　

- enable all controllers in `KeyConfiguration.create()`
- replace loop block of controller configuration in `setPlayerConfig()` with `setControllerConfig()`, in `BMSPlayerInputProcessor`

