### PR TITLE
SkinTimingVisualizerの描画パフォーマンスを改善した

### DIFF
--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -49,7 +49,8 @@ public class MainController {
 
 	private static final String VERSION = "beatoraja 0.8.7";
 
-	public static final boolean debug = false;
+	public static final boolean debug = true;
+	public static final int debugTextXpos = 600;
 
 	/**
 	 * 起動時間
@@ -432,30 +433,47 @@ public class MainController {
 			sprite.begin();
 			systemfont.setColor(Color.CYAN);
 			message.setLength(0);
-			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), 10,
+			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), debugTextXpos,
 					config.getResolution().height - 2);
 			if(debug) {
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), 10,
+				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 26);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Total Memory Used(MB) ").append(Runtime.getRuntime().totalMemory() / (1024 * 1024)), 10,
+				systemfont.draw(sprite, message.append("Total Memory Used(MB) ").append(Runtime.getRuntime().totalMemory() / (1024 * 1024)), debugTextXpos,
 						config.getResolution().height - 50);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Total Free Memory(MB) ").append(Runtime.getRuntime().freeMemory() / (1024 * 1024)), 10,
+				systemfont.draw(sprite, message.append("Total Free Memory(MB) ").append(Runtime.getRuntime().freeMemory() / (1024 * 1024)), debugTextXpos,
 						config.getResolution().height - 74);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Max Sprite In Batch ").append(sprite.maxSpritesInBatch), 10,
+				systemfont.draw(sprite, message.append("Max Sprite In Batch ").append(sprite.maxSpritesInBatch), debugTextXpos,
 						config.getResolution().height - 98);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Skin Pixmap Resource Size ").append(SkinLoader.getResource().size()), 10,
+				systemfont.draw(sprite, message.append("Skin Pixmap Resource Size ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 122);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Stagefile Pixmap Resource Size ").append(selector.getStagefileResource().size()), 10,
+				systemfont.draw(sprite, message.append("Stagefile Pixmap Resource Size ").append(selector.getStagefileResource().size()), debugTextXpos,
 						config.getResolution().height - 146);
 				message.setLength(0);
-				systemfont.draw(sprite, message.append("Banner Pixmap Resource Size ").append(selector.getBannerResource().size()), 10,
+				systemfont.draw(sprite, message.append("Banner Pixmap Resource Size ").append(selector.getBannerResource().size()), debugTextXpos,
 						config.getResolution().height - 170);
+						if (current.getSkin() != null) {
+					message.setLength(0);
+					systemfont.draw(sprite, message.append("Skin Prepare Time ").append(current.getSkin().pcntPrepare), debugTextXpos,
+							config.getResolution().height - 194);
+					message.setLength(0);
+					systemfont.draw(sprite, message.append("Skin Draw Time ").append(current.getSkin().pcntDraw), debugTextXpos,
+							config.getResolution().height - 218);
+					var i = 0;
+					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
+					var f = "%" + l + "s";
+					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
+						message.setLength(0);
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]/100).append(" / ").append(e.getValue()[1]/100);
+						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
+						i++;
+					}
+				}
 			}
 
 			sprite.end();

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -465,7 +465,7 @@ public class MainController {
 					systemfont.draw(sprite, message.append("Skin Draw Time ").append(current.getSkin().pcntDraw), debugTextXpos,
 							config.getResolution().height - 218);
 					var i = 0;
-					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
+					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().orElse(1);
 					var f = "%" + l + "s";
 					message.setLength(0);
 					message.append(String.format(f,"SkinObject")).append(" num // prepare cur/avg/max // draw cur/avg/max");

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -469,7 +469,7 @@ public class MainController {
 					var f = "%" + l + "s";
 					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
 						message.setLength(0);
-						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]/100).append(" / ").append(e.getValue()[1]/100);
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]).append(" / ").append(e.getValue()[1]/100);
 						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
 						i++;
 					}

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -467,10 +467,20 @@ public class MainController {
 					var i = 0;
 					var l = current.getSkin().pcntmap.keySet().stream().mapToInt(c->c.getSimpleName().length()).max().getAsInt();
 					var f = "%" + l + "s";
+					message.setLength(0);
+					message.append(String.format(f,"SkinObject")).append(" num // prepare cur/avg/max // draw cur/avg/max");
+					systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - 242);
 					for (Map.Entry<Class, long[]> e : current.getSkin().pcntmap.entrySet()) {
 						message.setLength(0);
-						message.append(String.format(f,e.getKey().getSimpleName())).append(" ").append(e.getValue()[0]).append(" / ").append(e.getValue()[1]/100);
-						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (242 + i * 24));
+						message.append(String.format(f,e.getKey().getSimpleName())).append(" ")
+						.append(e.getValue()[0]).append(" // ")
+						.append(e.getValue()[1]/100).append(" / ")
+						.append(e.getValue()[2]/10000).append(" / ")
+						.append(e.getValue()[3]/100).append(" // ")
+						.append(e.getValue()[4]/100).append(" / ")
+						.append(e.getValue()[5]/10000).append(" / ")
+						.append(e.getValue()[6]/100);
+						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (266 + i * 24));
 						i++;
 					}
 				}

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -435,7 +435,7 @@ public class MainController {
 			message.setLength(0);
 			systemfont.draw(sprite, message.append("FPS ").append(Gdx.graphics.getFramesPerSecond()), debugTextXpos,
 					config.getResolution().height - 2);
-			if(debug) {
+					if(debug) {
 				message.setLength(0);
 				systemfont.draw(sprite, message.append("Skin Pixmap Images ").append(SkinLoader.getResource().size()), debugTextXpos,
 						config.getResolution().height - 26);
@@ -475,10 +475,10 @@ public class MainController {
 						message.append(String.format(f,e.getKey().getSimpleName())).append(" ")
 						.append(e.getValue()[0]).append(" // ")
 						.append(e.getValue()[1]/100).append(" / ")
-						.append(e.getValue()[2]/10000).append(" / ")
+						.append(e.getValue()[2]/100000).append(" / ")
 						.append(e.getValue()[3]/100).append(" // ")
 						.append(e.getValue()[4]/100).append(" / ")
-						.append(e.getValue()[5]/10000).append(" / ")
+						.append(e.getValue()[5]/100000).append(" / ")
 						.append(e.getValue()[6]/100);
 						systemfont.draw(sprite, message, debugTextXpos, config.getResolution().height - (266 + i * 24));
 						i++;

--- a/src/bms/player/beatoraja/skin/Skin.java
+++ b/src/bms/player/beatoraja/skin/Skin.java
@@ -226,9 +226,9 @@ public class Skin {
 			}
 			tempmap.forEach((k,v)-> {
 				pcntmap.put(k, Arrays.copyOf(v, 7));
-				Queue<Long> q1 = new ArrayDeque<>(110);
-				Queue<Long> q2 = new ArrayDeque<>(110);
-				for (int i = 0; i < 100; i++) {
+				Queue<Long> q1 = new ArrayDeque<>(1010);
+				Queue<Long> q2 = new ArrayDeque<>(1010);
+				for (int i = 0; i < 1000; i++) {
 					q1.add(0L);
 					q2.add(0L);
 				}

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -18,10 +18,9 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
  */
 public final class SkinTimingVisualizer extends SkinObject {
 
-	// TODO 各Textureを1枚にまとめてblBindTextureの回数を削減する
-	private TextureRegion backtex = null;
-	private TextureRegion shapetex = null;
-	private Pixmap shape = null;
+	private TextureRegion backtex;
+	private TextureRegion line;
+	private Color[] lineColors;
 
 	private Color[] JColor;
 	/**
@@ -37,15 +36,12 @@ public final class SkinTimingVisualizer extends SkinObject {
 	 * 判定履歴表示用ラインの幅
 	 */
 	private final int lineWidth;
-	private final int width;
 	private final int center;
 	private final float judgeWidthRate;
 	private final boolean drawDecay;
 	
 	private BMSModel model;
 	private int[][] judgeArea;
-
-	private int currentindex = -1;
 	
 	private int index;
 	private long[] recent;
@@ -63,7 +59,6 @@ public final class SkinTimingVisualizer extends SkinObject {
 			int transparent, int drawDecay) {
 
 		this.lineWidth = MathUtils.clamp(lineWidth, 1, 4);
-		this.width = width;
 		this.center = judgeWidthMillis;
 		this.judgeWidthRate = width / (float) (judgeWidthMillis * 2 + 1);
 		this.lineColor = Color.valueOf(colorStringValidation(lineColor));
@@ -85,20 +80,16 @@ public final class SkinTimingVisualizer extends SkinObject {
 		}
 		super.prepare(time, state);
 		final PlayerResource resource = state.resource;
-		if(resource.getBMSModel() != model) {
-			model = resource.getBMSModel();
-			judgeArea = getJudgeArea(resource);			
-		}
-		
 		index = ((BMSPlayer)state).getJudgeManager().getRecentJudgesIndex();
 		recent = ((BMSPlayer)state).getJudgeManager().getRecentJudges();
-	}
-	
-	public void draw(SkinObjectRenderer sprite) {
-		// 背景テクスチャ生成
-		if (backtex == null) {
+
+		if(resource.getBMSModel() != model) {
+			model = resource.getBMSModel();
+			judgeArea = getJudgeArea(resource);	
+
+			// BMSModel毎に背景テクスチャ生成
 			int pwidth = center * 2 + 1;
-			shape = new Pixmap(pwidth, 1, Pixmap.Format.RGBA8888);
+			var shape = new Pixmap(pwidth, 1, Pixmap.Format.RGBA8888);
 
 			int beforex1 = center;
 			int beforex2 = center + 1;
@@ -119,53 +110,43 @@ public final class SkinTimingVisualizer extends SkinObject {
 					beforex2 = x2;
 				}
 			}
-			
+
 			shape.setColor(0f, 0f, 0f, 0.25f);
-			for(int x = center % 10;x < pwidth;x += 10) {
+			for (int x = center % 10; x < pwidth; x += 10) {
 				shape.drawLine(x, 0, x, 1);
 			}
 
 			backtex = new TextureRegion(new Texture(shape));
 			shape.dispose();
-			shape = null;
+
 		}
 
-		if (shape == null) {
-			shape = new Pixmap(width, recent.length * 2, Pixmap.Format.RGBA8888);
-		}
-
-		if(currentindex != index) {
-			currentindex = index;
-			// 前景テクスチャ 透明色でフィルして初期化
-			shape.setColor(Color.CLEAR);
-			shape.fill();
-
+		if(line == null) {
+			var pix = new Pixmap(lineWidth, 1, Pixmap.Format.RGBA8888);
+			pix.setColor(Color.WHITE);
+			pix.fill();
+			line = new TextureRegion(new Texture(pix));
+			lineColors = new Color[recent.length];
 			for (int i = 0; i < recent.length; i++) {
-				int j = i + index + 1;
-				if (recent[j % recent.length] == Long.MIN_VALUE) {
-					continue;
-				}
+				lineColors[i] = new Color(lineColor.r, lineColor.g, lineColor.b, lineColor.a / 100 * (i + 1));
+			}
+			pix.dispose();
+		}
+	}
+	
+	public void draw(SkinObjectRenderer sprite) {
 
-				shape.setColor(
-						Color.rgba8888(lineColor.r, lineColor.g, lineColor.b, (lineColor.a * i / (1.0f * recent.length))));
-				int x = (width - lineWidth) / 2
-						+ (int) (MathUtils.clamp(recent[j % recent.length], -center, center) * judgeWidthRate);
-				if (drawDecay) {
-					shape.fillRectangle(x, recent.length - i, lineWidth, i * 2);
+		draw(sprite, backtex);
+		for (int i = 0; i < recent.length; i++) {
+			int j = (index + i + 1) % recent.length;
+			if (-center <= recent[j] && recent[j] <= center) {
+				if(drawDecay) {
+					draw(sprite, line, region.x + (region.width - lineWidth) / 2 + recent[j] * judgeWidthRate, region.y + region.height * (recent.length - i) / recent.length / 2, lineWidth, region.height * i / recent.length, lineColors[i], 0);
 				} else {
-					shape.fillRectangle(x, 0, lineWidth, recent.length * 2);
+					draw(sprite, line, region.x + (region.width - lineWidth) / 2 + recent[j] * judgeWidthRate, region.y, lineWidth, region.height, lineColors[i], 0);
 				}
 			}
 		}
-
-		if (shapetex == null) {
-			shapetex = new TextureRegion(new Texture(shape));
-		} else {
-			shapetex.getTexture().draw(shape, 0, 0);
-		}
-
-		draw(sprite, backtex);
-		draw(sprite, shapetex);
 	}
 
 	static int[][] getJudgeArea(PlayerResource resource) {
@@ -192,8 +173,7 @@ public final class SkinTimingVisualizer extends SkinObject {
 	@Override
 	public void dispose() {
 		Optional.ofNullable(backtex).ifPresent(t -> t.getTexture().dispose());
-		Optional.ofNullable(shapetex).ifPresent(t -> t.getTexture().dispose());
-		Optional.ofNullable(shape).ifPresent(Pixmap::dispose);
+		Optional.ofNullable(line).ifPresent(t -> t.getTexture().dispose());
 	}
 
 	/**

--- a/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
+++ b/src/bms/player/beatoraja/skin/SkinTimingVisualizer.java
@@ -16,7 +16,7 @@ import bms.player.beatoraja.skin.Skin.SkinObjectRenderer;
  *
  * @author keh
  */
-public class SkinTimingVisualizer extends SkinObject {
+public final class SkinTimingVisualizer extends SkinObject {
 
 	// TODO 各Textureを1枚にまとめてblBindTextureの回数を削減する
 	private TextureRegion backtex = null;


### PR DESCRIPTION
今まではdrawが呼ばれるたびにPixmapからTextureを生成していたため、それがオーバーヘッドとなっていた。
判定位置表示ラインのTextureをあらかじめ生成し、SkinObject#drawでラインを描画することで描画パフォーマンスを向上させた。
TextureRegion数に変化なし。