### PR TITLE
Fixed problem where CONSTANT could not be referenced when initializing the PLAY skin

### DIFF
--- a/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
+++ b/src/bms/player/beatoraja/skin/property/BooleanPropertyFactory.java
@@ -661,7 +661,7 @@ public class BooleanPropertyFactory {
 							return playConfig.isEnableConstant();
 						}
 					} else if (state instanceof BMSPlayer player) {
-						return player.getLanerender().getPlayConfig().isEnableConstant();
+						return player.resource.getPlayerConfig().getPlayConfig(player.getMode()).getPlayconfig().isEnableConstant();
 					}
 					return false;
 				})


### PR DESCRIPTION
PLAYスキンの初期化時（ロード時）に `OPTON_CONSTANT` を参照できない問題を修正しました。

同様に初期化段階だと参照できないスキンプロパティが幾つかありますが、一括で対応するならスキンをロードするタイミングを変更する解決策が有力であること、またその解決策を採用する場合は慎重な動作確認が必要なことから、今回は一旦0.8.8新規オプションの `OPTION_CONSTANT` のみの修正となっています。