### PR TITLE
Fixed an issue where replay keyinputs were not being saved correctly

### DIFF
--- a/src/bms/player/beatoraja/ReplayData.java
+++ b/src/bms/player/beatoraja/ReplayData.java
@@ -86,6 +86,7 @@ public final class ReplayData implements Validatable {
 	public PlayConfig config;
 	
 	public void shrink() {
+		if (keylog.length == 0) return;
 		try {
 			ByteArrayOutputStream output = new ByteArrayOutputStream();
 			OutputStream base64 = Base64.getUrlEncoder().wrap(output);


### PR DESCRIPTION
一度のプレイ（リザルト）で複数のリプレイを保存する場合、1回目の後処理によって2回目以降にキー入力ログを正しく保存できなくなる問題を修正しました。