### PR TITLE
同時発音数のデフォルトを修正

### DIFF
--- a/src/bms/player/beatoraja/AudioConfig.java
+++ b/src/bms/player/beatoraja/AudioConfig.java
@@ -25,7 +25,7 @@ public class AudioConfig implements Validatable {
 	/**
 	 * オーディオ同時発音数
 	 */
-	private int deviceSimultaneousSources = 128;
+	private int deviceSimultaneousSources = 256;
 	/**
 	 * オーディオサンプリングレート(0:指定なし)
 	 */


### PR DESCRIPTION
デフォルト128だと発音できないBMSが増えてきたのでデフォルト値を修正