### PR TITLE
For Key Config screen, rename "2dx sp", "popn", "2dx dp" to "7 KEYS", "9 KEYS", "14 KEYS"

### DIFF
--- a/src/bms/player/beatoraja/config/KeyConfiguration.java
+++ b/src/bms/player/beatoraja/config/KeyConfiguration.java
@@ -67,7 +67,7 @@ public class KeyConfiguration extends MainState {
 					-2 } };
 	private static final int playerOffset = 100;
 
-	private static final String[] SELECTKEY = { "2dx sp", "popn", "2dx dp" };
+	private static final String[] SELECTKEY = { "7 KEYS", "9 KEYS", "14 KEYS" };
 
 	private int cursorpos = 0;
 	private int scrollpos = 0;
@@ -255,11 +255,11 @@ public class KeyConfiguration extends MainState {
 			titlefont.setColor(Color.CYAN);
 			titlefont.draw(sprite, "<-- " + MODE[mode] + " -->", 80 * scaleX, 650 * scaleY);
 			titlefont.setColor(Color.YELLOW);
-			titlefont.draw(sprite, "Key Board", 180 * scaleX, 620 * scaleY);
+			titlefont.draw(sprite, "Keyboard", 180 * scaleX, 620 * scaleY);
 			titlefont.draw(sprite, "Controller1", 330 * scaleX, 620 * scaleY);
 			titlefont.draw(sprite, "MIDI", 630 * scaleX, 620 * scaleY);
 			titlefont.setColor(Color.ORANGE);
-			titlefont.draw(sprite, "Music Select (press [1] to change) :   ", 750 * scaleX, 620 * scaleY);
+			titlefont.draw(sprite, "Music Select Input (press [1] to change) :   ", 750 * scaleX, 620 * scaleY);
 			titlefont.draw(sprite, SELECTKEY[config.getMusicselectinput()], 780 * scaleX, 590 * scaleY);
 
 			titlefont.draw(sprite, "Controller Device 1 (press [2] to change) :   ", 750 * scaleX, 500 * scaleY);


### PR DESCRIPTION
## Before
![before](https://github.com/user-attachments/assets/2ef14f52-732f-4b2e-963f-61c260ef69c9)

## After
![after](https://github.com/user-attachments/assets/669a284b-884b-4fdf-b748-ff56e0cc9b57)

## Explanation
The key modes in the key configuration menu are named 5 KEYS, 7 KEYS, 9 KEYS, 10 KEYS, 14 KEYS, etc in the top left corner of the screen.

But when choosing which key mode to use for music select input, they are named "2dx sp" (for 7 KEYS), "popn" (for 9 KEYS), "2dx dp" (for 14 KEYS).

I think this is confusing for many new players because they may not know that "2dx sp" just means using the "7 KEYS" key config, because the names are different even though they refer to the same thing.

There are also many players who play BMS but are not familiar with IIDX and Pop'n Music.

Because of this, I often get questions by people confused by this option, so I think it's better to change the names so that they match.

I've also changed "Music Select (press [1] to change)" to "Music Select Input (press [1] to change)" to make it easier to understand the purpose of this option.

(extra change: renamed "Key Board" to "Keyboard")

### Note
These changes do not affect existing configuration files, as the music select input option is saved as an integer, not a string.