### PR TITLE
fix stop play behavior in course mode

### DIFF
--- a/src/bms/player/beatoraja/play/BMSPlayer.java
+++ b/src/bms/player/beatoraja/play/BMSPlayer.java
@@ -837,7 +837,8 @@ public class BMSPlayer extends MainState {
 	public ScoreData createScoreData() {
 		final PlayerConfig config = resource.getPlayerConfig();
 		ScoreData score = judge.getScoreData();
-		if (score.getEpg() + score.getLpg() + score.getEgr() + score.getLgr() + score.getEgd() + score.getLgd() + score.getEbd() + score.getLbd() == 0) {
+		if (resource.getCourseBMSModels() == null
+				&& (score.getEpg() + score.getLpg() + score.getEgr() + score.getLgr() + score.getEgd() + score.getLgd() + score.getEbd() + score.getLbd() == 0)) {
 			return null;
 		}
 
@@ -934,8 +935,7 @@ public class BMSPlayer extends MainState {
 			return;
 		}
 		if (state != STATE_FINISHED && 
-				(judge.getPastNotes() == resource.getSongdata().getNotes() 
-				|| (judge.getJudgeCount(0) + judge.getJudgeCount(1) + judge.getJudgeCount(2) + judge.getJudgeCount(3) == 0)
+				(judge.getPastNotes() == resource.getSongdata().getNotes()
 				|| resource.getPlayMode().mode == BMSPlayerMode.Mode.AUTOPLAY)) {
 			state = STATE_FINISHED;
 			timer.setTimerOn(TIMER_FADEOUT);


### PR DESCRIPTION
## issue
コースモードで曲開始後1ノーツも処理せずにスタート+セレクト同時押しでプレイを停止すると、完走扱いになり、次の曲に進んでしまう。

when you press start and select button to quit without hitting any notes in course mode, it transits to `STATE_FINISHED` rather than `STATE_FAILED` and moves onto the next song.

## changes
- 1ノーツも処理せずに終了した場合`STATE_FAILED`になるようにする
- コースモードの時は1ノーツも処理していなくても`createScoreData()`が`null`を返却しないようにする
　
- make it transit to `STATE_FAILED` when quitting with no notes hit.
- make `createScoreData()` return non-null value in course mode even if no notes are hit