### PR TITLE
fix Y direction misalignment of notes with offset H

### DIFF
--- a/src/bms/player/beatoraja/play/LaneRenderer.java
+++ b/src/bms/player/beatoraja/play/LaneRenderer.java
@@ -489,7 +489,7 @@ public class LaneRenderer {
 				if (note != null) {
 					//4分のタイミングでノートを拡大する
 					float dstx = lanes[lane].region.x + offsetX;
-					float dsty = (float) y + offsetY - offsetH / 2;
+					float dsty = (float) y + offsetY;
 					float dstw = lanes[lane].region.width + offsetW;
 					float dsth = scale + offsetH;
 					if(skin.getNoteExpansionRate()[0] != 100 || skin.getNoteExpansionRate()[1] != 100) {


### PR DESCRIPTION
ノーツのoffset Hが設定されているとき、ノーツがその中心を基準に拡大縮小される(Y座標が`-offsetH / 2`だけずらされる)ので、小節線と揃わなくなっているが、特にノーツの中心を基準にする必要がないように思われるので、ノーツの下端を基準とするように戻したい。
 
Previously, notes are scaled around its center when offset H is set (i.e., Y value is offset by `-offsetH / 2`, cf. https://github.com/exch-bms2/beatoraja/commit/3f181341a48607153181e7974f6f77049875f058 ), causing misalignment with measure line (cf. #788)
- #788

There would be no reason to do that, this simply removes the offset to resolve the issue.