### PR TITLE
Fix texture sometimes mixes & use-after-free

### DIFF
--- a/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
+++ b/src/bms/player/beatoraja/play/bga/BGImageProcessor.java
@@ -25,17 +25,25 @@ public class BGImageProcessor {
 	/**
 	 * BGイメージのキャッシュ
 	 */
-	private Texture[] bgacache;
-	/**
-	 * キャッシュされているBGイメージID
-	 */
-	private int[] bgacacheid;
+	private Map<Integer, Texture> bgacache;
 
 	private final PixmapResourcePool cache;
 
 	public BGImageProcessor(int size, int maxgen) {
-		bgacache = new Texture[size];
-		bgacacheid = new int[size];
+		bgacache = new LinkedHashMap<>(size + 1, .75F, true) {
+			@Override
+			protected boolean removeEldestEntry(Map.Entry<Integer, Texture> eldest) {
+				if (size() > size) {
+					Texture tex = eldest.getValue();
+					if (tex != null) {
+						tex.dispose();
+					}
+					return true;
+				}
+				return false;
+			}
+		};
+
 		cache = new PixmapResourcePool(maxgen) {
 
 			protected Pixmap convert(Pixmap pixmap) {
@@ -74,24 +82,19 @@ public class BGImageProcessor {
 	 */
 	public void prepare(TimeLine[] timelines) {
 		long l = System.currentTimeMillis();
-		Arrays.fill(bgacacheid, -1);
-		for (Texture bga : bgacache) {
-			if (bga != null) {
-				bga.dispose();
-			}
-		}
-		Arrays.fill(bgacache, null);
+		bgacache.forEach((k, tex) -> tex.dispose());
+		bgacache.clear();
 
 		int count = 0;
 		for (TimeLine tl : timelines) {
 			int bga = tl.getBGA();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bga < bgamap.length && bgamap[bga] != null) {
+			if (bga >= 0 && !bgacache.containsKey(bga) && bga < bgamap.length && bgamap[bga] != null) {
 				getTexture(bga);
 				count++;
 			}
 
 			bga = tl.getLayer();
-			if (bga >= 0 && bgacache[bga % bgacache.length] == null && bga < bgamap.length && bgamap[bga] != null) {
+			if (bga >= 0 && bgacache.containsKey(bga) && bga < bgamap.length && bgamap[bga] != null) {
 				getTexture(bga);
 				count++;
 			}
@@ -101,23 +104,14 @@ public class BGImageProcessor {
 	}
 
 	public Texture getTexture(int id) {
-		final int cid = id % bgacache.length;
-		// BGイメージキャッシュにTextureがある場合
-		if (bgacacheid[cid] == id) {
-			return bgacache[cid];
+		if (bgacache.containsKey(id)) {
+			return bgacache.get(id);
 		}
 		// BGイメージキャッシュにTextureがない場合
 		if (id < bgamap.length && bgamap[id] != null){
-			if(bgacache[cid] == null) {
-				bgacache[cid] = new Texture(bgamap[id]);				
-			} else if(bgacache[cid].getWidth() != bgamap[id].getWidth() || bgacache[cid].getHeight() != bgamap[id].getHeight()){
-				bgacache[cid].dispose();
-				bgacache[cid] = new Texture(bgamap[id]);				
-			} else {
-				bgacache[cid].draw(bgamap[id], 0, 0);
-			}
-			bgacacheid[cid] = id;
-			return bgacache[cid];
+			Texture tex = new Texture(bgamap[id]);
+			bgacache.put(id, tex);
+			return tex;
 		}
 		return null;
 	}
@@ -126,12 +120,8 @@ public class BGImageProcessor {
 	 * リソースを開放する
 	 */
 	public void dispose() {
-		for (Texture bga : bgacache) {
-			if (bga != null) {
-				bga.dispose();
-			}
-		}
-		bgacache = new Texture[0];
+		bgacache.forEach((k, tex) -> tex.dispose());
+		bgacache.clear();
 
 		cache.dispose();
 	}	


### PR DESCRIPTION
closes #560 

I haven't tested this patch in vanilla raja, needing some help!

This is a patch that fixes the wrong cache implementation when loading textures for BGAs. Sometimes the textures are mixed together, leading to a known issue for many pictures have transparent colors mixed together which ends like a "halo". And sometimes the texture is diposed before using it, leading to #560.

This patch removes the "hand crafted" fixed size cache with a simple LRU cache instead. It's encapsulated to ensure correctness & keeps the initial design idea of providing a "fixed size" cache pool.