### PR TITLE
fix some issues related to #LNMODE

### DIFF
--- a/src/bms/player/beatoraja/result/MusicResult.java
+++ b/src/bms/player/beatoraja/result/MusicResult.java
@@ -340,11 +340,12 @@ public class MusicResult extends AbstractResult {
 		int count = 0;
 		avgduration = newscore.getAvgjudge();
 		timingDistribution.init();
-		final int lanes = resource.getBMSModel().getMode().key;
-		for (TimeLine tl : resource.getBMSModel().getAllTimeLines()) {
+		BMSModel model = resource.getBMSModel();
+		final int lanes = model.getMode().key;
+		for (TimeLine tl : model.getAllTimeLines()) {
 			for (int i = 0; i < lanes; i++) {
 				Note n = tl.getNote(i);
-				if (n != null && !(resource.getBMSModel().getLntype() == BMSModel.LNTYPE_LONGNOTE
+				if (n != null && !((model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE))
 						&& n instanceof LongNote && ((LongNote) n).isEnd())) {
 					int state = n.getState();
 					int time = n.getPlayTime();

--- a/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
+++ b/src/bms/player/beatoraja/skin/SkinNoteDistributionGraph.java
@@ -260,6 +260,9 @@ public final class SkinNoteDistributionGraph extends SkinObject {
 		}
 
 		final Mode mode = model.getMode();
+		// #LNMODE is explicitly set to 1 (LN)
+		// or #LNMODE is undefined and getLntype (which reflects playconfig) is LN (0)
+		final boolean ignoreLNEnd = model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE);
 		for (TimeLine tl : model.getAllTimeLines()) {
 			final int index = tl.getTime() / 1000;
 			if(index >= data.length) {
@@ -289,8 +292,7 @@ public final class SkinNoteDistributionGraph extends SkinObject {
 								}
 								count++;
 							}
-							if((model.getLntype() == BMSModel.LNTYPE_LONGNOTE && n instanceof LongNote
-									&& ((LongNote) n).isEnd())) {
+							if((ignoreLNEnd && ((LongNote) n).isEnd())) {
 								data[index][mode.isScratchKey(i) ? 0 : 3]++;
 								data[index][mode.isScratchKey(i) ? 1 : 4]--;									
 							}
@@ -300,16 +302,14 @@ public final class SkinNoteDistributionGraph extends SkinObject {
 						}
 						break;
 					case TYPE_JUDGE:
-						if (n instanceof MineNote || (model.getLntype() == BMSModel.LNTYPE_LONGNOTE && n instanceof LongNote
-								&& ((LongNote) n).isEnd())) {
+						if (n instanceof MineNote || (ignoreLNEnd && n instanceof LongNote && ((LongNote) n).isEnd())) {
 							break;
 						}
 						data[index][st]++;
 						count++;
 						break;
 					case TYPE_EARLYLATE:
-						if (n instanceof MineNote || (model.getLntype() == BMSModel.LNTYPE_LONGNOTE && n instanceof LongNote
-						&& ((LongNote) n).isEnd())) {
+						if (n instanceof MineNote || (ignoreLNEnd && n instanceof LongNote && ((LongNote) n).isEnd())) {
 							break;
 						}
 						if (st <= 1) {

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1017,7 +1017,21 @@ public class IntegerPropertyFactory {
 		bpmguide(306, (state) -> (state.resource.getPlayerConfig().isBpmguide() ? 1 : 0)),
 
 		customjudge(301, (state) -> (state.resource.getPlayerConfig().isCustomJudge() ? 1 : 0)),
-		lnmode(308, (state) -> (state.resource.getPlayerConfig().getLnmode())),
+		lnmode(308, (state) -> {
+			if (state instanceof BMSPlayer || state instanceof MusicResult) {
+				SongData model = state.resource.getSongdata();
+				if (model.hasAnyLongNote() && !model.hasUndefinedLongNote()) { // #LNMODE defined
+					if (model.hasLongNote()) {
+						return 0;
+					} else if (model.hasChargeNote()) {
+						return 1;
+					} else {
+						return 2;
+					}
+				}
+			}
+			return state.resource.getPlayerConfig().getLnmode();
+		}),
 		notesdisplaytimingautoadjust(75, (state) -> (state.resource.getPlayerConfig().isNotesDisplayTimingAutoAdjust() ? 1 : 0)),
 		gaugeautoshift(78, (state) -> (state.resource.getPlayerConfig().getGaugeAutoShift())),
 		bottomshiftablegauge(341, (state) -> (state.resource.getPlayerConfig().getBottomShiftableGauge())),

--- a/src/bms/player/beatoraja/song/SongInformation.java
+++ b/src/bms/player/beatoraja/song/SongInformation.java
@@ -107,8 +107,8 @@ public class SongInformation implements Validatable {
 						}
 					}
 
-					if(!(model.getLntype() == BMSModel.LNTYPE_LONGNOTE && n instanceof LongNote
-							&& ((LongNote) n).isEnd())) {
+					if(!((model.getLnmode() == 1 || (model.getLnmode() == 0 && model.getLntype() == BMSModel.LNTYPE_LONGNOTE))
+							&& n instanceof LongNote && ((LongNote) n).isEnd())){
 						if (n instanceof NormalNote) {
 							data[tl.getTime() / 1000][model.getMode().isScratchKey(i) ? 2 : 5]++;
 							lanenotes[i][0]++;


### PR DESCRIPTION
## issue
Since #LNMODE definition in BMS file overrides player's LN mode option, there are some issues. 
- skin property provides playerconfig value regardless of #LNMODE 
- note distribution graph also refers playerconfig and draws a weird one like:
![example](https://github.com/exch-bms2/beatoraja/assets/42915825/6eca2695-567f-46da-8759-953a564cb323)

## changes
check `BMSModel.getLnmode()` or `SongData.has*Note()` to see whether #LNMODE is defined