### PR TITLE
add skin Paformance counter only if debug on.

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -49,7 +49,7 @@ public class MainController {
 
 	private static final String VERSION = "beatoraja 0.8.7";
 
-	public static final boolean debug = true;
+	public static final boolean debug = false;
 	public static final int debugTextXpos = 600;
 
 	/**
@@ -470,7 +470,10 @@ public class MainController {
 					message.setLength(0);
 					message.append(String.format(f,"SkinObject")).append(" num // prepare cur/avg/max // draw cur/avg/max");
 					systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - 242);
-					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
+					var entrys = current.getSkin().pcntmap.entrySet().stream()
+						.sorted((e1,e2) -> e1.getKey().getSimpleName().compareTo(e2.getKey().getSimpleName()))
+						.toList();
+					for (Map.Entry<Class, long[]> e : entrys) {
 						message.setLength(0);
 						message.append(String.format(f,e.getKey().getSimpleName())).append(" ")
 						.append(e.getValue()[0]).append(" // ")

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -50,7 +50,7 @@ public class MainController {
 	private static final String VERSION = "beatoraja 0.8.7";
 
 	public static final boolean debug = false;
-	public static final int debugTextXpos = 600;
+	public static final int debugTextXpos = 10;
 
 	/**
 	 * 起動時間

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -49,7 +49,8 @@ public class MainController {
 
 	private static final String VERSION = "beatoraja 0.8.7";
 
-	public static final boolean debug = false;
+	public static final boolean debug = true;
+	public static final int debugTextXpos = 600;
 
 	/**
 	 * 起動時間
@@ -432,30 +433,47 @@ public class MainController {
 			sprite.begin();
 			systemfont.setColor(Color.CYAN);
 			message.setLength(0);
-			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), 10,
+			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), debugTextXpos,
 					config.getResolution().height - 2);
 			if(debug) {
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), 10,
+				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 26);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Total Memory Used(MB) ").append(Runtime.getRuntime().totalMemory() / (1024 * 1024)), 10,
+				systemfont.draw(sprite, message.append("Total Memory Used(MB) ").append(Runtime.getRuntime().totalMemory() / (1024 * 1024)), debugTextXpos,
 						config.getResolution().height - 50);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Total Free Memory(MB) ").append(Runtime.getRuntime().freeMemory() / (1024 * 1024)), 10,
+				systemfont.draw(sprite, message.append("Total Free Memory(MB) ").append(Runtime.getRuntime().freeMemory() / (1024 * 1024)), debugTextXpos,
 						config.getResolution().height - 74);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Max Sprite In Batch ").append(sprite.maxSpritesInBatch), 10,
+				systemfont.draw(sprite, message.append("Max Sprite In Batch ").append(sprite.maxSpritesInBatch), debugTextXpos,
 						config.getResolution().height - 98);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Skin Pixmap Resource Size ").append(SkinLoader.getResource().size()), 10,
+				systemfont.draw(sprite, message.append("Skin Pixmap Resource Size ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 122);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Stagefile Pixmap Resource Size ").append(selector.getStagefileResource().size()), 10,
+				systemfont.draw(sprite, message.append("Stagefile Pixmap Resource Size ").append(selector.getStagefileResource().size()), debugTextXpos,
 						config.getResolution().height - 146);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Banner Pixmap Resource Size ").append(selector.getBannerResource().size()), 10,
+				systemfont.draw(sprite, message.append("Banner Pixmap Resource Size ").append(selector.getBannerResource().size()), debugTextXpos,
 						config.getResolution().height - 170);
+						if (current.getSkin() != null) {
+					message.setLength(0);
+					systemfont.draw(sprite, message.append("Skin Prepare Time ").append(current.getSkin().pcntPrepare), debugTextXpos,
+							config.getResolution().height - 194);
+					message.setLength(0);
+					systemfont.draw(sprite, message.append("Skin Draw Time ").append(current.getSkin().pcntDraw), debugTextXpos,
+							config.getResolution().height - 218);
+					var i = 0;
+					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
+					var f = "%" + l + "s";
+					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
+						message.setLength(0);
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]/100).append(" / ").append(e.getValue()[1]/100);
+						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
+						i++;
+					}
+				}
 			}
 
 			sprite.end();

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -465,7 +465,7 @@ public class MainController {
 					systemfont.draw(sprite, message.append("Skin Draw Time ").append(current.getSkin().pcntDraw), debugTextXpos,
 							config.getResolution().height - 218);
 					var i = 0;
-					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
+					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().orElse(1);
 					var f = "%" + l + "s";
 					message.setLength(0);
 					message.append(String.format(f,"SkinObject")).append(" num // prepare cur/avg/max // draw cur/avg/max");

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -469,7 +469,7 @@ public class MainController {
 					var f = "%" + l + "s";
 					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
 						message.setLength(0);
-						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]/100).append(" / ").append(e.getValue()[1]/100);
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]).append(" / ").append(e.getValue()[1]/100);
 						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
 						i++;
 					}

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -467,10 +467,20 @@ public class MainController {
 					var i = 0;
 					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
 					var f = "%" + l + "s";
+					message.setLength(0);
+					message.append(String.format(f,"SkinObject")).append(" num // prepare cur/avg/max // draw cur/avg/max");
+					systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - 242);
 					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
 						message.setLength(0);
-						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]).append(" / ").append(e.getValue()[1]/100);
-						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ")
+						.append(e.getValue()[0]).append(" // ")
+						.append(e.getValue()[1]/100).append(" / ")
+						.append(e.getValue()[2]/10000).append(" / ")
+						.append(e.getValue()[3]/100).append(" // ")
+						.append(e.getValue()[4]/100).append(" / ")
+						.append(e.getValue()[5]/10000).append(" / ")
+						.append(e.getValue()[6]/100);
+						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (266 + i * 24));
 						i++;
 					}
 				}

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -435,7 +435,7 @@ public class MainController {
 			message.setLength(0);
 			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), debugTextXpos,
 					config.getResolution().height - 2);
-			if(debug) {
+					if(debug) {
 				message.setLength(0);
 				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 26);
@@ -475,10 +475,10 @@ public class MainController {
 						message.append(String.format(f,e.getKey().getSimpleName())).append(" ")
 						.append(e.getValue()[0]).append(" // ")
 						.append(e.getValue()[1]/100).append(" / ")
-						.append(e.getValue()[2]/10000).append(" / ")
+						.append(e.getValue()[2]/100000).append(" / ")
 						.append(e.getValue()[3]/100).append(" // ")
 						.append(e.getValue()[4]/100).append(" / ")
-						.append(e.getValue()[5]/10000).append(" / ")
+						.append(e.getValue()[5]/100000).append(" / ")
 						.append(e.getValue()[6]/100);
 						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (266 + i * 24));
 						i++;

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -226,9 +226,9 @@ public class Skin {
 			}
 			tempmap.forEach((k,v)-> {
 				pcntmap.put(k, Arrays.copyOf(v, 7));
-				Queue<Long> q1 = new ArrayDeque<>(110);
-				Queue<Long> q2 = new ArrayDeque<>(110);
-				for (int i = 0; i < 100; i++) {
+				Queue<Long> q1 = new ArrayDeque<>(1010);
+				Queue<Long> q2 = new ArrayDeque<>(1010);
+				for (int i = 0; i < 1000; i++) {
 					q1.add(0L);
 					q2.add(0L);
 				}


### PR DESCRIPTION
デバッグ時の情報テキストの位置をpublic static finalで定義ました。
デバッグ時のみ、F1で表示される情報にスキン描画パフォーマンスカウンタを追加しました。
skinObjectのサブクラス毎にPrepare, Drawで分けて0.1μs単位で計測しています。
7つの数字は左から、オブジェクト数、Prepare時間、移動平均、最大、Draw時間、移動平均、最大
