### PR TITLE
Display Unicode characters

### DIFF
--- a/src/bms/player/beatoraja/select/BarRenderer.java
+++ b/src/bms/player/beatoraja/select/BarRenderer.java
@@ -209,14 +209,16 @@ public final class BarRenderer {
 			
 			bartextCharset.clear();
 			for (Bar song : manager.currentsongs) {
-				for (char c : song.getTitle().toCharArray()) {
-					bartextCharset.add(c);
+				final String title = song.getTitle();
+				for (int index = 0; index < title.length();) {
+					final int codePoint = title.codePointAt(index);
+					bartextCharset.add(codePoint);
+					index += Character.charCount(codePoint);
 				}
 			}
-			char[] chars = new char[bartextCharset.size];
-			int i = 0;
+			StringBuilder chars = new StringBuilder(bartextCharset.size);
 			for (IntSetIterator iterator = bartextCharset.iterator();iterator.hasNext;) {
-				chars[i++] = (char) iterator.next();
+				chars.appendCodePoint(iterator.next());
 			}
 //			Arrays.fill(bartextCharset, false);
 //			int charCount = 0;
@@ -243,7 +245,7 @@ public final class BarRenderer {
 			
 			for(int index = 0;index < SkinBar.BARTEXT_COUNT;index++) {
 				if(baro.getText(index) != null) {
-					baro.getText(index).prepareFont(String.valueOf(chars));
+					baro.getText(index).prepareFont(chars.toString());
 				}				
 			}
 		}

--- a/src/bms/player/beatoraja/select/MusicSelectSkin.java
+++ b/src/bms/player/beatoraja/select/MusicSelectSkin.java
@@ -1,6 +1,7 @@
 package bms.player.beatoraja.select;
 
 import bms.player.beatoraja.skin.*;
+import com.badlogic.gdx.math.Rectangle;
 
 /**
  * 選曲スキン
@@ -17,6 +18,7 @@ public class MusicSelectSkin extends Skin {
 	 * クリック可能なBarのindex
 	 */
 	private int[] clickableBar = new int[0];
+	private Rectangle searchTextRegion = new Rectangle(0, 0, 1, 1);
 
 	public MusicSelectSkin(SkinHeader header) {
 		super(header);
@@ -36,6 +38,16 @@ public class MusicSelectSkin extends Skin {
 
 	public void setCenterBar(int centerBar) {
 		this.centerBar = centerBar;
+	}
+
+	public Rectangle getSearchTextRegion() {
+		return searchTextRegion;
+	}
+
+	public void setSearchTextRegion(Rectangle searchTextRegion) {
+		if (searchTextRegion != null) {
+			this.searchTextRegion = searchTextRegion;
+		}
 	}
 
 }

--- a/src/bms/player/beatoraja/skin/BitmapFontCache.java
+++ b/src/bms/player/beatoraja/skin/BitmapFontCache.java
@@ -3,12 +3,13 @@ package bms.player.beatoraja.skin;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
+
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.utils.Array;
 
 public class BitmapFontCache {
-    static private final Map<Path, CacheableBitmapFont> _cacheStore = new HashMap<>();
+    static private final Map<CacheKey, CacheableBitmapFont> _cacheStore = new HashMap<>();
 
     static public class CacheableBitmapFont {
         public BitmapFont.BitmapFontData fontData;
@@ -18,20 +19,62 @@ public class BitmapFontCache {
         public int type;
         public float pageWidth;
         public float pageHeight;
+        public int base;
+        public int glyphYOffset;
+        public Map<Integer, BitmapFont.Glyph> supplementaryGlyphs;
     }
 
     static public boolean Has(Path path) {
+        return Has(path, 0);
+    }
+
+    static public boolean Has(Path path, int type) {
         if (path == null)
             return false;
 
-        return _cacheStore.containsKey(path);
+        return _cacheStore.containsKey(new CacheKey(path, type));
     }
 
     static public void Set(Path path, CacheableBitmapFont font) {
-        _cacheStore.put(path, font);
+        Set(path, font != null ? font.type : 0, font);
+    }
+
+    static public void Set(Path path, int type, CacheableBitmapFont font) {
+        _cacheStore.put(new CacheKey(path, type), font);
     }
 
     static public CacheableBitmapFont Get(Path path) {
-        return _cacheStore.get(path);
+        return Get(path, 0);
+    }
+
+    static public CacheableBitmapFont Get(Path path, int type) {
+        return _cacheStore.get(new CacheKey(path, type));
+    }
+
+    static private final class CacheKey {
+        private final Path path;
+        private final int type;
+
+        private CacheKey(Path path, int type) {
+            this.path = path;
+            this.type = type;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (!(obj instanceof CacheKey)) {
+                return false;
+            }
+            CacheKey other = (CacheKey) obj;
+            return type == other.type && path.equals(other.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return 31 * path.hashCode() + type;
+        }
     }
 }

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -1,8 +1,16 @@
 package bms.player.beatoraja.skin;
 
 import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import bms.player.beatoraja.skin.property.StringProperty;
 import bms.player.beatoraja.skin.property.StringPropertyFactory;
@@ -10,7 +18,9 @@ import bms.player.beatoraja.skin.BitmapFontCache.CacheableBitmapFont;
 import com.badlogic.gdx.files.FileHandle;
 import com.badlogic.gdx.graphics.Color;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
+import com.badlogic.gdx.graphics.g2d.BitmapFont.Glyph;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.GlyphLayout.GlyphRun;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import com.badlogic.gdx.math.Rectangle;
 import com.badlogic.gdx.math.Vector2;
@@ -71,6 +81,7 @@ public final class SkinTextBitmap extends SkinText {
 				shader.setUniformf("u_shadowOffset",
 						new Vector2(getShadowOffset().x / source.getPageWidth(), getShadowOffset().y / source.getPageHeight()));
 			});
+			drawFallbackColorGlyphs(sprite, x + offsetX, region.y + offsetY + region.getHeight());
 		} else {
 			sprite.setType(SkinObjectRenderer.TYPE_BILINEAR);
 			if (!getShadowOffset().isZero()) {
@@ -83,24 +94,60 @@ public final class SkinTextBitmap extends SkinText {
 		font.getData().setScale(1);
 	}
 
+	private void drawFallbackColorGlyphs(SkinObjectRenderer sprite, float x, float y) {
+		if (!source.hasFallbackColorGlyphs(layout)) {
+			return;
+		}
+
+		Color previous = new Color(sprite.getColor());
+		sprite.setColor(1, 1, 1, color.a);
+		sprite.setType(SkinObjectRenderer.TYPE_BILINEAR);
+
+		float scaleX = font.getData().scaleX;
+		float scaleY = font.getData().scaleY;
+		for (GlyphRun run : layout.runs) {
+			float glyphX = x + run.x;
+			float glyphY = y + run.y;
+			for (int i = 0; i < run.glyphs.size; i++) {
+				Glyph glyph = run.glyphs.get(i);
+				glyphX += run.xAdvances.get(i);
+				if (!source.isFallbackColorGlyph(glyph)) {
+					continue;
+				}
+				TextureRegion region = source.getRegion(glyph.page);
+				if (region == null) {
+					continue;
+				}
+				TextureRegion glyphRegion = new TextureRegion(region);
+				glyphRegion.setRegion(glyph.u, glyph.v2, glyph.u2, glyph.v);
+				sprite.draw(glyphRegion, glyphX + glyph.xoffset * scaleX, glyphY + glyph.yoffset * scaleY,
+						glyph.width * scaleX, glyph.height * scaleY);
+			}
+		}
+
+		sprite.setType(SkinObjectRenderer.TYPE_DISTANCE_FIELD);
+		sprite.setColor(previous);
+	}
+
 	private void setLayout(Color c, Rectangle r) {
+		String text = source.remapSupplementaryGlyphs(getText());
 		if (isWrapping()) {
-			layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], true);
+			layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], true);
 		} else {
 			switch (getOverflow()) {
 				case OVERFLOW_OVERFLOW -> {
-					layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+					layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
 				}
 				case OVERFLOW_SHRINK -> {
-					layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+					layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
 					float actualWidth = layout.width;
 					if (actualWidth > r.getWidth()) {
 						font.getData().setScale(font.getData().scaleX * r.getWidth() / actualWidth, font.getData().scaleY);
-						layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+						layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
 					}
 				}
 				case OVERFLOW_TRUNCATE -> {
-					layout.setText(font, getText(), 0, getText().length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
+					layout.setText(font, text, 0, text.length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
 				}
 			}
 		}
@@ -119,6 +166,7 @@ public final class SkinTextBitmap extends SkinText {
 		private boolean usecim;
 		private boolean useMipMaps;
 		private Path fontPath;
+		private FallbackFont[] fallbackFonts = new FallbackFont[0];
 		private BitmapFont.BitmapFontData fontData;
 		private Array<TextureRegion> regions;
 		private BitmapFont font;
@@ -126,15 +174,43 @@ public final class SkinTextBitmap extends SkinText {
 		private int type;
 		private float pageWidth;
 		private float pageHeight;
+		private int base;
+		private int glyphYOffset;
+		private Map<Integer, BitmapFont.Glyph> supplementaryGlyphs = Collections.emptyMap();
+		private final Map<Integer, Character> activeSupplementaryGlyphMap = new HashMap<>();
+		private final Map<Character, Integer> activePrivateUseGlyphMap = new HashMap<>();
+		private final Set<Integer> activeBmpFallbackGlyphs = new HashSet<>();
+		private final Map<FallbackFont, Integer> fallbackPageOffsets = new HashMap<>();
+		private final Set<Integer> activeFallbackPages = new HashSet<>();
+
+		private static final int PRIVATE_USE_AREA_START = 0xe000;
+		private static final int PRIVATE_USE_AREA_END = 0xf8ff;
 
 		public SkinTextBitmapSource(Path fontPath, boolean usecim) {
 			this(fontPath, usecim, true);
 		}
 
 		public SkinTextBitmapSource(Path fontPath, boolean usecim, boolean useMipMaps) {
+			this(fontPath, new FallbackFont[0], usecim, useMipMaps);
+		}
+
+		public SkinTextBitmapSource(Path fontPath, Path[] fallbackFontPaths, boolean usecim) {
+			this(fontPath, fallbackFontPaths, usecim, true);
+		}
+
+		public SkinTextBitmapSource(Path fontPath, Path[] fallbackFontPaths, boolean usecim, boolean useMipMaps) {
+			this(fontPath, toFallbackFonts(fallbackFontPaths), usecim, useMipMaps);
+		}
+
+		public SkinTextBitmapSource(Path fontPath, FallbackFont[] fallbackFonts, boolean usecim) {
+			this(fontPath, fallbackFonts, usecim, true);
+		}
+
+		public SkinTextBitmapSource(Path fontPath, FallbackFont[] fallbackFonts, boolean usecim, boolean useMipMaps) {
 			this.usecim = usecim;
 			this.useMipMaps = useMipMaps;
 			this.fontPath = fontPath;
+			this.fallbackFonts = fallbackFonts != null ? fallbackFonts : new FallbackFont[0];
 		}
 
 		public CacheableBitmapFont createCacheableFont(Path _fontPath, int _type) {
@@ -144,9 +220,15 @@ public final class SkinTextBitmap extends SkinText {
 			float _originalSize = 0;
 			float _pageWidth = 0;
 			float _pageHeight = 0;
+			int _base = 0;
+			int _glyphYOffset = 0;
+			Map<Integer, BitmapFont.Glyph> _supplementaryGlyphs = Collections.emptyMap();
 
 			try {
-				_fontData = new BitmapFont.BitmapFontData(new FileHandle(_fontPath.toFile()), false);
+				FileHandle fontFile = new FileHandle(_fontPath.toFile());
+				RemappedFontFile remappedFontFile = createRemappedFontFile(fontFile);
+				_fontData = new BitmapFont.BitmapFontData(remappedFontFile.fileHandle, false);
+				_supplementaryGlyphs = remappedFontFile.supplementaryGlyphs;
 
 				_regions = new Array<>(_fontData.imagePaths.length);
 				for (int i = 0; i < _fontData.imagePaths.length; ++i) {
@@ -160,10 +242,14 @@ public final class SkinTextBitmap extends SkinText {
 					String line = reader.readLine();
 					_originalSize = (float) Integer.parseInt(line.substring(line.indexOf("size=") + 5).split(" ")[0]);
 					line = reader.readLine();
+					_base = getIntAttribute(line, "base");
 					_pageWidth = (float) Integer.parseInt(line.substring(line.indexOf("scaleW=") + 7).split(" ")[0]);
 					_pageHeight = (float) Integer.parseInt(line.substring(line.indexOf("scaleH=") + 7).split(" ")[0]);
+					_glyphYOffset = readRepresentativeGlyphYOffset(reader);
 				} catch (Exception e) {
 					_originalSize = _fontData.lineHeight;
+					_base = (int) _fontData.ascent;
+					_glyphYOffset = getRepresentativeGlyphYOffset(_fontData);
 					if (_regions.size > 0) {
 						_pageWidth = (float) _regions.get(0).getRegionWidth();
 						_pageHeight = (float) _regions.get(0).getRegionHeight();
@@ -181,27 +267,378 @@ public final class SkinTextBitmap extends SkinText {
 			result.type = _type;
 			result.pageWidth = _pageWidth;
 			result.pageHeight = _pageHeight;
+			result.base = _base;
+			result.glyphYOffset = _glyphYOffset;
+			result.supplementaryGlyphs = _supplementaryGlyphs;
 
 			return result;
 		}
 
 		public BitmapFont getFont() {
-			if (!BitmapFontCache.Has(fontPath)) {
+			if (!BitmapFontCache.Has(fontPath, type)) {
 				CacheableBitmapFont _newFont = createCacheableFont(fontPath, type);
-				BitmapFontCache.Set(fontPath, _newFont);
+				BitmapFontCache.Set(fontPath, type, _newFont);
 			}
 
-			CacheableBitmapFont cached = BitmapFontCache.Get(fontPath);
+			CacheableBitmapFont cached = BitmapFontCache.Get(fontPath, type);
 
 			fontData = cached.fontData;
-			regions = cached.regions;
-			font = cached.font;
+			regions = cached.regions != null ? new Array<>(cached.regions) : new Array<>();
 			originalSize = cached.originalSize;
 			type = cached.type;
 			pageWidth = cached.pageWidth;
 			pageHeight = cached.pageHeight;
+			base = cached.base;
+			glyphYOffset = cached.glyphYOffset;
+			supplementaryGlyphs = cached.supplementaryGlyphs != null ? cached.supplementaryGlyphs : Collections.emptyMap();
+			activeBmpFallbackGlyphs.clear();
+			activeSupplementaryGlyphMap.clear();
+			activePrivateUseGlyphMap.clear();
+			fallbackPageOffsets.clear();
+			activeFallbackPages.clear();
+			attachFallbackFonts();
+			font = fontData != null ? new BitmapFont(fontData, regions, false) : null;
 
 			return font;
+		}
+
+		public String remapSupplementaryGlyphs(String text) {
+			if (fontData == null) {
+				return text;
+			}
+
+			StringBuilder result = null;
+			Set<Integer> requiredCodePoints = new HashSet<>();
+			for (int index = 0; index < text.length();) {
+				int codePoint = text.codePointAt(index);
+				if (codePoint > Character.MAX_VALUE) {
+					if (result == null) {
+						result = new StringBuilder(text.length());
+						result.append(text, 0, index);
+					}
+					requiredCodePoints.add(codePoint);
+					Character mapped = ensureSupplementaryGlyphMapped(codePoint, requiredCodePoints);
+					if (mapped == null) {
+						index += Character.charCount(codePoint);
+						continue;
+					}
+					result.append(mapped.charValue());
+				} else if (result != null) {
+					ensureBmpFallbackGlyph(codePoint);
+					result.append((char) codePoint);
+				} else {
+					ensureBmpFallbackGlyph(codePoint);
+				}
+				index += Character.charCount(codePoint);
+			}
+			return result != null ? result.toString() : text;
+		}
+
+		private void attachFallbackFonts() {
+			for (FallbackFont fallback : fallbackFonts) {
+				if (fallback == null || fallback.path == null || fallbackPageOffsets.containsKey(fallback)) {
+					continue;
+				}
+				if (!BitmapFontCache.Has(fallback.path, fallback.type)) {
+					CacheableBitmapFont fallbackFont = createCacheableFont(fallback.path, fallback.type);
+					BitmapFontCache.Set(fallback.path, fallback.type, fallbackFont);
+				}
+				CacheableBitmapFont fallbackFont = BitmapFontCache.Get(fallback.path, fallback.type);
+				if (fallbackFont == null || fallbackFont.fontData == null || fallbackFont.regions == null) {
+					continue;
+				}
+				int pageOffset = regions.size;
+				int pageCount = 0;
+				for (TextureRegion region : fallbackFont.regions) {
+					regions.add(region);
+					if (fallback.type == TYPE_STANDARD) {
+						activeFallbackPages.add(pageOffset + pageCount);
+					}
+					pageCount++;
+				}
+				if (pageCount == 0) {
+					continue;
+				}
+				fallbackPageOffsets.put(fallback, pageOffset);
+			}
+		}
+
+		private RemappedFontFile createRemappedFontFile(FileHandle fontFile) {
+			String fontText = new String(fontFile.readBytes(), StandardCharsets.UTF_8);
+			Map<Integer, BitmapFont.Glyph> glyphMap = new HashMap<>();
+			String[] lines = fontText.split("\\r?\\n", -1);
+			StringBuilder remappedText = new StringBuilder(fontText.length());
+			int charCount = 0;
+			int kerningCount = 0;
+
+			for (String line : lines) {
+				if (line.startsWith("char ")) {
+					int codePoint = getIntAttribute(line, "id");
+					if (codePoint > Character.MAX_VALUE && codePoint <= Character.MAX_CODE_POINT) {
+						BitmapFont.Glyph glyph = createGlyph(line, codePoint);
+						if (glyph != null) {
+							glyphMap.put(codePoint, glyph);
+						}
+						continue;
+					}
+					charCount++;
+				} else if (line.startsWith("kerning ")) {
+					int first = getIntAttribute(line, "first");
+					int second = getIntAttribute(line, "second");
+					if (first > Character.MAX_VALUE || second > Character.MAX_VALUE) {
+						continue;
+					}
+					kerningCount++;
+				}
+			}
+
+			for (String line : lines) {
+				if (line.startsWith("char ")) {
+					int codePoint = getIntAttribute(line, "id");
+					if (codePoint > Character.MAX_VALUE && codePoint <= Character.MAX_CODE_POINT) {
+						continue;
+					}
+				} else if (line.startsWith("kerning ")) {
+					int first = getIntAttribute(line, "first");
+					int second = getIntAttribute(line, "second");
+					if (first > Character.MAX_VALUE || second > Character.MAX_VALUE) {
+						continue;
+					}
+				}
+				String remappedLine = line;
+				if (line.startsWith("chars count=")) {
+					remappedLine = "chars count=" + charCount;
+				} else if (line.startsWith("kernings count=")) {
+					remappedLine = "kernings count=" + kerningCount;
+				}
+				if (remappedText.length() > 0) {
+					remappedText.append('\n');
+				}
+				remappedText.append(remappedLine);
+			}
+
+			if (glyphMap.isEmpty()) {
+				return new RemappedFontFile(fontFile, Collections.emptyMap());
+			}
+			return new RemappedFontFile(new InMemoryFontFileHandle(fontFile, remappedText.toString().getBytes(StandardCharsets.UTF_8)),
+					glyphMap);
+		}
+
+		private void ensureBmpFallbackGlyph(int codePoint) {
+			if (activeBmpFallbackGlyphs.contains(codePoint) || fontData.getGlyph((char) codePoint) != null) {
+				return;
+			}
+
+			BitmapFont.Glyph glyph = findFallbackGlyph(codePoint, codePoint, false);
+			if (glyph != null && hasRegion(glyph.page)) {
+				fontData.setGlyphRegion(glyph, regions.get(glyph.page));
+				fontData.setGlyph(codePoint, glyph);
+				activeBmpFallbackGlyphs.add(codePoint);
+			}
+		}
+
+		private Character ensureSupplementaryGlyphMapped(int codePoint, Set<Integer> requiredCodePoints) {
+			Character mapped = activeSupplementaryGlyphMap.get(codePoint);
+			if (mapped == null) {
+				mapped = findPrivateUseSlot(requiredCodePoints);
+				if (mapped == null) {
+					return null;
+				}
+				BitmapFont.Glyph glyph = findFallbackGlyph(codePoint, mapped.charValue(), true);
+				if (glyph == null || !hasRegion(glyph.page)) {
+					return null;
+				}
+				fontData.setGlyphRegion(glyph, regions.get(glyph.page));
+				fontData.setGlyph(mapped.charValue(), glyph);
+				activeSupplementaryGlyphMap.put(codePoint, mapped);
+				activePrivateUseGlyphMap.put(mapped, codePoint);
+			}
+			return mapped;
+		}
+
+		private Character findPrivateUseSlot(Set<Integer> requiredCodePoints) {
+			for (int codePoint = PRIVATE_USE_AREA_START; codePoint <= PRIVATE_USE_AREA_END; codePoint++) {
+				Character slot = Character.valueOf((char) codePoint);
+				Integer activeCodePoint = activePrivateUseGlyphMap.get(slot);
+				if (activeCodePoint == null) {
+					return slot;
+				}
+				if (!requiredCodePoints.contains(activeCodePoint)) {
+					fontData.setGlyph(slot.charValue(), null);
+					activePrivateUseGlyphMap.remove(slot);
+					activeSupplementaryGlyphMap.remove(activeCodePoint);
+					return slot;
+				}
+			}
+			return null;
+		}
+
+		private BitmapFont.Glyph findFallbackGlyph(int codePoint, int mappedCodePoint, boolean supplementary) {
+			if (supplementary) {
+				BitmapFont.Glyph glyph = supplementaryGlyphs.get(codePoint);
+				if (glyph != null && hasRegion(glyph.page)) {
+					return copyGlyph(glyph, mappedCodePoint, 0);
+				}
+			}
+
+			for (FallbackFont fallback : fallbackFonts) {
+				if (fallback == null || fallback.path == null) {
+					continue;
+				}
+				CacheableBitmapFont fallbackFont = BitmapFontCache.Get(fallback.path, fallback.type);
+				Integer pageOffset = fallbackPageOffsets.get(fallback);
+				if (fallbackFont == null || fallbackFont.fontData == null || pageOffset == null) {
+					continue;
+				}
+				BitmapFont.Glyph glyph = supplementary
+						? (fallbackFont.supplementaryGlyphs != null ? fallbackFont.supplementaryGlyphs.get(codePoint) : null)
+						: fallbackFont.fontData.getGlyph((char) codePoint);
+				if (glyph != null && glyph.page >= 0 && glyph.page < fallbackFont.regions.size
+						&& hasRegion(glyph.page + pageOffset.intValue())) {
+					return copyGlyph(glyph, mappedCodePoint, pageOffset.intValue(), fallbackFont.glyphYOffset - glyphYOffset);
+				}
+			}
+			return null;
+		}
+
+		private boolean hasRegion(int page) {
+			return page >= 0 && page < regions.size && regions.get(page) != null;
+		}
+
+		private boolean isFallbackColorGlyph(Glyph glyph) {
+			return glyph != null && activeFallbackPages.contains(glyph.page);
+		}
+
+		private boolean hasFallbackColorGlyphs(GlyphLayout layout) {
+			for (GlyphRun run : layout.runs) {
+				for (int i = 0; i < run.glyphs.size; i++) {
+					if (isFallbackColorGlyph(run.glyphs.get(i))) {
+						return true;
+					}
+				}
+			}
+			return false;
+		}
+
+		private TextureRegion getRegion(int page) {
+			return hasRegion(page) ? regions.get(page) : null;
+		}
+
+		private BitmapFont.Glyph createGlyph(String line, int codePoint) {
+			try {
+				BitmapFont.Glyph glyph = new BitmapFont.Glyph();
+				glyph.id = codePoint;
+				glyph.srcX = getIntAttribute(line, "x");
+				glyph.srcY = getIntAttribute(line, "y");
+				glyph.width = getIntAttribute(line, "width");
+				glyph.height = getIntAttribute(line, "height");
+				glyph.xoffset = getIntAttribute(line, "xoffset");
+				glyph.yoffset = -glyph.height - getIntAttribute(line, "yoffset");
+				glyph.xadvance = getIntAttribute(line, "xadvance");
+				glyph.page = getIntAttribute(line, "page");
+				return glyph;
+			} catch (RuntimeException e) {
+				return null;
+			}
+		}
+
+		private BitmapFont.Glyph copyGlyph(BitmapFont.Glyph source, int mappedCodePoint) {
+			return copyGlyph(source, mappedCodePoint, 0);
+		}
+
+		private BitmapFont.Glyph copyGlyph(BitmapFont.Glyph source, int mappedCodePoint, int pageOffset) {
+			return copyGlyph(source, mappedCodePoint, pageOffset, 0);
+		}
+
+		private BitmapFont.Glyph copyGlyph(BitmapFont.Glyph source, int mappedCodePoint, int pageOffset, int yoffsetAdjust) {
+			BitmapFont.Glyph glyph = new BitmapFont.Glyph();
+			glyph.id = mappedCodePoint;
+			glyph.srcX = source.srcX;
+			glyph.srcY = source.srcY;
+			glyph.width = source.width;
+			glyph.height = source.height;
+			glyph.xoffset = source.xoffset;
+			glyph.yoffset = source.yoffset + yoffsetAdjust;
+			glyph.xadvance = source.xadvance;
+			glyph.page = source.page + pageOffset;
+			return glyph;
+		}
+
+		private int getIntAttribute(String line, String name) {
+			String prefix = name + "=";
+			int valueStart = line.indexOf(prefix);
+			if (valueStart < 0) {
+				return 0;
+			}
+			valueStart += prefix.length();
+			int valueEnd = valueStart;
+			if (valueEnd < line.length() && line.charAt(valueEnd) == '-') {
+				valueEnd++;
+			}
+			while (valueEnd < line.length() && Character.isDigit(line.charAt(valueEnd))) {
+				valueEnd++;
+			}
+			return Integer.parseInt(line.substring(valueStart, valueEnd));
+		}
+
+		private int readRepresentativeGlyphYOffset(BufferedReader reader) throws java.io.IOException {
+			Map<Integer, Integer> anchorOffsets = new HashMap<>();
+			Integer firstVisibleOffset = null;
+			String line;
+			while ((line = reader.readLine()) != null) {
+				if (!line.startsWith("char ")) {
+					continue;
+				}
+				int height = getIntAttribute(line, "height");
+				if (height <= 0) {
+					continue;
+				}
+				int codePoint = getIntAttribute(line, "id");
+				int yoffset = getIntAttribute(line, "yoffset");
+				if (firstVisibleOffset == null) {
+					firstVisibleOffset = yoffset;
+				}
+				if (isVerticalAnchorCodePoint(codePoint)) {
+					anchorOffsets.put(codePoint, yoffset);
+				}
+			}
+
+			int[] preferredCodePoints = { 'S', 'P', 'A', 'N', 'O', 'T', 'H', 'E', 'R', '[', ']', 'M', '0' };
+			for (int codePoint : preferredCodePoints) {
+				Integer yoffset = anchorOffsets.get(codePoint);
+				if (yoffset != null) {
+					return yoffset.intValue();
+				}
+			}
+			return firstVisibleOffset != null ? firstVisibleOffset.intValue() : 0;
+		}
+
+		private int getRepresentativeGlyphYOffset(BitmapFont.BitmapFontData fontData) {
+			int[] preferredCodePoints = { 'S', 'P', 'A', 'N', 'O', 'T', 'H', 'E', 'R', '[', ']', 'M', '0' };
+			for (int codePoint : preferredCodePoints) {
+				BitmapFont.Glyph glyph = fontData.getGlyph((char) codePoint);
+				if (glyph != null && glyph.height > 0) {
+					return -glyph.yoffset - glyph.height;
+				}
+			}
+			return 0;
+		}
+
+		private boolean isVerticalAnchorCodePoint(int codePoint) {
+			return codePoint == 'S' || codePoint == 'P' || codePoint == 'A' || codePoint == 'N' || codePoint == 'O'
+					|| codePoint == 'T' || codePoint == 'H' || codePoint == 'E' || codePoint == 'R'
+					|| codePoint == '[' || codePoint == ']' || codePoint == 'M' || codePoint == '0';
+		}
+
+		private static FallbackFont[] toFallbackFonts(Path[] fallbackFontPaths) {
+			if (fallbackFontPaths == null) {
+				return new FallbackFont[0];
+			}
+			FallbackFont[] fallbackFonts = new FallbackFont[fallbackFontPaths.length];
+			for (int i = 0; i < fallbackFontPaths.length; i++) {
+				fallbackFonts[i] = new FallbackFont(fallbackFontPaths[i], TYPE_STANDARD);
+			}
+			return fallbackFonts;
 		}
 
 		public float getOriginalSize() {
@@ -229,6 +666,64 @@ public final class SkinTextBitmap extends SkinText {
 			if (font != null) {
 				font.dispose();
 				font = null;
+			}
+		}
+
+		private static final class RemappedFontFile {
+			private final FileHandle fileHandle;
+			private final Map<Integer, BitmapFont.Glyph> supplementaryGlyphs;
+
+			private RemappedFontFile(FileHandle fileHandle, Map<Integer, BitmapFont.Glyph> supplementaryGlyphs) {
+				this.fileHandle = fileHandle;
+				this.supplementaryGlyphs = supplementaryGlyphs;
+			}
+		}
+
+		private static final class InMemoryFontFileHandle extends FileHandle {
+			private final FileHandle original;
+			private final byte[] bytes;
+
+			private InMemoryFontFileHandle(FileHandle original, byte[] bytes) {
+				super(original.file());
+				this.original = original;
+				this.bytes = bytes;
+			}
+
+			@Override
+			public InputStream read() {
+				return new ByteArrayInputStream(bytes);
+			}
+
+			@Override
+			public FileHandle parent() {
+				return original.parent();
+			}
+		}
+
+		public static final class FallbackFont {
+			private final Path path;
+			private final int type;
+
+			public FallbackFont(Path path, int type) {
+				this.path = path;
+				this.type = type;
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj) {
+					return true;
+				}
+				if (!(obj instanceof FallbackFont)) {
+					return false;
+				}
+				FallbackFont other = (FallbackFont) obj;
+				return type == other.type && path.equals(other.path);
+			}
+
+			@Override
+			public int hashCode() {
+				return 31 * path.hashCode() + type;
 			}
 		}
 	}

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -105,9 +105,10 @@ public final class SkinTextBitmap extends SkinText {
 
 		float scaleX = font.getData().scaleX;
 		float scaleY = font.getData().scaleY;
+		float ascent = font.getData().ascent;
 		for (GlyphRun run : layout.runs) {
 			float glyphX = x + run.x;
-			float glyphY = y + run.y;
+			float glyphY = y + ascent + run.y;
 			for (int i = 0; i < run.glyphs.size; i++) {
 				Glyph glyph = run.glyphs.get(i);
 				glyphX += run.xAdvances.get(i);

--- a/src/bms/player/beatoraja/skin/SkinTextBitmap.java
+++ b/src/bms/player/beatoraja/skin/SkinTextBitmap.java
@@ -185,6 +185,7 @@ public final class SkinTextBitmap extends SkinText {
 
 		private static final int PRIVATE_USE_AREA_START = 0xe000;
 		private static final int PRIVATE_USE_AREA_END = 0xf8ff;
+		private static final int[] MISSING_GLYPH_CANDIDATES = { 0x25a1, 0x25a2, 0x2610, 0x25a0, '?' }; // □, ▢, ☐, ■, ?
 
 		public SkinTextBitmapSource(Path fontPath, boolean usecim) {
 			this(fontPath, usecim, true);
@@ -430,6 +431,9 @@ public final class SkinTextBitmap extends SkinText {
 			}
 
 			BitmapFont.Glyph glyph = findFallbackGlyph(codePoint, codePoint, false);
+			if (glyph == null) {
+				glyph = findMissingGlyph(codePoint);
+			}
 			if (glyph != null && hasRegion(glyph.page)) {
 				fontData.setGlyphRegion(glyph, regions.get(glyph.page));
 				fontData.setGlyph(codePoint, glyph);
@@ -445,6 +449,9 @@ public final class SkinTextBitmap extends SkinText {
 					return null;
 				}
 				BitmapFont.Glyph glyph = findFallbackGlyph(codePoint, mapped.charValue(), true);
+				if (glyph == null) {
+					glyph = findMissingGlyph(mapped.charValue());
+				}
 				if (glyph == null || !hasRegion(glyph.page)) {
 					return null;
 				}
@@ -468,6 +475,34 @@ public final class SkinTextBitmap extends SkinText {
 					activePrivateUseGlyphMap.remove(slot);
 					activeSupplementaryGlyphMap.remove(activeCodePoint);
 					return slot;
+				}
+			}
+			return null;
+		}
+
+		private BitmapFont.Glyph findMissingGlyph(int mappedCodePoint) {
+			for (int candidate : MISSING_GLYPH_CANDIDATES) {
+				BitmapFont.Glyph glyph = fontData.getGlyph((char) candidate);
+				if (glyph != null && hasRegion(glyph.page)) {
+					return copyGlyph(glyph, mappedCodePoint, 0);
+				}
+			}
+
+			for (FallbackFont fallback : fallbackFonts) {
+				if (fallback == null || fallback.path == null) {
+					continue;
+				}
+				CacheableBitmapFont fallbackFont = BitmapFontCache.Get(fallback.path, fallback.type);
+				Integer pageOffset = fallbackPageOffsets.get(fallback);
+				if (fallbackFont == null || fallbackFont.fontData == null || fallbackFont.regions == null || pageOffset == null) {
+					continue;
+				}
+				for (int candidate : MISSING_GLYPH_CANDIDATES) {
+					BitmapFont.Glyph glyph = fallbackFont.fontData.getGlyph((char) candidate);
+					if (glyph != null && glyph.page >= 0 && glyph.page < fallbackFont.regions.size
+							&& hasRegion(glyph.page + pageOffset.intValue())) {
+						return copyGlyph(glyph, mappedCodePoint, pageOffset.intValue(), fallbackFont.glyphYOffset - glyphYOffset);
+					}
 				}
 			}
 			return null;

--- a/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -3,13 +3,20 @@ package bms.player.beatoraja.skin;
 import bms.player.beatoraja.skin.property.StringProperty;
 import bms.player.beatoraja.skin.property.StringPropertyFactory;
 
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Pixmap;
 import com.badlogic.gdx.graphics.g2d.BitmapFont;
 import com.badlogic.gdx.graphics.g2d.GlyphLayout;
+import com.badlogic.gdx.graphics.g2d.PixmapPacker;
 import com.badlogic.gdx.graphics.g2d.freetype.FreeTypeFontGenerator;
 import com.badlogic.gdx.math.Rectangle;
 
@@ -32,27 +39,63 @@ public final class SkinTextFont extends SkinText {
     private GlyphLayout layout;
 
     private FreeTypeFontGenerator generator;
+    private FreeTypeFontGenerator[] fallbackGenerators = new FreeTypeFontGenerator[0];
     private FreeTypeFontGenerator.FreeTypeFontParameter parameter;
     private String preparedFonts;
+    private final Set<Integer> activeBmpFallbackGlyphs = new HashSet<>();
+    private final Map<Integer, Character> activeSupplementaryGlyphMap = new HashMap<>();
+    private final Map<Character, Integer> activePrivateUseGlyphMap = new HashMap<>();
+    private int packedGlyphSequence;
+    private static final int PRIVATE_USE_AREA_START = 0xe000;
+    private static final int PRIVATE_USE_AREA_END = 0xf8ff;
     
     private final Color shadowcolor = new Color();
 
     public SkinTextFont(String fontpath, int cycle, int size, int shadow) {
-        this(fontpath, cycle, size, shadow, StringPropertyFactory.getStringProperty(-1));
+        this(fontpath, new String[0], cycle, size, shadow, StringPropertyFactory.getStringProperty(-1));
     }
 
     public SkinTextFont(String fontpath, int cycle, int size, int shadow, StringProperty property) {
+        this(fontpath, new String[0], cycle, size, shadow, property);
+    }
+
+    public SkinTextFont(String fontpath, String[] fallbackFontPaths, int cycle, int size, int shadow, StringProperty property) {
     	super(property);
     	try {
             generator = new FreeTypeFontGenerator(Gdx.files.internal(fontpath));
+            fallbackGenerators = loadFallbackGenerators(fallbackFontPaths);
             parameter = new FreeTypeFontGenerator.FreeTypeFontParameter();
             parameter.characters = "";
+            parameter.incremental = true;
 //            this.setCycle(cycle);
             parameter.size = size;
             setShadowOffset(new Vector2(shadow, shadow));    		
     	} catch (GdxRuntimeException e) {
     		Logger.getGlobal().warning("Skin Font読み込み失敗");
     	}
+    }
+
+    private FreeTypeFontGenerator[] loadFallbackGenerators(String[] fallbackFontPaths) {
+        if (fallbackFontPaths == null || fallbackFontPaths.length == 0) {
+            return new FreeTypeFontGenerator[0];
+        }
+
+        FreeTypeFontGenerator[] generators = new FreeTypeFontGenerator[fallbackFontPaths.length];
+        int count = 0;
+        for (String fallbackFontPath : fallbackFontPaths) {
+            if (fallbackFontPath == null || fallbackFontPath.isEmpty()) {
+                continue;
+            }
+            try {
+                generators[count++] = new FreeTypeFontGenerator(Gdx.files.internal(fallbackFontPath));
+            } catch (GdxRuntimeException e) {
+                Logger.getGlobal().warning("Fallback Skin Font load failed: " + fallbackFontPath);
+            }
+        }
+
+        FreeTypeFontGenerator[] result = new FreeTypeFontGenerator[count];
+        System.arraycopy(generators, 0, result, 0, count);
+        return result;
     }
     
     public boolean validate() {
@@ -69,10 +112,12 @@ public final class SkinTextFont extends SkinText {
         }
         
         try {
-            parameter.characters = text;        	
+            parameter.characters = toBmpCharacters(text);
             font = generator.generateFont(parameter);
+            disableIncrementalGlyphGeneration();
             layout = new GlyphLayout(font, "");
             preparedFonts = text;
+            clearSupplementaryGlyphs();
         } catch (GdxRuntimeException e) {
     		Logger.getGlobal().warning("Font準備失敗 : " + text + " - " + e.getMessage());
     	}
@@ -89,9 +134,11 @@ public final class SkinTextFont extends SkinText {
         }
         
         try {
-            parameter.characters = text;
+            parameter.characters = toBmpCharacters(text);
             font = generator.generateFont(parameter);
-            layout = new GlyphLayout(font, "");        	
+            disableIncrementalGlyphGeneration();
+            layout = new GlyphLayout(font, "");
+            clearSupplementaryGlyphs();
     	} catch (GdxRuntimeException e) {
     		Logger.getGlobal().warning("Font準備失敗 : " + text + " - " + e.getMessage());
     	}
@@ -116,26 +163,225 @@ public final class SkinTextFont extends SkinText {
     }
 
     private void setLayout(Color c, Rectangle r) {
+        String text = remapMissingGlyphs(getText());
         if (isWrapping()) {
-            layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], true);
+            layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], true);
         } else {
             switch (getOverflow()) {
-            	case OVERFLOW_OVERFLOW -> layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+            	case OVERFLOW_OVERFLOW -> layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
             	case OVERFLOW_SHRINK -> {
-            		layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+            		layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
             		float actualWidth = layout.width;
             		if (actualWidth > r.getWidth()) {
             			font.getData().setScale(font.getData().scaleX * r.getWidth() / actualWidth, font.getData().scaleY);
-            			layout.setText(font, getText(), c, r.getWidth(), ALIGN[getAlign()], false);
+            			layout.setText(font, text, c, r.getWidth(), ALIGN[getAlign()], false);
             		}
             	}
-            	case OVERFLOW_TRUNCATE -> layout.setText(font, getText(), 0, getText().length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
+            	case OVERFLOW_TRUNCATE -> layout.setText(font, text, 0, text.length(), c, r.getWidth(), ALIGN[getAlign()], false, "");
             }
         }
     }
 
+    private String toBmpCharacters(String text) {
+        StringBuilder result = null;
+        for (int index = 0; index < text.length();) {
+            int codePoint = text.codePointAt(index);
+            if (codePoint > Character.MAX_VALUE) {
+                if (result == null) {
+                    result = new StringBuilder(text.length());
+                    result.append(text, 0, index);
+                }
+            } else if (result != null) {
+                result.append((char) codePoint);
+            }
+            index += Character.charCount(codePoint);
+        }
+        return result != null ? result.toString() : text;
+    }
+
+    private String remapMissingGlyphs(String text) {
+        StringBuilder result = null;
+        Set<Integer> requiredCodePoints = null;
+        for (int index = 0; index < text.length();) {
+            int codePoint = text.codePointAt(index);
+            if (codePoint > Character.MAX_VALUE) {
+                if (result == null) {
+                    result = new StringBuilder(text.length());
+                    result.append(text, 0, index);
+                }
+                if (requiredCodePoints == null) {
+                    requiredCodePoints = new HashSet<>();
+                }
+                requiredCodePoints.add(codePoint);
+                Character mapped = ensureSupplementaryGlyphMapped(codePoint, requiredCodePoints);
+                if (mapped == null) {
+                    index += Character.charCount(codePoint);
+                    continue;
+                }
+                result.append(mapped.charValue());
+            } else if (result != null) {
+                ensureBmpFallbackGlyph(codePoint);
+                result.append((char) codePoint);
+            } else {
+                ensureBmpFallbackGlyph(codePoint);
+            }
+            index += Character.charCount(codePoint);
+        }
+        return result != null ? result.toString() : text;
+    }
+
+    private void ensureBmpFallbackGlyph(int codePoint) {
+        if (fallbackGenerators.length == 0 || activeBmpFallbackGlyphs.contains(codePoint)
+                || font.getData().getGlyph((char) codePoint) != null) {
+            return;
+        }
+
+        try {
+            BitmapFont.Glyph glyph = createGlyph(codePoint, codePoint, true);
+            if (glyph != null) {
+                font.getData().setGlyph(codePoint, glyph);
+                activeBmpFallbackGlyphs.add(codePoint);
+            }
+        } catch (Exception e) {
+        }
+    }
+
+    private Character ensureSupplementaryGlyphMapped(int codePoint, Set<Integer> requiredCodePoints) {
+        Character mapped = activeSupplementaryGlyphMap.get(codePoint);
+        if (mapped != null) {
+            return mapped;
+        }
+
+        mapped = findPrivateUseSlot(requiredCodePoints);
+        if (mapped == null) {
+            return null;
+        }
+
+        try {
+            BitmapFont.Glyph glyph = createGlyph(codePoint, mapped.charValue(), false);
+            if (glyph == null) {
+                return null;
+            }
+            font.getData().setGlyph(mapped.charValue(), glyph);
+            activeSupplementaryGlyphMap.put(codePoint, mapped);
+            activePrivateUseGlyphMap.put(mapped, codePoint);
+            return mapped;
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private Character findPrivateUseSlot(Set<Integer> requiredCodePoints) {
+        for (int codePoint = PRIVATE_USE_AREA_START; codePoint <= PRIVATE_USE_AREA_END; codePoint++) {
+            Character slot = Character.valueOf((char) codePoint);
+            if (!activePrivateUseGlyphMap.containsKey(slot)) {
+                return slot;
+            }
+        }
+
+        for (int codePoint = PRIVATE_USE_AREA_START; codePoint <= PRIVATE_USE_AREA_END; codePoint++) {
+            Character slot = Character.valueOf((char) codePoint);
+            Integer activeCodePoint = activePrivateUseGlyphMap.get(slot);
+            if (!requiredCodePoints.contains(activeCodePoint)) {
+                font.getData().setGlyph(slot.charValue(), null);
+                activePrivateUseGlyphMap.remove(slot);
+                activeSupplementaryGlyphMap.remove(activeCodePoint);
+                return slot;
+            }
+        }
+        return null;
+    }
+
+    private BitmapFont.Glyph createGlyph(int codePoint, int mappedCodePoint, boolean fallbackOnly) throws Exception {
+        if (!fallbackOnly) {
+            BitmapFont.Glyph glyph = createGlyph(generator, codePoint, mappedCodePoint);
+            if (glyph != null) {
+                return glyph;
+            }
+        }
+        for (FreeTypeFontGenerator fallbackGenerator : fallbackGenerators) {
+            BitmapFont.Glyph glyph = createGlyph(fallbackGenerator, codePoint, mappedCodePoint);
+            if (glyph != null) {
+                return glyph;
+            }
+        }
+        return null;
+    }
+
+    private BitmapFont.Glyph createGlyph(FreeTypeFontGenerator generator, int codePoint, int mappedCodePoint) throws Exception {
+        FreeTypeFontGenerator.GlyphAndBitmap glyphAndBitmap =
+                generator.generateGlyphAndBitmap(codePoint, parameter.size, parameter.flip);
+        if (glyphAndBitmap == null || glyphAndBitmap.glyph == null || glyphAndBitmap.bitmap == null
+                || glyphAndBitmap.bitmap.getWidth() == 0 || glyphAndBitmap.bitmap.getRows() == 0) {
+            return null;
+        }
+
+        Pixmap pixmap = glyphAndBitmap.bitmap.getPixmap(Pixmap.Format.RGBA8888, parameter.color, parameter.gamma);
+        try {
+            PixmapPacker packer = getFontDataPacker();
+            if (packer == null) {
+                return null;
+            }
+            String glyphName = "fallback-" + mappedCodePoint + "-" + codePoint + "-" + packedGlyphSequence++;
+            Rectangle packed = packer.pack(glyphName, pixmap);
+            int page = packer.getPageIndex(glyphName);
+            if (page < 0) {
+                return null;
+            }
+            packer.updateTextureRegions(font.getRegions(), parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
+
+            BitmapFont.Glyph glyph = copyGlyph(glyphAndBitmap.glyph, mappedCodePoint);
+            glyph.page = page;
+            glyph.srcX = (int) packed.x;
+            glyph.srcY = (int) packed.y;
+            font.getData().setGlyphRegion(glyph, font.getRegion(glyph.page));
+            return glyph;
+        } finally {
+            pixmap.dispose();
+        }
+    }
+
+    private PixmapPacker getFontDataPacker() throws Exception {
+        Field packerField = font.getData().getClass().getDeclaredField("packer");
+        packerField.setAccessible(true);
+        return (PixmapPacker) packerField.get(font.getData());
+    }
+
+    private void disableIncrementalGlyphGeneration() {
+        try {
+            Field generatorField = font.getData().getClass().getDeclaredField("generator");
+            generatorField.setAccessible(true);
+            generatorField.set(font.getData(), null);
+        } catch (Exception e) {
+        }
+    }
+
+    private BitmapFont.Glyph copyGlyph(BitmapFont.Glyph source, int mappedCodePoint) {
+        BitmapFont.Glyph glyph = new BitmapFont.Glyph();
+        glyph.id = mappedCodePoint;
+        glyph.srcX = source.srcX;
+        glyph.srcY = source.srcY;
+        glyph.width = source.width;
+        glyph.height = source.height;
+        glyph.xoffset = source.xoffset;
+        glyph.yoffset = source.yoffset;
+        glyph.xadvance = source.xadvance;
+        glyph.page = source.page;
+        return glyph;
+    }
+
+    private void clearSupplementaryGlyphs() {
+        activeBmpFallbackGlyphs.clear();
+        activeSupplementaryGlyphMap.clear();
+        activePrivateUseGlyphMap.clear();
+        packedGlyphSequence = 0;
+    }
+
     public void dispose() {
     	Optional.ofNullable(generator).ifPresent(FreeTypeFontGenerator::dispose);
+        for (FreeTypeFontGenerator fallbackGenerator : fallbackGenerators) {
+            Optional.ofNullable(fallbackGenerator).ifPresent(FreeTypeFontGenerator::dispose);
+        }
     	Optional.ofNullable(font).ifPresent(BitmapFont::dispose);
     	setDisposed();
     }

--- a/src/bms/player/beatoraja/skin/SkinTextFont.java
+++ b/src/bms/player/beatoraja/skin/SkinTextFont.java
@@ -48,6 +48,7 @@ public final class SkinTextFont extends SkinText {
     private int packedGlyphSequence;
     private static final int PRIVATE_USE_AREA_START = 0xe000;
     private static final int PRIVATE_USE_AREA_END = 0xf8ff;
+    private static final int[] MISSING_GLYPH_CANDIDATES = { 0x25a1, 0x25a2, 0x2610, 0x25a0, '?' }; // □, ▢, ☐, ■, ?
     
     private final Color shadowcolor = new Color();
 
@@ -231,13 +232,15 @@ public final class SkinTextFont extends SkinText {
     }
 
     private void ensureBmpFallbackGlyph(int codePoint) {
-        if (fallbackGenerators.length == 0 || activeBmpFallbackGlyphs.contains(codePoint)
-                || font.getData().getGlyph((char) codePoint) != null) {
+        if (activeBmpFallbackGlyphs.contains(codePoint) || font.getData().getGlyph((char) codePoint) != null) {
             return;
         }
 
         try {
             BitmapFont.Glyph glyph = createGlyph(codePoint, codePoint, true);
+            if (glyph == null) {
+                glyph = createMissingGlyph(codePoint);
+            }
             if (glyph != null) {
                 font.getData().setGlyph(codePoint, glyph);
                 activeBmpFallbackGlyphs.add(codePoint);
@@ -260,7 +263,10 @@ public final class SkinTextFont extends SkinText {
         try {
             BitmapFont.Glyph glyph = createGlyph(codePoint, mapped.charValue(), false);
             if (glyph == null) {
-                return null;
+                glyph = createMissingGlyph(mapped.charValue());
+            }
+            if (glyph == null) {
+            	return null;
             }
             font.getData().setGlyph(mapped.charValue(), glyph);
             activeSupplementaryGlyphMap.put(codePoint, mapped);
@@ -290,6 +296,63 @@ public final class SkinTextFont extends SkinText {
             }
         }
         return null;
+    }
+
+    private BitmapFont.Glyph createMissingGlyph(int mappedCodePoint) throws Exception {
+        for (int candidate : MISSING_GLYPH_CANDIDATES) {
+            BitmapFont.Glyph glyph = createGlyph(generator, candidate, mappedCodePoint);
+            if (glyph != null) {
+                return glyph;
+            }
+            for (FreeTypeFontGenerator fallbackGenerator : fallbackGenerators) {
+                glyph = createGlyph(fallbackGenerator, candidate, mappedCodePoint);
+                if (glyph != null) {
+                    return glyph;
+                }
+            }
+        }
+
+        PixmapPacker packer = getFontDataPacker();
+        if (packer == null) {
+            return null;
+        }
+
+        int height = Math.max(8, parameter.size);
+        int width = Math.max(6, Math.round(height * 0.75f));
+        int stroke = Math.max(1, height / 12);
+        Pixmap pixmap = new Pixmap(width, height, Pixmap.Format.RGBA8888);
+        try {
+            pixmap.setColor(0, 0, 0, 0);
+            pixmap.fill();
+            Color c = parameter.color != null ? parameter.color : Color.WHITE;
+            pixmap.setColor(c);
+            for (int i = 0; i < stroke; i++) {
+                pixmap.drawRectangle(i, i, width - i * 2, height - i * 2);
+            }
+
+            String glyphName = "missing-" + mappedCodePoint + "-" + packedGlyphSequence++;
+            Rectangle packed = packer.pack(glyphName, pixmap);
+            int page = packer.getPageIndex(glyphName);
+            if (page < 0) {
+                return null;
+            }
+            packer.updateTextureRegions(font.getRegions(), parameter.minFilter, parameter.magFilter, parameter.genMipMaps);
+
+            BitmapFont.Glyph glyph = new BitmapFont.Glyph();
+            glyph.id = mappedCodePoint;
+            glyph.srcX = (int) packed.x;
+            glyph.srcY = (int) packed.y;
+            glyph.width = width;
+            glyph.height = height;
+            glyph.xoffset = 0;
+            glyph.yoffset = -height;
+            glyph.xadvance = width + Math.max(1, stroke);
+            glyph.page = page;
+            font.getData().setGlyphRegion(glyph, font.getRegion(glyph.page));
+            return glyph;
+        } finally {
+            pixmap.dispose();
+        }
     }
 
     private BitmapFont.Glyph createGlyph(int codePoint, int mappedCodePoint, boolean fallbackOnly) throws Exception {

--- a/src/bms/player/beatoraja/skin/SkinTextImage.java
+++ b/src/bms/player/beatoraja/skin/SkinTextImage.java
@@ -8,7 +8,6 @@ import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Disposable;
 import com.badlogic.gdx.utils.IntMap;
 
-import java.io.UnsupportedEncodingException;
 
 /**
  * イメージデータをソースとして持つスキン用テキスト
@@ -40,42 +39,20 @@ public final class SkinTextImage extends SkinText {
 
 	@Override
 	public void prepareFont(String text) {
-		try {
-			byte[] b = text.getBytes("utf-16le");
-			for (int i = 0; i < b.length;) {
-				int code = 0;
-				code |= (b[i++] & 0xff);
-				code |= (b[i++] & 0xff) << 8;
-				if (code >= 0xdc00 && code < 0xff00 && i < b.length) {
-					code |= (b[i++] & 0xff) << 16;
-					code |= (b[i++] & 0xff) << 24;
-				}
-				source.getImage(code);
-			}
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
+		for (int i = 0; i < text.length();) {
+			int code = text.codePointAt(i);
+			i += Character.charCount(code);
+			source.getImage(code);
 		}
 	}
 
 	@Override
 	protected void prepareText(String text) {
-		byte[] b = null;
-		try {
-			b = text.getBytes("utf-16le");
-		} catch (UnsupportedEncodingException e) {
-			e.printStackTrace();
-			return;
-		}
 		textwidth = 0;
 		texts.clear();
-		for (int i = 0; i < b.length;) {
-			int code = 0;
-			code |= (b[i++] & 0xff);
-			code |= (b[i++] & 0xff) << 8;
-			if (code >= 0xdc00 && code < 0xff00 && i < b.length) {
-				code |= (b[i++] & 0xff) << 16;
-				code |= (b[i++] & 0xff) << 24;
-			}
+		for (int i = 0; i < text.length();) {
+			int code = text.codePointAt(i);
+			i += Character.charCount(code);
 			final TextureRegion ch = source.getImage(code);
 			if (ch != null) {
 				texts.add(ch);

--- a/src/bms/player/beatoraja/skin/json/JsonSkin.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkin.java
@@ -98,6 +98,12 @@ public class JsonSkin {
 	public static class Font {
 		public String id;
 		public String path;
+		public FontFallback[] fallback = new FontFallback[0];
+		public int type;
+	}
+
+	public static class FontFallback {
+		public String path;
 		public int type;
 	}
 

--- a/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
@@ -636,6 +636,9 @@ public abstract class JsonSkinObjectLoader<S extends Skin> {
 						SkinTextBitmap.SkinTextBitmapSource.FallbackFont[] fallbackFonts =
 								new SkinTextBitmap.SkinTextBitmapSource.FallbackFont[font.fallback.length];
 						for (int i = 0; i < font.fallback.length; i++) {
+							if (font.fallback[i] == null || font.fallback[i].path == null) {
+								continue;
+							}
 							fallbackFonts[i] = new SkinTextBitmap.SkinTextBitmapSource.FallbackFont(
 									skinPath.getParent().resolve(font.fallback[i].path), font.fallback[i].type);
 						}
@@ -647,6 +650,9 @@ public abstract class JsonSkinObjectLoader<S extends Skin> {
 				} else {
 					String[] fallbackPaths = new String[font.fallback.length];
 					for (int i = 0; i < font.fallback.length; i++) {
+						if (font.fallback[i] == null || font.fallback[i].path == null) {
+							continue;
+						}
 						fallbackPaths[i] = skinPath.getParent().resolve(font.fallback[i].path).toString();
 					}
 					skinText = new SkinTextFont(path.toString(), fallbackPaths, 0, text.size, 0, property);

--- a/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkinObjectLoader.java
@@ -633,13 +633,23 @@ public abstract class JsonSkinObjectLoader<S extends Skin> {
 				}
 				if (path.toString().toLowerCase().endsWith(".fnt")) {
 					if (!loader.bitmapSourceMap.containsKey(font.id)) {
-						SkinTextBitmap.SkinTextBitmapSource source = new SkinTextBitmap.SkinTextBitmapSource(path, loader.usecim);
+						SkinTextBitmap.SkinTextBitmapSource.FallbackFont[] fallbackFonts =
+								new SkinTextBitmap.SkinTextBitmapSource.FallbackFont[font.fallback.length];
+						for (int i = 0; i < font.fallback.length; i++) {
+							fallbackFonts[i] = new SkinTextBitmap.SkinTextBitmapSource.FallbackFont(
+									skinPath.getParent().resolve(font.fallback[i].path), font.fallback[i].type);
+						}
+						SkinTextBitmap.SkinTextBitmapSource source = new SkinTextBitmap.SkinTextBitmapSource(path, fallbackFonts, loader.usecim);
 						source.setType(font.type);
 						loader.bitmapSourceMap.put(font.id, source);
 					}
 					skinText = new SkinTextBitmap(loader.bitmapSourceMap.get(font.id), text.size * ((float)loader.dstr.width / loader.sk.w), property);
 				} else {
-					skinText = new SkinTextFont(path.toString(), 0, text.size, 0, property);
+					String[] fallbackPaths = new String[font.fallback.length];
+					for (int i = 0; i < font.fallback.length; i++) {
+						fallbackPaths[i] = skinPath.getParent().resolve(font.fallback[i].path).toString();
+					}
+					skinText = new SkinTextFont(path.toString(), fallbackPaths, 0, text.size, 0, property);
 				}
 				skinText.setConstantText(text.constantText);
 				StringWriter writer = text.event != null ? text.event : StringPropertyFactory.getStringWriter(text.ref);

--- a/src/bms/player/beatoraja/skin/json/JsonSkinSerializer.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkinSerializer.java
@@ -112,6 +112,9 @@ public class JsonSkinSerializer {
 	private class FontFallbackSerializer extends Json.ReadOnlySerializer<JsonSkin.FontFallback> {
 		public JsonSkin.FontFallback read(Json json, JsonValue jsonValue, Class cls) {
 			JsonSkin.FontFallback fallback = new JsonSkin.FontFallback();
+			if (jsonValue == null) {
+				return fallback;
+			}
 			if (jsonValue.isString()) {
 				fallback.path = jsonValue.asString();
 				fallback.type = 0;
@@ -119,9 +122,16 @@ public class JsonSkinSerializer {
 				JsonValue path = jsonValue.get("path");
 				if (path != null) {
 					fallback.path = path.asString();
+				} else if (jsonValue.has("value")) {
+					fallback.path = jsonValue.get("value").asString();
+				} else if (jsonValue.child != null && jsonValue.child.isString()) {
+					fallback.path = jsonValue.child.asString();
 				}
 				JsonValue type = jsonValue.get("type");
 				fallback.type = type != null ? type.asInt() : 0;
+			} else {
+				fallback.path = jsonValue.asString();
+				fallback.type = 0;
 			}
 			return fallback;
 		}

--- a/src/bms/player/beatoraja/skin/json/JsonSkinSerializer.java
+++ b/src/bms/player/beatoraja/skin/json/JsonSkinSerializer.java
@@ -71,6 +71,7 @@ public class JsonSkinSerializer {
 				JsonSkin.Offset[].class,
 				JsonSkin.Source[].class,
 				JsonSkin.Font[].class,
+				JsonSkin.FontFallback[].class,
 				JsonSkin.Image[].class,
 				JsonSkin.ImageSet[].class,
 				JsonSkin.Value[].class,
@@ -93,6 +94,7 @@ public class JsonSkinSerializer {
 			json.setSerializer(c, new ArraySerializer<>(enabledOptions, path));
 		}
 
+		json.setSerializer(JsonSkin.FontFallback.class, new FontFallbackSerializer());
 		json.setSerializer(BooleanProperty.class, new LuaScriptSerializer<>(SkinLuaAccessor::loadBooleanProperty,
 				BooleanPropertyFactory::getBooleanProperty, BooleanPropertyFactory::getBooleanProperty));
 		json.setSerializer(IntegerProperty.class, new LuaScriptSerializer<>(SkinLuaAccessor::loadIntegerProperty,
@@ -105,6 +107,24 @@ public class JsonSkinSerializer {
 		json.setSerializer(FloatWriter.class, new LuaScriptSerializer<>(SkinLuaAccessor::loadFloatWriter, FloatPropertyFactory::getRateWriter));
 		json.setSerializer(StringWriter.class, new LuaScriptSerializer<>(SkinLuaAccessor::loadStringWriter, null));
 		json.setSerializer(Event.class, new LuaScriptSerializer<>(SkinLuaAccessor::loadEvent, EventFactory::getEvent));
+	}
+
+	private class FontFallbackSerializer extends Json.ReadOnlySerializer<JsonSkin.FontFallback> {
+		public JsonSkin.FontFallback read(Json json, JsonValue jsonValue, Class cls) {
+			JsonSkin.FontFallback fallback = new JsonSkin.FontFallback();
+			if (jsonValue.isString()) {
+				fallback.path = jsonValue.asString();
+				fallback.type = 0;
+			} else if (jsonValue.isObject()) {
+				JsonValue path = jsonValue.get("path");
+				if (path != null) {
+					fallback.path = path.asString();
+				}
+				JsonValue type = jsonValue.get("type");
+				fallback.type = type != null ? type.asInt() : 0;
+			}
+			return fallback;
+		}
 	}
 
 	private abstract class Serializer<T> extends Json.ReadOnlySerializer<T> {


### PR DESCRIPTION
この変更は、今後出てくるかもしれないあらゆるUnicodeのタイトルやアーティスト名を表示できるよう、そのための仕組みを用意するものです。
最終的にはスキンの対応次第ですので、この変更自体が表示を可能にするものではありません。

1つ目
U+10000以上（絵文字や拡張漢字など）は直接利用することができなかったため、動的に私用領域（U+E000以降）に割り当てるようにしました。
ただし約6400文字の上限があります。

2つ目
フォントファイルの収録文字数に上限があることから、TTF/OTFフォントに収録されていないコードポイントは他のフォントを参照しにいく、フォールバック機能を加えました。
jsonならば
```json
{
  "id": 0,
  "path": "font/Main.ttf",
  "fallback": [
    "font/NotoSansCJKjp-Regular.otf",
    "font/NotoEmoji-Regular.ttf"
  ]
}
```

luaならば
```lua
font = {
  {
    id = 0,
    path = "font/Main.ttf",
    fallback = {
      "font/NotoSansCJKjp-Regular.otf",
      "font/NotoEmoji-Regular.ttf"
    }
  }
}
```
のように指定します。

画像フォントもフォールバック可能にしており、同様にluaの場合は、
```lua
{
    id = 1, path = "Select/font/fnt/main.fnt", type = 1,
    fallback = {
        {path = "Select/font/fnt/main-korean.fnt", type = 1},
        {path = "Select/font/fnt/main-emoji.fnt", type = 0}
    }
}
```
のように指定します。

以下の画像はスキンを改変して NotoEmoji をフォールバックに加えたサンプルです。
<img width="1920" height="1055" alt="20260617_190823_Music_Select" src="https://github.com/user-attachments/assets/0bdc833e-3588-45a3-a388-ec911b968551" />

TTF/OTF使用時はモノクロ絵文字のみですが、画像フォントを作成した場合はカラー絵文字にも対応できます。
以下はNotoColorEmojiから作成した画像フォントをフォールバックに加えた例です。
<img width="1920" height="1080" alt="20260620_115236_Music_Select" src="https://github.com/user-attachments/assets/80e13f2a-fa30-4e5c-ae5e-8ee849dd531b" />

余談ですが、NotoEmoji、NotoColorEmojiはオープンソースで配布され、利用しやすいのでおすすめです。
