### PR TITLE
Supported property to get constant option status with MusicSelector

### DIFF
--- a/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -654,7 +654,18 @@ public class BooleanPropertyFactory {
 		trophy_option_exsrandom(OPTION_CLEAR_EXSRANDOM, new TrophyDrawCondition(SongTrophy.EX_S_RANDOM)),
 
 		constant(OPTION_CONSTANT, new DrawProperty(DrawProperty.TYPE_NO_STATIC,
-				(state) -> ((state instanceof BMSPlayer) ? ((BMSPlayer) state).getLanerender().getPlayConfig().isEnableConstant() : false))),
+				(state -> {
+					if (state instanceof MusicSelector selector) {
+						final PlayConfig playConfig = selector.getSelectedBarPlayConfig();
+						if (playConfig != null) {
+							return playConfig.isEnableConstant();
+						}
+					} else if (state instanceof BMSPlayer player) {
+						return player.getLanerender().getPlayConfig().isEnableConstant();
+					}
+					return false;
+				})
+		)),
 
 		;
 		/**

--- a/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/IntegerPropertyFactory.java
@@ -1281,6 +1281,19 @@ public class IntegerPropertyFactory {
 		cleartype_ranking8(397, createRankinCleartypeProperty(7)),
 		cleartype_ranking9(398, createRankinCleartypeProperty(8)),
 		cleartype_ranking10(399, createRankinCleartypeProperty(9)),
+
+		constant(400, (state) -> {
+			if (state instanceof MusicSelector selector) {
+				final PlayConfig playConfig = selector.getSelectedBarPlayConfig();
+				if (playConfig != null) {
+					return playConfig.isEnableConstant() ? 1 : 0;
+				}
+			} else if (state instanceof BMSPlayer player) {
+				return player.getLanerender().getPlayConfig().isEnableConstant() ? 1 : 0;
+			}
+			return -1;
+		}),
+
 		pattern_1p_1(450, getAssignedLane(0, false)),
 		pattern_1p_2(451, getAssignedLane(1, false)),
 		pattern_1p_3(452, getAssignedLane(2, false)),


### PR DESCRIPTION
CONSTANTオプションのオンオフ状態取得がプレイ画面 (BMSPlayer) でのOPTIONプロパティのみだったため、以下の変更を行いました。

- option(400) を選曲画面で利用可能にした
- event_index(400) を追加した

event_indexは他のプレイオプション同様、0がOFFで1がONです。使用例として、状態を表示しつつクリックで状態を切り替える画像ボタンは以下のようにして定義できます：

```lua
{ id = "constant", src = "options", x = 2000, y = 500, w = 150, h = 70, divy = 2, len = 2, ref = 400, act = 400 }
```