### PR TITLE
PracticeConfiguration: Add BM controls for practice mode

### DIFF
--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -37,7 +37,6 @@ public final class PracticeConfiguration {
 	private BitmapFont titlefont;
 
 	private int cursorpos = 0;
-	private long presscount = 0;
 
 	private BMSModel model;
 
@@ -64,7 +63,10 @@ public final class PracticeConfiguration {
 
 	public static final PracticeElement[] elements = PracticeElement.values();
 
+	private PracticeModeControls controls = new PracticeModeControls();
+
 	public void create(BMSModel model, Config config) {
+		controls.initialize(config);
 		property.judgerank = model.getJudgerank();
 		property.endtime = model.getLastTime() + 1000;
 		Path p = Paths.get("practice/" + model.getSHA256() + ".json");
@@ -125,52 +127,66 @@ public final class PracticeConfiguration {
 	}
 	
 	public void processInput(BMSPlayerInputProcessor input) {
-		if (input.isControlKeyPressed(ControlKeys.UP)) {
+		controls.readInput(input, model.getMode());
+		boolean turbo = controls.getInputTurbo();
+
+		int yTicks = controls.extractYTicks();
+		while (yTicks > 0) {
+			do {
+			cursorpos = (cursorpos + 1) % elements.length;
+			} while(!elements[cursorpos].optionAvailable.test(this));
+			--yTicks;
+		}
+		while (yTicks < 0) {
 			do {
 				cursorpos = (cursorpos + elements.length - 1) % elements.length;
-			} while(!elements[cursorpos].predicate.test(this));
+			} while(!elements[cursorpos].optionAvailable.test(this));
+			++yTicks;
 		}
-		if (input.isControlKeyPressed(ControlKeys.DOWN)) {
-			do {
-				cursorpos = (cursorpos + 1) % elements.length;
-			} while(!elements[cursorpos].predicate.test(this));
-		}
-		if (input.getControlKeyState(ControlKeys.LEFT) && (presscount == 0 || presscount + 10 < System.currentTimeMillis())) {
-			if (presscount == 0) {
-				presscount = System.currentTimeMillis() + 500;
-			} else {
-				presscount = System.currentTimeMillis();
+
+		int nonAnalogXTicks = controls.extractNonAnalogXTicks();
+		if (nonAnalogXTicks != 0) {
+			boolean inc = nonAnalogXTicks > 0;
+			nonAnalogXTicks = Math.abs(nonAnalogXTicks);
+			for (int i = 0; i < nonAnalogXTicks ; ++i) {
+				elements[cursorpos].action.run(this, inc, false, turbo);
 			}
-			elements[cursorpos].action.accept(this, false);
-		} else if (input.getControlKeyState(ControlKeys.RIGHT) && (presscount == 0 || presscount + 10 < System.currentTimeMillis())) {
-			if (presscount == 0) {
-				presscount = System.currentTimeMillis() + 500;
-			} else {
-				presscount = System.currentTimeMillis();
+		} 
+		int analogXTicks = controls.extractAnalogXTicks(elements[cursorpos].useFineAnalogTicks);
+		if (analogXTicks != 0) {
+			boolean inc = analogXTicks > 0;
+			analogXTicks = Math.abs(analogXTicks);
+			for (int i = 0; i < analogXTicks ; ++i) {
+				elements[cursorpos].action.run(this, inc, true, turbo);
 			}
-			elements[cursorpos].action.accept(this, true);
-		} else if (!(input.getControlKeyState(ControlKeys.LEFT) || input.getControlKeyState(ControlKeys.RIGHT))) {
-			presscount = 0;
 		}
 	}
 
 	public void draw(Rectangle r, SkinObjectRenderer sprite, long time, MainState state) {
+		final Color unfocusedColor = (controls != null && controls.isHorizontalMode()) ? Color.GRAY : Color.CYAN;
+		final Color focusedColor = (controls != null && controls.getInputTurbo()) ? Color.ORANGE : Color.YELLOW;
+		final int ySpacing = 22;
 		float x = r.x + r.width / 8;
 		float y = r.y + r.height * 7 / 8;
 		if(titlefont != null) {
 			for(int i = 0;i < elements.length;i++) {
-				if(elements[i].predicate.test(this)) {
-					sprite.draw(titlefont, elements[i].text.apply(property), x, y - 22 * i, cursorpos == i ? Color.YELLOW : Color.CYAN);
+				if(elements[i].optionAvailable.test(this)) {
+					sprite.draw(titlefont, elements[i].text.apply(property), x, y - ySpacing * i, cursorpos == i ? focusedColor : unfocusedColor);
 				}
 			}
 
-			if (state.resource.mediaLoadFinished()) {
-				sprite.draw(titlefont, "PRESS 1KEY TO PLAY", x, y - 276, Color.ORANGE);
+			if (model.getMode() == Mode.POPN_9K) {
+				sprite.draw(titlefont, "KEYS: 2,8=UP, 3,7=DOWN, 4=LEFT, 6=RIGHT, 5=TURBO", x, y - ySpacing*12 - 12, Color.ORANGE);
+			} else {
+				sprite.draw(titlefont, "KEYS: SCR=UP/DOWN, 2+SCR=LEFT/RIGHT, 4=TURBO", x, y - ySpacing*12 - 12, Color.ORANGE);
 			}
-			
+			if (state.resource.mediaLoadFinished()) {
+				sprite.draw(titlefont, "PRESS 1KEY TO PLAY", x, y - ySpacing*13 - 12, Color.ORANGE);
+			}
+
 			String[] judge = {"PGREAT :","GREAT  :","GOOD   :", "BAD    :", "POOR   :", "KPOOR  :"};
 			for(int i = 0; i < 6; i++) {
-				sprite.draw(titlefont, String.format("%s %d %d %d",judge[i], state.getJudgeCount(i, true) + state.getJudgeCount(i, false), state.getJudgeCount(i, true), state.getJudgeCount(i, false)), x + 250, y - (i * 22), Color.WHITE);
+				sprite.draw(titlefont, String.format("%s %d %d %d",judge[i], state.getJudgeCount(i, true) + state.getJudgeCount(i, false), state.getJudgeCount(i, true), state.getJudgeCount(i, false)), x + 250, y - (i * ySpacing), Color.WHITE);
 			}			
 		}
 
@@ -185,100 +201,313 @@ public final class PracticeConfiguration {
 		}
 	}
 
+	private final class PracticeModeControls {
+		private boolean inputUp;
+		private boolean inputDown;
+		private boolean inputTurbo;
+		private boolean inputLeft;
+		private boolean inputRight;
+
+		private long nextHoldTick;
+		private int nonAnalogYTicks;
+		private int nonAnalogXTicks;
+
+		private boolean turntableHorizontalModePrev;
+
+		private int inputXAnalogAmount;
+		private int inputYAnalogAmount;
+
+		private int scrollDurationLow;
+		private int scrollDurationHigh;
+		private int analogTicksPerScroll;
+
+		public void initialize(Config config) {
+	        scrollDurationLow = config.getScrollDurationLow();
+	        scrollDurationHigh = config.getScrollDurationHigh();
+        	analogTicksPerScroll = config.getAnalogTicksPerScroll();
+	    }
+
+		public void readInput(BMSPlayerInputProcessor input, Mode mode) {
+			final boolean inputUpPrev = inputUp;
+			final boolean inputDownPrev = inputDown;
+			final boolean inputLeftPrev = inputLeft;
+			final boolean inputRightPrev = inputRight;
+
+			if (mode == Mode.POPN_9K) {
+				//  1 3 5 7
+				// 0 2 4 6 8
+				inputUp = input.getControlKeyState(ControlKeys.UP) || input.getKeyState(1) || input.getKeyState(7);
+				inputDown = input.getControlKeyState(ControlKeys.DOWN) || input.getKeyState(2) || input.getKeyState(6);
+				inputLeft = input.getControlKeyState(ControlKeys.LEFT) || input.getKeyState(3);
+				inputRight = input.getControlKeyState(ControlKeys.RIGHT) || input.getKeyState(5);
+				inputTurbo = input.getKeyState(4);
+				inputXAnalogAmount = 0;
+				inputYAnalogAmount = 0;
+			} else {
+				//  1 3 5
+				// 0 2 4 6
+				inputUp = input.getControlKeyState(ControlKeys.UP);
+				inputDown = input.getControlKeyState(ControlKeys.DOWN);
+				inputLeft = input.getControlKeyState(ControlKeys.LEFT);
+				inputRight = input.getControlKeyState(ControlKeys.RIGHT);
+				inputTurbo = input.getKeyState(3);
+				boolean turntableHorizontalMode = input.getKeyState(1) || inputTurbo;
+
+				int turntableUpIndex1 = -1;
+				int turntableDownIndex1 = -1;
+				int turntableUpIndex2 = -1;
+				int turntableDownIndex2 = -1;
+				switch (mode) {
+					case BEAT_5K: {
+						turntableUpIndex1 = 6;
+						turntableDownIndex1 = 5;
+						break;
+					}
+					case BEAT_7K: {
+						turntableUpIndex1 = 8;
+						turntableDownIndex1 = 7;
+						break;
+					}
+					case BEAT_10K: {
+						turntableUpIndex1 = 6;
+						turntableDownIndex1 = 5;
+						turntableUpIndex2 = 13;
+						turntableDownIndex2 = 12;
+						break;
+					}
+					case BEAT_14K: {
+						turntableUpIndex1 = 8;
+						turntableDownIndex1 = 7;
+						turntableUpIndex2 = 17;
+						turntableDownIndex2 = 16;
+						break;
+					}
+					case KEYBOARD_24K: {
+						turntableUpIndex1 = 25;
+						turntableDownIndex1 = 24;
+						break;
+					}
+					case KEYBOARD_24K_DOUBLE: {
+						turntableUpIndex1 = 25;
+						turntableDownIndex1 = 24;
+						turntableUpIndex2 = 51;
+						turntableDownIndex2 = 50;
+						break;
+					}
+				}
+				final boolean resetAnalogInput = (turntableHorizontalMode != turntableHorizontalModePrev);
+				if (resetAnalogInput) {
+					inputXAnalogAmount = 0;
+					inputYAnalogAmount = 0;
+					turntableHorizontalModePrev = turntableHorizontalMode;
+				}
+				processTurntableInput(input, turntableUpIndex1, true, turntableHorizontalMode, resetAnalogInput);
+				processTurntableInput(input, turntableDownIndex1, false, turntableHorizontalMode, resetAnalogInput);
+				processTurntableInput(input, turntableUpIndex2, true, turntableHorizontalMode, resetAnalogInput);
+				processTurntableInput(input, turntableDownIndex2, false, turntableHorizontalMode, resetAnalogInput);
+			}
+
+			if (inputUpPrev != inputUp || inputDownPrev != inputDown || inputLeftPrev != inputLeft || inputRightPrev != inputRight) {
+				nextHoldTick = 0;
+			}
+			if (inputUp || inputDown || inputLeft || inputRight) {
+				long currentTimeMillis = System.currentTimeMillis();
+				if (nextHoldTick <= currentTimeMillis) {
+					if (nextHoldTick == 0) {
+						nextHoldTick = currentTimeMillis + scrollDurationLow;
+					} else {
+						nextHoldTick = currentTimeMillis + scrollDurationHigh;
+					}
+					if (inputRight) nonAnalogXTicks += 1;
+					else if (inputLeft) nonAnalogXTicks -= 1;
+					else if (inputDown) nonAnalogYTicks += 1;
+					else if (inputUp) nonAnalogYTicks -= 1;
+				}
+			}
+		}
+
+		private void processTurntableInput(BMSPlayerInputProcessor input, int index, boolean scratchUp, boolean turntableHorizontalMode, boolean resetAnalogInput) {
+			if (index == -1) return;
+			if (input.isAnalogInput(index)) {
+				if (resetAnalogInput) {
+					input.resetAnalogInput(index);
+				}
+				int analogDiff = input.getAnalogDiffAndReset(index, 200);
+				if (turntableHorizontalMode) {
+					inputXAnalogAmount += (scratchUp ? analogDiff : -analogDiff);
+				} else {
+					inputYAnalogAmount += (scratchUp ? -analogDiff : analogDiff);
+				}
+			} else {
+				if (turntableHorizontalMode) {
+					if (scratchUp) {
+						inputRight = inputRight || input.getKeyState(index);
+					} else {
+						inputLeft = inputLeft || input.getKeyState(index);
+					}
+				} else {
+					if (scratchUp) {
+						inputUp = inputUp || input.getKeyState(index);
+					} else {
+						inputDown = inputDown || input.getKeyState(index);
+					}
+				}
+			}
+		}
+
+		public int extractAnalogXTicks(boolean useFineAnalogTicks) {
+			int ticksPerScroll = useFineAnalogTicks ? 1 : analogTicksPerScroll;
+			int actualTicks = controls.inputXAnalogAmount / ticksPerScroll;
+			controls.inputXAnalogAmount %= ticksPerScroll; // Note: -15 % 12 = -3
+			return actualTicks;
+		}
+
+		public int extractNonAnalogXTicks() {
+			int actualTicks = nonAnalogXTicks;
+			nonAnalogXTicks = 0;
+			return actualTicks;
+		}
+
+		public int extractYTicks() {
+			int actualTicks = controls.inputYAnalogAmount / analogTicksPerScroll;
+			controls.inputYAnalogAmount %= analogTicksPerScroll; // Note: -15 % 12 = -3
+			actualTicks += nonAnalogYTicks;
+			nonAnalogYTicks = 0;
+			return actualTicks;
+		}
+
+		public boolean getInputTurbo() {
+			return inputTurbo;
+		}
+
+		public boolean isHorizontalMode() {
+			return turntableHorizontalModePrev;
+		}
+	}
+
+	private static int roundDownTo(int value, int base) {
+		return value/base*base;
+	}
+
+	@FunctionalInterface
+	interface PracticeAction {
+		void run(PracticeConfiguration practice, boolean inc, boolean isAnalog, boolean turboSpeed);
+	}
+
 	enum PracticeElement {
 
-		STARTTIME((practice, inc) -> {
+		STARTTIME((practice, inc, isAnalog, turboSpeed) -> {
 			final TimeLine[] tl = practice.model.getAllTimeLines();
 			final PracticeProperty property = practice.property;
-			if(inc) {
-				if (property.starttime + 2000 <= tl[tl.length - 1].getTime()) {
-					property.starttime += 100;
-				}
-				if (property.starttime + 900 >= property.endtime) {
-					property.endtime += 100;
-				}
+			final int maxStartTime = roundDownTo(tl[tl.length - 1].getTime() - 2000, 100);
+			final int minStartTime = 0;
+			int change = turboSpeed ? (isAnalog ? 1000 : 2500) : 100;
+			if (inc) {
+				property.starttime = Math.min(property.starttime + change, maxStartTime);
+				property.endtime = Math.max(property.endtime, property.starttime + 1000);
 			} else {
-				if (property.starttime >= 100) {
-					property.starttime -= 100;
-				}
+				property.starttime = Math.max(property.starttime - change, minStartTime);
 			}
-		}, property -> String.format("START TIME : %2d:%02d.%1d", property.starttime / 60000,
+		}, true, property -> String.format("START TIME : %2d:%02d.%1d", property.starttime / 60000,
 				(property.starttime / 1000) % 60, (property.starttime / 100) % 10)),
-		ENDTIME((practice, inc) -> {
+		ENDTIME((practice, inc, isAnalog, turboSpeed) -> {
 			final TimeLine[] tl = practice.model.getAllTimeLines();
 			final PracticeProperty property = practice.property;
-			if(inc) {
-				if (property.endtime <= tl[tl.length - 1].getTime() + 1000) {
-					property.endtime += 100;
-				}
+			final int maxEndTime = roundDownTo(tl[tl.length - 1].getTime() + 1000, 100);
+			final int minEndTime = roundDownTo(property.starttime + 1000, 100);
+			int change = turboSpeed ? (isAnalog ? 1000 : 2500) : 100;
+			if (inc) {
+				property.endtime = Math.min(property.endtime + change, maxEndTime);
 			} else {
-				if (property.endtime > property.starttime + 1000) {
-					property.endtime -= 100;
-				}
+				property.endtime = Math.max(property.endtime - change, minEndTime);
 			}
-		}, property -> String.format("END TIME : %2d:%02d.%1d", property.endtime / 60000,
+		}, true, property -> String.format("END TIME : %2d:%02d.%1d", property.endtime / 60000,
 				(property.endtime / 1000) % 60, (property.endtime / 100) % 10)),
-		GAUGETYPE((practice, inc) -> {
+		GAUGETYPE((practice, inc, isAnalog, turboSpeed) -> {
 			final PracticeProperty property = practice.property;
 			property.gaugetype = (property.gaugetype + (inc ? 1 : 8)) % 9;
 			if ((practice.model.getMode() == Mode.POPN_5K || practice.model.getMode() == Mode.POPN_9K) && property.gaugetype >= 3 && property.startgauge > 100) {
 				property.startgauge = 100;
 			}
-		}, property -> "GAUGE TYPE : " + GAUGE[property.gaugetype]),
-		GAUGECATEGORY((practice, inc) -> {
+		}, false, property -> "GAUGE TYPE : " + GAUGE[property.gaugetype]),
+		GAUGECATEGORY((practice, inc, isAnalog, turboSpeed) -> {
 			final PracticeProperty property = practice.property;
-			GaugeProperty[] cateories = GaugeProperty.values();
-			for(int i = 0;i < cateories.length;i++) {
-				if(property.gaugecategory == cateories[i]) {
-					property.gaugecategory = cateories[(i + (inc ? 1 : (cateories.length - 1))) % cateories.length];
+			GaugeProperty[] categories = GaugeProperty.values();
+			for(int i = 0;i < categories.length;i++) {
+				if(property.gaugecategory == categories[i]) {
+					property.gaugecategory = categories[(i + (inc ? 1 : (categories.length - 1))) % categories.length];
 					break;
 				}
 			}
 			property.startgauge = (int) property.gaugecategory.values[property.gaugetype].init;
-		}, property -> "GAUGE CATEGORY : " + property.gaugecategory.name()),
-		GAUGEVALUE((practice, inc) -> {
+		}, false, property -> "GAUGE CATEGORY : " + property.gaugecategory.name()),
+		GAUGEVALUE((practice, inc, isAnalog, turboSpeed) -> {
 			final PracticeProperty property = practice.property;
-			property.startgauge = MathUtils.clamp(property.startgauge + (inc ? 1 : -1), 1, (int)property.gaugecategory.values[property.gaugetype].max);
-		}, property -> "GAUGE VALUE : " + property.startgauge),
-		JUDGERANK((practice, inc) -> {
-			practice.property.judgerank = MathUtils.clamp(practice.property.judgerank + (inc ? 1 : -1), 1, 400);
-		}, property -> "JUDGERANK : " + property.judgerank),
-		TOTAL((practice, inc) -> {
-			practice.property.total = MathUtils.clamp(practice.property.total + (inc ? 10 : -10), 20, 5000);
-		}, property -> "TOTAL : " + (int)property.total),
-		FREQ((practice, inc) -> {
-			practice.property.freq = MathUtils.clamp(practice.property.freq + (inc ? 5 : -5), 50, 200);
-		}, property -> "FREQUENCY : " + property.freq),
-		GRAPHTYPE((practice, inc) -> {
+			int change = turboSpeed ? 10 : 1;
+			int maxValue = (int)property.gaugecategory.values[property.gaugetype].max;
+			if (inc && turboSpeed && property.startgauge == 1) {
+				property.startgauge = Math.min(change, maxValue);
+			} else {
+				property.startgauge = MathUtils.clamp(property.startgauge + (inc ? change : -change), 1, maxValue);
+			}
+		}, true, property -> "GAUGE VALUE : " + property.startgauge),
+		JUDGERANK((practice, inc, isAnalog, turboSpeed) -> {
+			final PracticeProperty property = practice.property;
+			int change = turboSpeed ? 25 : 1;
+			if (inc && turboSpeed && property.judgerank == 1) {
+				property.judgerank = Math.min(change, 400);
+			} else {
+				property.judgerank = MathUtils.clamp(property.judgerank + (inc ? change : -change), 1, 400);
+			}
+		}, true, property -> "JUDGERANK : " + property.judgerank),
+		TOTAL((practice, inc, isAnalog, turboSpeed) -> {
+			int change = turboSpeed ? 25 : 5;
+			if (isAnalog) {
+				change = turboSpeed ? 20 : 1;
+			}
+			practice.property.total = MathUtils.clamp(practice.property.total + (inc ? change : -change), 10, 5000);
+		}, true, property -> "TOTAL : " + (int)property.total),
+		FREQ((practice, inc, isAnalog, turboSpeed) -> {
+			int change = turboSpeed ? 25 : 5;
+			if (isAnalog) {
+				change = turboSpeed ? 10 : 1;
+			}
+			practice.property.freq = MathUtils.clamp(practice.property.freq + (inc ? change : -change), 50, 200);
+		}, true, property -> "FREQUENCY : " + property.freq),
+		GRAPHTYPE((practice, inc, isAnalog, turboSpeed) -> {
 			practice.property.graphtype = (practice.property.graphtype + (inc ? 1 : 2)) % 3;
-		}, property -> "GRAPHTYPE : " + GRAPHTYPESTR[property.graphtype]),
-		OPTION1P((practice, inc) -> {
+		}, false, property -> "GRAPHTYPE : " + GRAPHTYPESTR[property.graphtype]),
+		OPTION1P((practice, inc, isAnalog, turboSpeed) -> {
 			final int options = (practice.model.getMode() == Mode.POPN_5K || practice.model.getMode() == Mode.POPN_9K ? 7 : 10);
 			practice.property.random = (practice.property.random + (inc ? 1 : (options -1))) % options;
-		}, property -> "OPTION-1P : " + RANDOM[property.random]),
-		OPTION2P((practice, inc) -> {
+		}, false, property -> "OPTION-1P : " + RANDOM[property.random]),
+		OPTION2P((practice, inc, isAnalog, turboSpeed) -> {
 			practice.property.random2 = (practice.property.random2 + (inc ? 1 : 9)) % 10;
-		}, property -> "OPTION-2P : " + RANDOM[property.random2], practice -> practice.model.getMode().player == 2),
-		OPTIONDP((practice, inc) -> {
+		}, false, property -> "OPTION-2P : " + RANDOM[property.random2], practice -> practice.model.getMode().player == 2),
+		OPTIONDP((practice, inc, isAnalog, turboSpeed) -> {
 			practice.property.doubleop = (practice.property.doubleop + 1) % 2;
-		}, property -> "OPTION-DP : " + DPRANDOM[property.doubleop], practice -> practice.model.getMode().player == 2);
+		}, false, property -> "OPTION-DP : " + DPRANDOM[property.doubleop], practice -> practice.model.getMode().player == 2);
 
-		public final BiConsumer<PracticeConfiguration, Boolean> action;
+		public final PracticeAction action;
+
+		public final boolean useFineAnalogTicks;
 
 		public final Function<PracticeProperty, String> text;
 
-		public final Predicate<PracticeConfiguration> predicate;
+		public final Predicate<PracticeConfiguration> optionAvailable;
 
-		private PracticeElement(BiConsumer<PracticeConfiguration, Boolean> action, Function<PracticeProperty, String> text) {
-			this(action, text, property -> true);
+		private PracticeElement(PracticeAction action, boolean useFineAnalogTicks, Function<PracticeProperty, String> text) {
+			this(action, useFineAnalogTicks, text, property -> true);
 		}
 
-		private PracticeElement(BiConsumer<PracticeConfiguration, Boolean> action, Function<PracticeProperty, String> text, Predicate<PracticeConfiguration> predicate) {
+		private PracticeElement(PracticeAction action, boolean useFineAnalogTicks, Function<PracticeProperty, String> text, Predicate<PracticeConfiguration> optionAvailable) {
 			this.action = action;
+			this.useFineAnalogTicks = useFineAnalogTicks;
 			this.text = text;
-			this.predicate = predicate;
+			this.optionAvailable = optionAvailable;
 		}
 	}
+
 	/**
 	 * プラクティスの各種設定値
 	 *

--- a/src/bms/player/beatoraja/play/PracticeConfiguration.java
+++ b/src/bms/player/beatoraja/play/PracticeConfiguration.java
@@ -175,14 +175,29 @@ public final class PracticeConfiguration {
 				}
 			}
 
+			String helpLine1 = "";
+			String helpLine2 = "";
 			if (model.getMode() == Mode.POPN_9K) {
-				sprite.draw(titlefont, "KEYS: 2,8=UP, 3,7=DOWN, 4=LEFT, 6=RIGHT, 5=TURBO", x, y - ySpacing*12 - 12, Color.ORANGE);
+				helpLine1 = "KEYS: 2/8=UP, 3/7=DOWN, 4=LEFT, 6=RIGHT,";
+				helpLine2 = "5=TURBO";
+			} else if (model.getMode() == Mode.KEYBOARD_24K || model.getMode() == Mode.KEYBOARD_24K_DOUBLE) {
+				helpLine1 = "KEYS: F#1/A#1=UP, G1/A1=DOWN, F1=LEFT,";
+				helpLine2 = "B1=RIGHT, D#1/G#1=TURBO";
 			} else {
-				sprite.draw(titlefont, "KEYS: SCR=UP/DOWN, 2+SCR=LEFT/RIGHT, 4=TURBO", x, y - ySpacing*12 - 12, Color.ORANGE);
+				helpLine1 = "KEYS: SCR=UP/DOWN, 2+SCR=LEFT/RIGHT, 4=TURBO";
 			}
 			if (state.resource.mediaLoadFinished()) {
-				sprite.draw(titlefont, "PRESS 1KEY TO PLAY", x, y - ySpacing*13 - 12, Color.ORANGE);
+				if (helpLine2.length() > 0) {
+					helpLine2 += ". ";
+				}
+				if (model.getMode() == Mode.KEYBOARD_24K || model.getMode() == Mode.KEYBOARD_24K_DOUBLE) {
+					helpLine2 += "PRESS C1 TO PLAY";
+				} else {
+					helpLine2 += "PRESS 1KEY TO PLAY";
+				}
 			}
+			sprite.draw(titlefont, helpLine1, x, y - ySpacing*12 - 12, Color.ORANGE);
+			sprite.draw(titlefont, helpLine2, x, y - ySpacing*13 - 12, Color.ORANGE);
 
 			String[] judge = {"PGREAT :","GREAT  :","GOOD   :", "BAD    :", "POOR   :", "KPOOR  :"};
 			for(int i = 0; i < 6; i++) {
@@ -252,6 +267,31 @@ public final class PracticeConfiguration {
 				inputRight = input.getControlKeyState(ControlKeys.RIGHT);
 				inputTurbo = input.getKeyState(3);
 				boolean turntableHorizontalMode = input.getKeyState(1) || inputTurbo;
+
+				if (mode == Mode.BEAT_10K) {
+					//  1 3    8 10
+					// 0 2 4  7 9 11
+					inputUp = inputUp || input.getKeyState(8) || input.getKeyState(10);
+					inputDown = inputDown || input.getKeyState(9);
+					inputLeft = inputLeft || input.getKeyState(7);
+					inputRight = inputRight || input.getKeyState(11);
+				} else if (mode == Mode.BEAT_14K) {
+					//  1 3 5    10 12 14
+					// 0 2 4 6  9 11 13 15
+					inputUp = inputUp || input.getKeyState(10) || input.getKeyState(14);
+					inputDown = inputDown || input.getKeyState(11) || input.getKeyState(13);
+					inputLeft = inputLeft || input.getKeyState(9);
+					inputRight = inputRight || input.getKeyState(15);
+					inputTurbo = inputTurbo || input.getKeyState(12);
+				} else if (mode == Mode.KEYBOARD_24K || mode == Mode.KEYBOARD_24K_DOUBLE) {
+					//  1 3   6 8 10
+					// 0 2 4 5 7 9 11
+					inputUp = inputUp || input.getKeyState(6) || input.getKeyState(10);
+					inputDown = inputDown || input.getKeyState(7) || input.getKeyState(9);
+					inputLeft = inputLeft || input.getKeyState(5);
+					inputRight = inputRight || input.getKeyState(11);
+					inputTurbo = inputTurbo || input.getKeyState(8);
+				}
 
 				int turntableUpIndex1 = -1;
 				int turntableDownIndex1 = -1;


### PR DESCRIPTION
## Main Changes
This PR lets you control the practice mode menu using the turntable + keys.
- This works for both analog inputs (analog turntable) and non-analog inputs (non-analog turntable, popn controller, or kb controls).
- Arrow key controls to change practice mode settings are not affected. They can still be used like before.

Note that lane cover and green number adjustment are not affected as they can only be adjusted after starting the song.

### Turbo Button
This PR also adds a "Turbo" button (hold key 4) to speed up options controls. This is useful as changing the "Start time" or "End time" settings was previously very slow.
- Turbo works with controller, keyboard, and arrow key controls.

### Video
https://github.com/user-attachments/assets/54b03b0b-edaf-46ff-8d3c-aa79d07613d3

# Controls:
For all control schemes, **Key 1** starts the song (C1 for 24K/48K).

## 9KEYS:
- **Key 2/8**: Up
- **Key 3/7**: Down
- **Key 4**: Left
- **Key 6**: Right
- **Key 5**: Turbo

## 5KEYS / 7KEYS:
- **Turntable**: Up/Down
- **Key 2 + Turntable**: Left/Right
- **Key 4**: Turbo

## 10KEYS:
- **Turntable**: Up/Down
- **Key 2 + Turntable**: Left/Right
- **Key 4**: Turbo

Alternative Keys:
- **Key 7/9**: Up
- **Key 8**: Down
- **Key 6**: Left
- **Key 10**: Right

## 14KEYS:
- **Turntable**: Up/Down
- **Key 2 + Turntable**: Left/Right
- **Key 4**: Turbo

Alternative Keys:
- **Key 9/13**: Up
- **Key 10/12**: Down
- **Key 8**: Left
- **Key 14**: Right
- **Key 11**: Turbo

## 24KEYS / 48KEYS:
- **Wheel**: Up/Down
- **C#1 + Wheel**: Left/Right
- **D#1**: Turbo

Alternative Keys:
- **F#1/A#1**: Up
- **G1/A1**: Down
- **F1**: Left
- **B1**: Right
- **G#**: Turbo
