### PR TITLE
fix problem that IR target is not set when random select is used

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -8,6 +8,9 @@ import java.nio.file.Path;
 import java.util.*;
 import java.util.logging.Logger;
 
+import bms.player.beatoraja.ir.RankingData;
+import bms.player.beatoraja.ir.RankingDataCache;
+import bms.player.beatoraja.song.SongData;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.FloatArray;
 
@@ -469,6 +472,16 @@ public class BMSPlayer extends MainState {
 			practice.create(model, main.getConfig());
 			state = STATE_PRACTICE;
 		} else {
+			if(main.getIRStatus().length > 0) {
+				SongData sd = resource.getSongdata();
+				RankingDataCache rankingCache = main.getRankingDataCache();
+				RankingData ranking = rankingCache.get(sd, config.getLnmode());
+				if (ranking == null) {
+					ranking = new RankingData();
+					rankingCache.put(sd, config.getLnmode(), ranking);
+				}
+				resource.setRankingData(ranking);
+			}
 			
 			if(resource.getRivalScoreData() == null || resource.getCourseBMSModels() != null) {
 				ScoreData targetScore = TargetProperty.getTargetProperty(config.getTargetid()).getTarget(main);

--- a/src/bms/player/beatoraja/select/MusicSelector.java
+++ b/src/bms/player/beatoraja/select/MusicSelector.java
@@ -288,14 +288,7 @@ public class MusicSelector extends MainState {
 								}
 							}
 						}
-						
-						if(main.getIRStatus().length > 0 && currentir == null) {
-							currentir = new RankingData();
-							main.getRankingDataCache().put(song, config.getLnmode(), currentir);
-						}
-						resource.setRankingData(currentir);
-						resource.setRivalScoreData(current.getRivalScore());
-						
+
 						playedsong = song;
 						main.changeState(MainStateType.DECIDE);
 					} else {
@@ -501,15 +494,6 @@ public class MusicSelector extends MainState {
 				currentir = new RankingData();
 				main.getRankingDataCache().put(gradeBar.getCourseData(), config.getLnmode(), currentir);
 			}
-			
-			RankingData songrank = main.getRankingDataCache().get(songs[0], config.getLnmode());
-			if(main.getIRStatus().length > 0 && songrank == null) {
-				songrank = new RankingData();
-				main.getRankingDataCache().put(songs[0], config.getLnmode(), songrank);
-			}
-			resource.setRankingData(songrank);
-			resource.setRivalScoreData(null);
-
 			main.changeState(MainStateType.DECIDE);
 			return true;
 		}


### PR DESCRIPTION
## issue

ランダムセレクトで選曲すると、`setRankingData() `が呼ばれないため、その前にプレイした曲の`RankingData`が参照され、IRターゲットのグラフがおかしくなる(起動後最初にランダムセレクトした場合は、ターゲットが表示されなくなる)

<img src="https://github.com/exch-bms2/beatoraja/assets/42915825/28243c32-5808-4d8e-967e-faf257514548" width="50%">

また、リザルトでIRにスコアが送信されると、`RankingDataCache`も上書きされる。

when you use random select, score graph of IR target does not work correctly, because `setRankingData()` is not called and`RankingData` of previous played song is referred. Also, `RankingDataCache` of previous song is overwritten when score is sent to IR.

## change

選曲決定時に呼ばれていた`setRankingData()` をプレイ開始前に呼ばれるように移動した。
move `setRankingData()` from `Musicselector` to `BMSPlayer` to ensure that `RankingData` is set before play.

## note
`MusicSelector`内の`setRivalScoreData()`を一緒に消したため、ライバルがセットされている状態でのターゲットグラフとランダムオプションがライバルのスコア依存ではなくなっています(ライバルの配置を使わなくなります)。
なので、ライバルの配置を引っ張ってくる実装については別途検討が必要です。

ライバルをセットしているとグラフとオプションが強制的にライバルのスコア依存になる仕様は混乱を招いている？ようなので、これは独立に決められた方がいいと個人的には思っていますが、判断はOwnerの方に任せます。

I also removed `setRivalScoreData()` in `MusicSelector`. This makes target graph and random option independent from rival's ScoreData (i.e. pattern of rival's score won't be used). Thus, the implementation of reusing rival's pattern needs to be reconsidered.

Since current implementation might be causing confusion, I personally think that target and option should be independent from rival's score, but I leave the desicion to the owner. 