### PR TITLE
Fix duplicate PortAudio initialization during startup (#874)

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "zulu-javafx-17"

--- a/src/bms/player/beatoraja/MainController.java
+++ b/src/bms/player/beatoraja/MainController.java
@@ -320,7 +320,9 @@ public final class MainController {
 			audio = new GdxAudioDeviceDriver(config);
 			break;
 		case PortAudio:
-			audio = new PortAudioDriver(config);
+			if (audio == null) {
+				audio = new PortAudioDriver(config);
+			}
 			break;
 		}
 


### PR DESCRIPTION
Closes #874.

  ## Problem

  When PortAudio is selected on Windows, startup may fail with:

  ```text
  java.lang.RuntimeException: Device unavailable
      at com.portaudio.PortAudio.openStream(Native Method)
      at bms.player.beatoraja.audio.PortAudioDriver.openStream(...)
      at bms.player.beatoraja.audio.PortAudioDriver.<init>(...)
      at bms.player.beatoraja.MainController.create(...)

  MainController initializes PortAudio before libGDX startup so that it can
  fall back to OpenAL when the selected device is unavailable.

  However, MainController.create() was creating another PortAudioDriver.
  The first instance already owns the output stream, so the second attempt can
  fail with Device unavailable.

  ## Changes

  - Reuse the PortAudio driver initialized before libGDX startup.
  - Create a new PortAudio driver in create() only when no instance exists.
  - Add an optional mise.toml configuration for the JavaFX-enabled Java 17
    development toolchain.

  OpenAL and AudioDevice initialization behavior is unchanged.

  ## Verification

  - Confirmed that the PortAudio construction path is executed only once.
  - Confirmed successful compilation and runnable JAR packaging with Java 17.